### PR TITLE
add test for generateFlowByActivity

### DIFF
--- a/bedrock/extract/__tests__/test_fba.py
+++ b/bedrock/extract/__tests__/test_fba.py
@@ -1,10 +1,19 @@
 import pytest
 
 from bedrock.extract.flowbyactivity import getFlowByActivity
+from bedrock.extract.generateflowbyactivity import generateFlowByActivity
 
 
 @pytest.mark.eeio_integration
 def test_get_fba_from_gcs() -> None:
     df = getFlowByActivity("EPA_GHGI_T_2_1", year=2022, download_FBA_if_missing=True)
+
+    assert len(df) > 0
+
+
+@pytest.mark.eeio_integration
+def test_generateFBA() -> None:
+    generateFlowByActivity(year=2022, source='EPA_GHGI')
+    df = getFlowByActivity("EPA_GHGI_T_2_1", year=2022)
 
     assert len(df) > 0


### PR DESCRIPTION
## What changed? Why?

Adds a test to generate a FBA, using the GHGI as the example. This will ensure that as we continue updating and refactoring flowsa code that core FBA generation functions remain intact.

## Testing

```
uv run pytest bedrock/extract/__tests__/test_fba.py -m eeio_integration
```

Resolves #40

### Todo

In the future I assume our testing strategy will evolve, and this test only applies to a single FBA and does not evaluate its contents.
