### PR TITLE
Add binary methodology selections in default config

### DIFF
--- a/bedrock/utils/config/usa_config.py
+++ b/bedrock/utils/config/usa_config.py
@@ -35,11 +35,19 @@ class USAConfig(BaseModel):
     #####
     # Methodology selection
     #####
+    ### Schema/Taxonomy selection
+    use_cornerstone_2026_model_schema: bool = False  # DRI: mo.li
     ### IO Methodology selection
-    # TODO: Add IO methodology selection
+    transform_b_matrix_with_useeio_method: bool = False  # DRI: mo.li
+    implement_waste_disaggregation: bool = False  # DRI: jorge.vendries
+    # TODO: Add transform_a_matrix after we decide what to do
     ### GHG Methodology selection
     usa_ghg_methodology: ta.Literal["national", "state"] = "national"
-    # TODO: Add more GHG methodology selection
+    update_transportation_ghg_method: bool = False  # DRI: catherine.birney
+    attribute_electricity_ghg_to_221100: bool = False  # DRI: catherine.birney
+    use_full_ghg_for_ng_and_petro_systems: bool = False  # DRI: ben.young
+    soda_ash_ghg_from_table_2_1: bool = False  # DRI: catherine.birney
+    hybrid_bea_naics_schema_in_ghg_attribution: bool = False  # DRI: ben.young
 
     @property
     def usa_detail_original_year(self) -> ta.Literal[2012, 2017]:


### PR DESCRIPTION
cc: @WesIngwersen @catherinebirney @jvendries @briantobin-99 
Closes:

## What changed? Why?

With specified method changes we will make, I added new configuration flags to the `USAConfig` class to support different methodological approaches:

- Added schema/taxonomy selection flag:
  - `use_cornerstone_2026_model_schema`

- Added IO methodology selection flags:
  - `transform_b_matrix_with_useeio_method`
  - `implement_waste_disaggregation`

- Added GHG methodology selection flags:
  - `update_transportation_ghg_method`
  - `attribute_electricity_ghg_to_221100`
  - `use_full_ghg_for_ng_and_petro_systems`
  - `soda_ash_ghg_from_table_2_1`
  - `hybrid_bea_naics_schema_in_ghg_attribution`

Each flag includes a DRI (Directly Responsible Individual) to indicate ownership and is defined as a scenario in our [Scenario Diagnostics Overview board](https://docs.google.com/spreadsheets/d/1P0PYXDf4GrJHItmo_kH4_WNOQfaHYsx1-sD3hfQZfo8/edit?gid=0#gid=0). This way, we can easily track method changes atomically.
![image.png](https://app.graphite.com/user-attachments/assets/fd1723e3-1b4d-40d2-bd4e-8c4496b1329b.png)

## Testing

All of the new methodology selections are set to `False` and none is deployed.