### PR TITLE
Fix groupby_cols to include StringDtype columns

### DIFF
--- a/bedrock/transform/flowby.py
+++ b/bedrock/transform/flowby.py
@@ -275,7 +275,7 @@ class _FlowBy(pd.DataFrame):
         return [
             str(x)
             for x in self
-            if self[x].dtype in ['int', 'object', 'int32', 'int64']
+            if self[x].dtype in ['int', 'object', 'int32', 'int64', 'string']
             and x not in ['Description', 'group_id']
         ]
 


### PR DESCRIPTION
## Summary

- Fixes the failing integration test (`test_generate_fbs_compare_to_remote[m1]`) on main ([run #156](https://github.com/cornerstone-data/bedrock/actions/runs/21990199921))

## Root Cause

Commit `38c4845` ("Resolves Future warnings", PR #154) converted string columns from `object` dtype to `pd.StringDtype()` in `dataclean.py`:

```python
s = flowby_partial_df[k].astype(pd.StringDtype())
```

However, the `groupby_cols` property in `_FlowBy` only recognized `'object'` as a string dtype:

```python
if self[x].dtype in ['int', 'object', 'int32', 'int64']
```

Since `pd.StringDtype()` has dtype name `'string'` (not `'object'`), **string columns were silently excluded from the aggregation groupby keys**. This caused `aggregate_flowby` to group by fewer columns, merging rows that should have remained separate — producing 5 fewer rows (2142 vs 2147 expected).

## Fix

Add `'string'` to the dtype allowlist in `groupby_cols`:

```python
if self[x].dtype in ['int', 'object', 'int32', 'int64', 'string']
```

## Test plan

- [ ] Re-run the integration test workflow (`test_integration`) to confirm the m1 test passes again

Made with [Cursor](https://cursor.com)