### PR TITLE
add GHA to run integration tests

### DIFF
--- a/.github/actions/setup-python/test_integration.yml
+++ b/.github/actions/setup-python/test_integration.yml
@@ -49,7 +49,7 @@ jobs:
           channel-id: C09S03U9CH4 # #alerts-bedrock
           payload: |
             {
-              "text": "CEDA USA Test Status",
+              "text": "CEDA USA Test Failure",
               "blocks": [
                 {
                   "type": "section",
@@ -84,7 +84,7 @@ jobs:
           channel-id: C09S03U9CH4 # #alerts-bedrock
           payload: |
             {
-              "text": "CEDA USA Test Status",
+              "text": "CEDA USA Test Success",
               "blocks": [
                 {
                   "type": "section",


### PR DESCRIPTION
As the title says
- Set up a Slack bot and hooked up its secret with Github
- This PR adds a github actions YAML file to run `uv run pytest -m ceda_integration` and messages Slack with the result

going forward, we can consider putting this on a cron, and also adding in `flowsa` integration tests