### PR TITLE
Fix type annotations in extract/bea/

### DIFF
--- a/bedrock/extract/bea/BEA_PCE.py
+++ b/bedrock/extract/bea/BEA_PCE.py
@@ -4,15 +4,19 @@
 """ """
 
 import json
+from typing import Any
 
 import numpy as np
 import pandas as pd
+from requests import Response
 
 from bedrock.transform.flowbyfunctions import assign_fips_location_system
 from bedrock.utils.mapping.location import get_state_FIPS
 
 
-def bea_pce_url_helper(*, build_url, config, **_):
+def bea_pce_url_helper(
+    *, build_url: str, config: dict[str, Any], **_: Any
+) -> list[str]:
     """
     This helper function uses the "build_url" input from generateflowbyactivity.py,
     which is a base url for data imports that requires parts of the url text
@@ -34,7 +38,7 @@ def bea_pce_url_helper(*, build_url, config, **_):
     return urls
 
 
-def bea_pce_call(*, resp, **_):
+def bea_pce_call(*, resp: Response, **_: Any) -> pd.DataFrame:
     """
     Convert response for calling url to pandas dataframe,
     begin parsing df into FBA format
@@ -50,7 +54,7 @@ def bea_pce_call(*, resp, **_):
         return df
 
 
-def bea_pce_parse(*, df_list, year, **_):
+def bea_pce_parse(*, df_list: list[pd.DataFrame], year: int, **_: Any) -> pd.DataFrame:
     """
     Combine, parse, and format the provided dataframes
     :param df_list: list of dataframes to concat and format
@@ -96,12 +100,13 @@ def bea_pce_parse(*, df_list, year, **_):
 
 
 if __name__ == "__main__":
-    import bedrock
+    from bedrock.extract.flowbyactivity import getFlowByActivity
+    from bedrock.extract.generateflowbyactivity import generateFlowByActivity
 
-    bedrock.extract.generateflowbyactivity.main(source='BEA_PCE', year=2023)
+    generateFlowByActivity(source='BEA_PCE', year=2023)
     fba = pd.DataFrame()
     for y in range(2023, 2024):
         fba = pd.concat(
-            [fba, bedrock.extract.flowbyactivity.getFlowByActivity('BEA_PCE', y)],
+            [fba, getFlowByActivity('BEA_PCE', y)],
             ignore_index=True,
         )


### PR DESCRIPTION
cc:
Closes: #111

## What changed? Why?

Added type hints to the BEA and BEA_PCE modules to improve code quality and maintainability. The changes include:

- Added proper type annotations to function parameters and return values
- Added explicit type casting where needed
- Fixed potential type issues with numpy transpose operations by wrapping results in pd.DataFrame
- Added assertions to verify index locations are integers before using them
- Simplified code by removing redundant variable assignments
- Used proper type casting for year parameters in summary table loading functions

## Testing
`uv run mypy bedrock/extract/bea/*.py`
![image.png](https://app.graphite.com/user-attachments/assets/26e68b63-4577-4344-9df4-f7adf5aedbf6.png)

