### PR TITLE
Fix file paths in FLOWSA files

### DIFF
--- a/bedrock/extract/epa/EPA_SIT.py
+++ b/bedrock/extract/epa/EPA_SIT.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pandas as pd
 
 from bedrock.extract.flowbyactivity import FlowByActivity
+from bedrock.extract.stateghgi.StateGHGI import VT_remove_dupicate_activities
 from bedrock.transform.flowbyfunctions import (
     assign_fips_location_system,
     load_fba_w_standardized_units,
@@ -248,9 +249,6 @@ def clean_up_state_data(fba: FlowByActivity, **_):
     # (these data will later be replaced with custom data in the 'StateGHGI'
     # stage)
     if 'VT' in state_list:  # and ('StateGHGI_VT' in method['source_names'].keys())
-        from bedrock.extract.StateGHGI.StateGHGI import (
-            VT_remove_dupicate_activities,
-        )
 
         df_subset = VT_remove_dupicate_activities(df_subset)
 

--- a/bedrock/extract/epa/EPA_StateGHGI.py
+++ b/bedrock/extract/epa/EPA_StateGHGI.py
@@ -9,6 +9,7 @@ from zipfile import ZipFile
 
 import pandas as pd
 
+from bedrock.extract.epa.EPA_GHGI import get_manufacturing_energy_ratios
 from bedrock.extract.flowbyactivity import FlowByActivity, getFlowByActivity
 from bedrock.transform.flowbyfunctions import assign_fips_location_system
 from bedrock.transform.flowbysector import FlowBySector
@@ -220,9 +221,6 @@ def allocate_industrial_combustion(fba: FlowByActivity, **_) -> FlowByActivity:
     distinguish those which use EIA MECS as allocation source and those that
     use alternate source.
     """
-    from bedrock.extract.EPA.EPA_GHGI import (
-        get_manufacturing_energy_ratios,
-    )
 
     pct_dict = get_manufacturing_energy_ratios(fba.config.get('clean_parameter'))
 

--- a/bedrock/utils/config/common.py
+++ b/bedrock/utils/config/common.py
@@ -185,11 +185,16 @@ def load_yaml_dict(filename, flowbytype=None, filepath=None, **kwargs):
     try:
         with open(yaml_path, 'r', encoding='utf-8') as f:
             config = flowsa_yaml.load(f, filepath)
-    except FileNotFoundError:
-        if 'config' in kwargs:
-            return deepcopy(kwargs['config'])
+    except FileNotFoundError as e:
+        if filename in str(e):
+            if 'config' in kwargs:
+                return deepcopy(kwargs['config'])
+            else:
+                raise FlowsaMethodNotFoundError(
+                    method_type=flowbytype, method=filename
+                ) from None
         else:
-            raise FlowsaMethodNotFoundError(method_type=flowbytype, method=filename)
+            raise e
     return config
 
 

--- a/bedrock/utils/config/settings.py
+++ b/bedrock/utils/config/settings.py
@@ -52,16 +52,18 @@ def return_folder_path(base_path: Path | str, filename: str) -> Path:
     :param base_path: path to "extract", "transform", "publish" directories
     :param filename: string, name of file for which to return the folder path
     """
-
+    base_path = Path(base_path)
     folder = filename.lower()
+    if "." in folder:
+        folder = folder.split(".")[0]
 
     while True:
-        folder_path = Path(base_path) / folder
+        folder_path = base_path / folder
         if folder_path.is_dir():
             return folder_path
 
         if "_" not in folder:
-            raise FileNotFoundError(f"{filename} not found in {base_path}")
+            return base_path
 
         folder = folder.rsplit("_", 1)[0]
 


### PR DESCRIPTION
cc:

## What changed? Why?

This PR fixes several import and file path resolution issues in the codebase:

1. Fixed circular imports by moving imports to the top of the file:
   - Moved `VT_remove_dupicate_activities` import in EPA_SIT.py
   - Moved `get_manufacturing_energy_ratios` import in EPA_StateGHGI.py

2. Enhanced error handling in `load_yaml_dict` to provide more specific error messages when files are not found.

3. Improved file path resolution in the YAML loader:
   - Added better error handling in the `include` and `from_index` functions
   - Added a fallback mechanism to try the original case when resolving module imports
   - Modified `return_folder_path` to handle filenames with extensions and return the base path when no matching folder is found

## Testing

locally ran `uv run pytest bedrock/transform/__tests__/test_fbs.py::test_generate_fbs -m eeio_integration` and it passed

![image.png](https://app.graphite.com/user-attachments/assets/3abbb512-d53d-4b9e-84f1-b61f928ee5d3.png)

