### PR TITLE
Port calculateProductofLeontiefAndProductionDemand

### DIFF
--- a/bedrock/utils/math/formulas.py
+++ b/bedrock/utils/math/formulas.py
@@ -23,6 +23,7 @@ Matrices
 from __future__ import annotations
 
 import logging
+from typing import Annotated
 
 import numpy as np
 import pandas as pd
@@ -183,19 +184,60 @@ def backcompute_U_matrix_via_commodity_shortcut(
     return A.multiply(q, axis=1)
 
 
-def backcompute_q_from_Ldom_and_y_nab(
-    *, Ldom: pd.DataFrame, y_nab: pd.Series[float]
+def backcompute_q_from_L_and_y(
+    *,
+    L: Annotated[pd.DataFrame, "Domestic Leontief inverse (Ldom)"],
+    y: Annotated[pd.Series[float], "National accounting balance final demand (y_nab)"],
 ) -> pd.Series[float]:
     """
-    Ldom is the domestic Leontief inverse
-    ynab is y for national accounting balance, i.e. domestic final consumption + exports
+    Backcompute commodity output q from Leontief inverse L and final demand y.
 
-    This way we capture all possible uses of a commodity, including
+    .. warning::
+        **CRITICAL**: This function requires a matching pair of L and y:
+        - L must be the **domestic** Leontief inverse (Ldom)
+        - y must be the **national accounting balance** final demand (y_nab),
+          i.e., domestic final consumption + exports
+
+        Using mismatched pairs (e.g., total L with domestic y, or domestic L
+        with total y) will produce incorrect results.
+
+    This way we capture all possible uses of a commodity, including:
     1. intermediate consumption by domestic industries
     2. domestic final consumption
     3. exports to foreign industries and final consumption
+
+    Parameters
+    ----------
+    L : pd.DataFrame
+        The domestic Leontief inverse matrix (Ldom)
+    y : pd.Series[float]
+        Final demand for national accounting balance (y_nab)
+
+    Returns
+    -------
+    pd.Series[float]
+        Commodity output vector q
+
+    Raises
+    ------
+    ValueError
+        If L is not square, or if L and y have mismatched indices
     """
-    return (Ldom @ np.diag(y_nab)).sum(axis=1)
+    # Validation with helpful error messages
+    if not L.index.equals(L.columns):
+        raise ValueError(
+            "L must be a square matrix (Leontief inverse). "
+            f"Expected L.index == L.columns, but got shape {L.shape}"
+        )
+    if not L.index.equals(y.index):
+        raise ValueError(
+            "L and y must have matching indices. "
+            f"L.index length: {len(L.index)}, y.index length: {len(y.index)}. "
+            "This function requires L to be the domestic Leontief inverse (Ldom) "
+            "and y to be the national accounting balance final demand (y_nab)."
+        )
+
+    return (L @ np.diag(y)).sum(axis=1)
 
 
 def backcompute_y_from_q_and_Aq(


### PR DESCRIPTION
cc:
Closes: #88

## What changed? Why?

Renamed and enhanced the `backcompute_q_from_Ldom_and_y_nab` function to `backcompute_q_from_L_and_y` with improved documentation and validation:

1. Added type annotations using `Annotated` to clarify parameter requirements
2. Added comprehensive docstring with detailed warnings about matching L and y pairs
3. Implemented input validation to check that:
   - L is a square matrix
   - L and y have matching indices
4. Added helpful error messages that explain what went wrong and what was expected

These changes make the function more robust and self-documenting, helping users avoid common mistakes when calculating commodity output from Leontief inverse and final demand.

## Testing

Verified that the function maintains the same mathematical logic while adding validation checks for common error cases.