### PR TITLE
[cont] fix import

### DIFF
--- a/bedrock/extract/eia/EIA_MECS.py
+++ b/bedrock/extract/eia/EIA_MECS.py
@@ -269,7 +269,7 @@ def eia_mecs_land_parse(
     return df
 
 
-def eia_mecs_energy_load_gcs(*, kwargs: dict[str, Any]) -> pd.DataFrame:
+def eia_mecs_energy_load_gcs(**kwargs: Any) -> pd.DataFrame:
     """For each url the file gets download and stored locally from gcs"""
     GCS_MECS_DIR = posixpath.join(GCS_CEDA_INPUT_DIR, f"EIA_MECS_{kwargs.get('year')}")
     name = os.path.basename(kwargs.get('url'))


### PR DESCRIPTION
cc:

## What changed? Why?

Changed the function signature of `eia_mecs_energy_load_gcs` from using a keyword-only dictionary parameter `*, kwargs: dict[str, Any]` to using standard keyword arguments with `**kwargs: Any`. This improves the function's usability by allowing callers to pass arguments directly rather than having to construct a dictionary.

## Testing

integration test passed: https://github.com/cornerstone-data/bedrock/actions/runs/20980523419