### PR TITLE
[GHG SAM] Add notes for aviation emissions

### DIFF
--- a/bedrock/ceda_usa/transform/allocation/co2/fuel_usage.py
+++ b/bedrock/ceda_usa/transform/allocation/co2/fuel_usage.py
@@ -23,6 +23,8 @@ load_table_a17 = functools.cache(_load_table_a17)
 def allocate_transportation_fuel_usage(
     fuel: TRANSPORTATION_FUEL_TYPES,
 ) -> pd.Series[float]:
+    # NOTE: This only ingests "Aviation Gasoline" row (1.5 MMT) from Table A-5 (2023)
+    # and ignores the "Jet Fuel" row (178.9 MMT), which is likely an under-estimation.
     total_fuel_for_transport = load_table_a17().loc[fuel.value, "Trans"]
     fuel_percent_breakout = derive_fuel_percent_breakout()
 


### PR DESCRIPTION
I'm trying to understand why CEDA only allocates 1.5 MMT CO2 to the aviation sector (481000), whereas FLOWSA had allocated 100+ MMT. I think it's an error in CEDA allocation model where we significantly under-allocated emissions.