### PR TITLE
updates to FBA/FBS metadata json

### DIFF
--- a/bedrock/utils/config/settings.py
+++ b/bedrock/utils/config/settings.py
@@ -128,7 +128,7 @@ def return_pkg_version(MODULEPATH: Path, package_name: str) -> str:
     return version(package_name)
 
 
-def get_git_hash(MODULEPATH: Path, length='short'):
+def get_git_hash(MODULEPATH: Path, length: str = 'short') -> str | None:
     """
     Returns git_hash of current directory or None if no git found
     :param MODULEPATH: Path, module path

--- a/bedrock/utils/metadata/metadata.py
+++ b/bedrock/utils/metadata/metadata.py
@@ -380,7 +380,8 @@ def find_file(meta: FileMeta, paths: Paths) -> Path | None:
 def read_source_metadata(
     paths: Paths, meta: FileMeta, force_JSON: bool = False
 ) -> dict[str, Any] | None:
-    """return the locally saved metadata dictionary from JSON,
+    """
+    return the locally saved metadata dictionary from JSON,
     meta should reflect the outputfile for which the metadata is associated
 
     :param meta: object of class FileMeta used to load the outputfile
@@ -389,16 +390,20 @@ def read_source_metadata(
     :return: metadata dictionary
     """
     if force_JSON:
-        meta.ext = 'json'
+        meta.ext = "json"
         path = find_file(meta, paths)
     else:
         p = find_file(meta, paths)
-        path = p.parent / f'{p.stem}_metadata.json' if p else None
+        path = p.parent / f"{p.stem}_metadata.json" if p else None
+
+    if path is None:
+        log.warning(f"metadata not found for {meta.name_data}")
+        return None
+
     try:
-        metadata = json.loads(path.read_text())
-        return metadata
-    except (FileNotFoundError, AttributeError):
-        log.warning(f'metadata not found for {meta.name_data}')
+        return json.loads(path.read_text())
+    except FileNotFoundError:
+        log.warning(f"metadata not found for {meta.name_data}")
         return None
 
 


### PR DESCRIPTION
cc:
Addresses #46 and #47 

## What changed? Why?

update data captured in metadata json for FBA and FBS 
- update url in metadata json to correctly point to bedrock files
- move `get_git_hash()`,  `return_pkg_version()`, `find_file()`, and `read_source_metadata()` from esupy and edit for bedrock repo
- correct filenames to include package version and githash in name, corrects issue of hash printed twice

## Testing
- Generated GHG FBA and GHG m1 FBS to text metadata url, package version, package hash. File names are correct and FBA metadata correctly appended within GHG FBS metadata


