### PR TITLE
Fix type annotations in utils/mapping

### DIFF
--- a/bedrock/utils/mapping/dqi.py
+++ b/bedrock/utils/mapping/dqi.py
@@ -3,11 +3,14 @@ Functions associated with data quality scoring
 """
 
 import numpy as np
+import pandas as pd
 
 from bedrock.utils.config.common import load_sector_length_cw_melt
 
 
-def adjust_dqi_reliability_collection_scores(df, sector_source_year):
+def adjust_dqi_reliability_collection_scores(
+    df: pd.DataFrame, sector_source_year: str
+) -> pd.DataFrame:
     """
     Adjust the dqi scores for
     Data Reliability, Data Collection

--- a/bedrock/utils/mapping/geo.py
+++ b/bedrock/utils/mapping/geo.py
@@ -26,10 +26,10 @@ class scale(enum.Enum):
         self.aggregation_level = aggregation_level
         self.has_fips_level = has_fips_level
 
-    def __lt__(self, other):
-        if other.__class__ is self.__class__:
+    def __lt__(self, other: object) -> bool:
+        if isinstance(other, scale):
             return self.aggregation_level < other.aggregation_level
-        elif other in [float('inf'), float('-inf')]:
+        elif isinstance(other, float) and other in [float('inf'), float('-inf')]:
             # ^^^ Add np.nan to list if such comparison is needed.
             return self.aggregation_level < other
             # ^^^ Enables pandas max and min functions to work even if
@@ -50,16 +50,16 @@ class scale(enum.Enum):
         :param geoscale: str
         :return: geo.scale constant
         '''
-        geoscale = geoscale.lower()
-        if geoscale == 'national':
+        geoscale_lower = geoscale.lower()
+        if geoscale_lower == 'national':
             return cls.NATIONAL
-        elif geoscale == 'census_region':
+        elif geoscale_lower == 'census_region':
             return cls.CENSUS_REGION
-        elif geoscale == 'census_division':
+        elif geoscale_lower == 'census_division':
             return cls.CENSUS_DIVISION
-        elif geoscale == 'state':
+        elif geoscale_lower == 'state':
             return cls.STATE
-        elif geoscale == 'county':
+        elif geoscale_lower == 'county':
             return cls.COUNTY
         else:
             raise ValueError(f'No geo.scale level corresponds to {geoscale}')


### PR DESCRIPTION
cc:
Closes: #99

## What changed? Why?

This PR adds type hints to the mapping utility modules in the `bedrock/utils/mapping` directory. The changes include:

1. Added proper type annotations to function parameters and return types in `dqi.py`, `geo.py`, `location.py`, and `naics.py`
2. Improved type safety by adding explicit type declarations for dictionaries and constants
3. Enhanced error handling with proper type checking and assertions
4. Refactored code in `location.py` to improve readability and maintainability
5. Fixed potential bugs by properly handling edge cases and null values
6. Improved the `scale.__lt__` method in `geo.py` to use `isinstance()` instead of `__class__` comparison
7. Enhanced the `extract_fips_years` function to handle both Series and Index inputs

## Testing

The changes were tested by ensuring all type annotations are correct and compatible with the existing codebase. The refactored code maintains the same functionality while improving type safety and readability.