### PR TITLE
Fix import in BEA.py

### DIFF
--- a/bedrock/extract/BEA/BEA.py
+++ b/bedrock/extract/BEA/BEA.py
@@ -14,7 +14,6 @@ import numpy as np
 import pandas as pd
 from esupy.processed_data_mgmt import download_from_remote
 
-from bedrock.transform.iot.derived_price_index import _map_detail_table
 from bedrock.extract.flowbyactivity import getFlowByActivity
 from bedrock.extract.generateflowbyactivity import generateFlowByActivity
 from bedrock.extract.iot.io_2017 import (
@@ -24,6 +23,7 @@ from bedrock.extract.iot.io_2017 import (
 )
 from bedrock.extract.iot.io_price_index import load_go_detail
 from bedrock.transform.flowbyfunctions import assign_fips_location_system
+from bedrock.transform.iot.derived_price_index import _map_detail_table
 from bedrock.utils.config.settings import PATHS
 from bedrock.utils.mapping.location import US_FIPS
 from bedrock.utils.metadata.metadata import set_fb_meta


### PR DESCRIPTION
cc:

## What changed? Why?

Updated import path to solve failure in this integration test: https://github.com/cornerstone-data/bedrock/actions/runs/20834889412

## Testing
locally ran `uv run pytest bedrock/transform/__tests__/test_fbs.py::test_generate_fbs -m eeio_integration` which failed in the test above, and it passes now

also rerunning integration test here: https://github.com/cornerstone-data/bedrock/actions/runs/20837138070