### PR TITLE
Fix type annotations in extract/usda/

### DIFF
--- a/bedrock/extract/usda/USDA_ACUP.py
+++ b/bedrock/extract/usda/USDA_ACUP.py
@@ -6,15 +6,17 @@
 Functions to import and parse USDA Chemical Use Survey
 """
 import json
+from typing import Any
 
 import pandas as pd
+from requests import Response
 
 from bedrock.transform.flowbyfunctions import assign_fips_location_system
 from bedrock.utils.config.common import WITHDRAWN_KEYWORD
 from bedrock.utils.mapping.location import US_FIPS, abbrev_us_state
 
 
-def acup_url_helper(*, build_url, config, **_):
+def acup_url_helper(*, build_url: str, config: dict[str, Any], **_: Any) -> list[str]:
     """
     This helper function uses the "build_url" input from generateflowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -42,7 +44,7 @@ def acup_url_helper(*, build_url, config, **_):
     return urls
 
 
-def acup_call(*, resp, **_):
+def acup_call(*, resp: Response, **_: Any) -> pd.DataFrame:
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
@@ -55,7 +57,9 @@ def acup_call(*, resp, **_):
     return df
 
 
-def acup_parse(*, df_list, source, year, **_):
+def acup_parse(
+    *, df_list: list[pd.DataFrame], source: str, year: str, **_: Any
+) -> pd.DataFrame:
     """
     Combine, parse, and format the provided dataframes
     :param df_list: list of dataframes to concat and format

--- a/bedrock/extract/usda/USDA_ERS_FIWS.py
+++ b/bedrock/extract/usda/USDA_ERS_FIWS.py
@@ -10,8 +10,10 @@ Downloads the Dec 3, 2024 update
 
 import io
 import zipfile
+from typing import Any
 
 import pandas as pd
+from requests import Response
 
 from bedrock.transform.flowbyfunctions import assign_fips_location_system
 from bedrock.utils.mapping.location import (
@@ -21,7 +23,7 @@ from bedrock.utils.mapping.location import (
 )
 
 
-def fiws_call(*, resp, **_):
+def fiws_call(*, resp: Response, **_: Any) -> pd.DataFrame:
     """
     Convert response for calling url to pandas dataframe, begin parsing
     df into FBA format
@@ -37,7 +39,7 @@ def fiws_call(*, resp, **_):
         return df
 
 
-def fiws_parse(*, df_list, year, **_):
+def fiws_parse(*, df_list: list[pd.DataFrame], year: str, **_: Any) -> pd.DataFrame:
     """
     Combine, parse, and format the provided dataframes
     :param df_list: list of dataframes to concat and format
@@ -122,9 +124,8 @@ def fiws_parse(*, df_list, year, **_):
 
 
 if __name__ == "__main__":
-    import bedrock
+    from bedrock.extract.flowbyactivity import getFlowByActivity
+    from bedrock.extract.generateflowbyactivity import generateFlowByActivity
 
-    bedrock.extract.generateflowbyactivity.main(
-        year='2012-2023', source='USDA_ERS_FIWS'
-    )
-    fba = bedrock.extract.flowbyactivity.getFlowByActivity('USDA_ERS_FIWS', year=2023)
+    generateFlowByActivity(year='2012-2023', source='USDA_ERS_FIWS')
+    fba = getFlowByActivity('USDA_ERS_FIWS', year=2023)

--- a/bedrock/extract/usda/USDA_ERS_MLU.py
+++ b/bedrock/extract/usda/USDA_ERS_MLU.py
@@ -9,9 +9,11 @@ Last updated: Thursday, April 16, 2020
 """
 
 import io
+from typing import Any
 
 import numpy as np
 import pandas as pd
+from requests import Response
 
 from bedrock.extract.flowbyactivity import FlowByActivity
 from bedrock.transform.flowbyfunctions import assign_fips_location_system
@@ -26,11 +28,11 @@ from bedrock.transform.literature_values import (
 from bedrock.utils.config.common import load_crosswalk
 from bedrock.utils.logging.flowsa_log import log, vlog
 from bedrock.utils.mapping.location import US_FIPS, get_all_state_FIPS_2
-from bedrock.utils.mapping.naics import industry_spec_key
+from bedrock.utils.mapping.naics import industry_spec_key  # type: ignore[attr-defined]
 from bedrock.utils.validation.validation import compare_df_units
 
 
-def mlu_call(*, resp, **_):
+def mlu_call(*, resp: Response, **_: Any) -> pd.DataFrame:
     """
     Convert response for calling url to pandas dataframe,
     begin parsing df into FBA format
@@ -42,7 +44,9 @@ def mlu_call(*, resp, **_):
     return df
 
 
-def mlu_parse(*, df_list, source, year, **_):
+def mlu_parse(
+    *, df_list: list[pd.DataFrame], source: str, year: str, **_: Any
+) -> pd.DataFrame:
     """
     Combine, parse, and format the provided dataframes
     :param df_list: list of dataframes to concat and format
@@ -91,7 +95,9 @@ def mlu_parse(*, df_list, source, year, **_):
     return dfm3
 
 
-def attribute_transportation_sector_fees_to_target_sectors(fba, sector_col):
+def attribute_transportation_sector_fees_to_target_sectors(
+    fba: FlowByActivity, sector_col: str
+) -> pd.DataFrame:
     """
     Equally attribute highway fees to all the sectors the fees are mapped to
     :param fba:
@@ -124,7 +130,9 @@ def attribute_transportation_sector_fees_to_target_sectors(fba, sector_col):
     return df_fha2
 
 
-def validate_land_attribution(fba, attributed_fba):
+def validate_land_attribution(
+    fba: FlowByActivity, attributed_fba: pd.DataFrame
+) -> None:
     """
     Function specific to validating the land attribution methods, as data
     is dropped
@@ -145,7 +153,7 @@ def validate_land_attribution(fba, attributed_fba):
 
 
 def allocate_usda_ers_mlu_land_in_urban_areas(
-    fba: FlowByActivity, **_
+    fba: FlowByActivity, **_: Any
 ) -> FlowByActivity:
     """
     This function is used to allocate the USDA_ERS_MLU activity 'land in
@@ -289,11 +297,11 @@ def allocate_usda_ers_mlu_land_in_urban_areas(
     # calculate the percent change in df caused by attribution
     validate_land_attribution(fba, allocated_urban_areas_df)
 
-    return allocated_urban_areas_df
+    return FlowByActivity(allocated_urban_areas_df)
 
 
 def allocate_usda_ers_mlu_land_in_rural_transportation_areas(
-    fba: FlowByActivity, **_
+    fba: FlowByActivity, **_: Any
 ) -> FlowByActivity:
     """
     This function is used to allocate the USDA_ERS_MLU activity
@@ -380,10 +388,10 @@ def allocate_usda_ers_mlu_land_in_rural_transportation_areas(
     # calculate the percent change in df caused by attribution
     validate_land_attribution(fba, allocated_rural_trans)
 
-    return allocated_rural_trans
+    return FlowByActivity(allocated_rural_trans)
 
 
-def allocate_usda_ers_mlu_other_land(fba: FlowByActivity, **_) -> FlowByActivity:
+def allocate_usda_ers_mlu_other_land(fba: FlowByActivity, **_: Any) -> FlowByActivity:
     """
     Function only designed for national model
 
@@ -413,8 +421,8 @@ def allocate_usda_ers_mlu_other_land(fba: FlowByActivity, **_) -> FlowByActivity
     rural_res = get_area_of_rural_land_occupied_by_houses_2013()
 
     # household codes
-    household = load_crosswalk('Household_SectorCodes')
-    household = household['Code'].drop_duplicates().tolist()
+    household_df = load_crosswalk('Household_SectorCodes')
+    household = household_df['Code'].drop_duplicates().tolist()
 
     # if it is state data, take weighted avg using land area
     if fba.config['geoscale'] == 'state':

--- a/bedrock/extract/usda/USDA_IWMS.py
+++ b/bedrock/extract/usda/USDA_IWMS.py
@@ -8,15 +8,17 @@ Water Management Survey data
 """
 
 import json
+from typing import Any
 
 import pandas as pd
+from requests import Response
 
 from bedrock.transform.flowbyfunctions import assign_fips_location_system
 from bedrock.utils.config.common import WITHDRAWN_KEYWORD
 from bedrock.utils.mapping.location import US_FIPS
 
 
-def iwms_url_helper(*, build_url, config, **_):
+def iwms_url_helper(*, build_url: str, config: dict[str, Any], **_: Any) -> list[str]:
     """
     This helper function uses the "build_url" input from generateflowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -39,7 +41,7 @@ def iwms_url_helper(*, build_url, config, **_):
     return urls_iwms
 
 
-def iwms_call(*, resp, **_):
+def iwms_call(*, resp: Response, **_: Any) -> pd.DataFrame:
     """
     Convert response for calling url to pandas dataframe, begin parsing df
     into FBA format
@@ -52,7 +54,7 @@ def iwms_call(*, resp, **_):
     return df_iwms
 
 
-def iwms_parse(*, df_list, year, **_):
+def iwms_parse(*, df_list: list[pd.DataFrame], year: str, **_: Any) -> pd.DataFrame:
     """
     Combine, parse, and format the provided dataframes
     :param df_list: list of dataframes to concat and format


### PR DESCRIPTION
cc:
Closes: #110

## What changed? Why?

Added type hints to USDA extraction modules to improve code maintainability and catch potential type errors. This includes:

- Added proper type annotations to function parameters and return values in USDA_ACUP.py, USDA_ERS_FIWS.py, USDA_ERS_MLU.py, and USDA_IWMS.py
- Fixed imports to include specific types like `Response` from requests and `Any` from typing
- Updated variable names to avoid shadowing (e.g., renamed `household` to `household_df`)
- Fixed return type in allocation functions to properly return `FlowByActivity` objects
- Updated imports in the main block of USDA_ERS_FIWS.py to use more specific imports

## Testing
uv run mypy bedrock/extract/usda/*.py
![image.png](https://app.graphite.com/user-attachments/assets/55a43dc8-6c9c-4a1e-a6e5-43629dd01377.png)

