### PR TITLE
Add API Key instructions for extract data

### DIFF
--- a/bedrock/extract/README.md
+++ b/bedrock/extract/README.md
@@ -105,4 +105,19 @@ on. See the example below.
 
 ```
 
+## API Keys
+Several extract data sources require API keys stored locally in `bedrock/extract/API_Keys.env`. 
+Data sources that require API Keys are identified within the method yaml with `api_key_required: true`.
 
+The `.env` should be set up as:
+
+BLS = "XXXXXX" \
+Census = "XXXXXX" \
+EIA = "XXXXXX" \
+USDA_Quickstats = "XXXXXX"
+
+To generate API Keys for each data source, go to:
+1. [BLS](https://data.bls.gov/registrationEngine/)
+1. [Census](https://api.census.gov/data/key_signup.html)
+1. [EIA](https://www.eia.gov/opendata/register.php)
+1. [USDA_Quickstats](https://quickstats.nass.usda.gov/api)

--- a/bedrock/utils/config/common.py
+++ b/bedrock/utils/config/common.py
@@ -64,8 +64,8 @@ def load_env_file_key(env_file, key):
     the users personal API keys. The user must register with this
     API and get the key and manually add to "API_Keys.env"
 
-    See wiki for how to get an api:
-    https://github.com/USEPA/flowsa/wiki/Using-FLOWSA#api-keys
+    See README for how to generate an API key:
+    https://github.com/cornerstone-data/bedrock/blob/main/bedrock/extract/README.md
 
     :param env_file: str, name of env to load, either 'API_Key'
     or 'external_path'
@@ -74,7 +74,7 @@ def load_env_file_key(env_file, key):
     :return: str, value of the key stored in the env
     """
     if env_file == 'API_Key':
-        load_dotenv(f'{MODULEPATH}/API_Keys.env', verbose=True)
+        load_dotenv(f'{extractpath}/API_Keys.env', verbose=True)
         value = os.getenv(key)
         if value is None:
             raise APIError(api_source=key)

--- a/bedrock/utils/validation/exceptions.py
+++ b/bedrock/utils/validation/exceptions.py
@@ -29,8 +29,8 @@ class FlowsaMethodNotFoundError(FileNotFoundError):
 class APIError(Exception):
     def __init__(self, api_source):
         message = (
-            f"Key file {api_source} not found. See github wiki for help "
-            "https://github.com/USEPA/flowsa/wiki/Using-FLOWSA#api-keys"
+            f"Key file {api_source} not found. See README for help "
+            "https://github.com/cornerstone-data/bedrock/blob/main/bedrock/extract/README.md"
         )
         self.message = message
         super().__init__(self.message)


### PR DESCRIPTION
cc:

## What changed? Why?

- Updated `extract` README with instructions on creating `API_Keys.env` and listing which extract data sources might need an API key
- Updated links to bedrock sources
- Updated path to load `API_Keys.env`

## Testing

Generated extract data sources that call on APIs

