### PR TITLE
Remove class Test_compare_commodity_output_to_domestics_use_plus_exports

### DIFF
--- a/bedrock/utils/validation/__tests__/test_eeio_diagnostics.py
+++ b/bedrock/utils/validation/__tests__/test_eeio_diagnostics.py
@@ -273,10 +273,6 @@ class TestRunAllDiagnostics:
         assert call_order == ["a", "b"]
 
 
-class Test_compare_commodity_output_to_domestics_use_plus_exports:
-    "Tests for the compareCommodityOuputandDomesticUseplusProductionDemand function"
-
-
 @pytest.mark.eeio_integration
 @pytest.mark.xfail(
     reason="This test is failing because of data manipulation for aligning with the CEDA schema. Need to resolve during method reconciliation."


### PR DESCRIPTION
cc:
Closes: #89

## What changed? Why?

Remove Test_compare_commodity_output_to_domestic_use_plus_exports as it is not doing anything.

<!--- screenshots (if applicable) -->

<!--- follow-ups planned? -->

## Testing

<!--- how did you confirm the change works? -->