### PR TITLE
Fix import in EIA_MECS.py

### DIFF
--- a/bedrock/extract/EIA/EIA_MECS.py
+++ b/bedrock/extract/EIA/EIA_MECS.py
@@ -16,16 +16,14 @@ import numpy as np
 import pandas as pd
 from requests import Response
 
-from bedrock.ceda_usa.utils.gcp import GCS_CEDA_INPUT_DIR
-from bedrock.extract.EIA.EIA_CBECS_Land import (
-    calculate_total_facility_land_area,
-)
+from bedrock.extract.EIA.EIA_CBECS_Land import calculate_total_facility_land_area
 from bedrock.extract.flowbyactivity import FlowByActivity, getFlowByActivity
 from bedrock.extract.generateflowbyactivity import generateFlowByActivity
 from bedrock.transform.flowbyclean import load_prepare_clean_source
 from bedrock.transform.flowbyfunctions import assign_fips_location_system
 from bedrock.utils.config.common import WITHDRAWN_KEYWORD
 from bedrock.utils.io.gcp import download_gcs_file_if_not_exists
+from bedrock.utils.io.gcp_paths import GCS_CEDA_INPUT_DIR
 from bedrock.utils.logging.flowsa_log import log
 from bedrock.utils.mapping.location import (
     US_FIPS,


### PR DESCRIPTION
cc:

## What changed? Why?

Updated the import statement for `GCS_CEDA_INPUT_DIR` to use it from `bedrock.utils.io.gcp_paths` instead of `bedrock.ceda_usa.utils.gcp` to address integration test failture: https://github.com/cornerstone-data/bedrock/actions/runs/20868196499/job/59964207636

## Testing

will rerun test on main once merged