### PR TITLE
Fix FutureWarning handling from #154: use option_context instead of StringDtype

### DIFF
--- a/bedrock/transform/dataclean.py
+++ b/bedrock/transform/dataclean.py
@@ -60,23 +60,23 @@ def add_missing_flow_by_fields(
             if response and col not in flowby_partial_df.columns:
                 flowby_partial_df[col] = np.nan
     # convert all None, 'nan' to np.nan
-    obj_cols = flowby_partial_df.select_dtypes(include=['object', 'string']).columns
-    flowby_partial_df[obj_cols] = flowby_partial_df[obj_cols].mask(
-        flowby_partial_df[obj_cols].isin(['None', 'nan'])
-    )
+    with pd.option_context('future.no_silent_downcasting', True):
+        flowby_partial_df = flowby_partial_df.replace(
+            {'None': np.nan, 'nan': np.nan}
+        ).infer_objects(copy=False)
     # convert data types to match those defined in flow_by_activity_fields
-    for k, v in flowbyfields.items():
-        if k in flowby_partial_df.columns:
-            flowby_partial_df[k] = flowby_partial_df[k].astype(v[0]['dtype'])
-            if v[0]['dtype'] in ['string', 'str', 'object']:
-                s = flowby_partial_df[k].astype(pd.StringDtype())
-                # optional normalization if those sentinel strings can appear:
-                s = s.mask(s.isin(['None', 'nan']))
-                flowby_partial_df[k] = s
-            else:
-                flowby_partial_df[k] = (
-                    flowby_partial_df[k].fillna(0).infer_objects(copy=False)
-                )
+    with pd.option_context('future.no_silent_downcasting', True):
+        for k, v in flowbyfields.items():
+            if k in flowby_partial_df.columns:
+                flowby_partial_df[k] = flowby_partial_df[k].astype(v[0]['dtype'])
+                if v[0]['dtype'] in ['string', 'str', 'object']:
+                    flowby_partial_df[k] = (
+                        flowby_partial_df[k].fillna(np.nan).infer_objects(copy=False)
+                    )
+                else:
+                    flowby_partial_df[k] = (
+                        flowby_partial_df[k].fillna(0).infer_objects(copy=False)
+                    )
     # convert all None, 'nan' to np.nan
     with pd.option_context('future.no_silent_downcasting', True):
         flowby_partial_df = flowby_partial_df.replace(

--- a/bedrock/transform/flowby.py
+++ b/bedrock/transform/flowby.py
@@ -625,18 +625,13 @@ class _FlowBy(pd.DataFrame):
             **{k: v for k, v in other_fields.items() if isinstance(v, dict)},
         }
 
-        # Ensure string-like columns use a dedicated string dtype before replace
-        string_cols = [k for k in replace_dict.keys() if k in filtered_fb.columns]
-
-        replaced_fb = (
-            filtered_fb.assign(
-                **{col: filtered_fb[col].astype('string') for col in string_cols}
+        with pd.option_context('future.no_silent_downcasting', True):
+            replaced_fb = (
+                filtered_fb.replace(replace_dict)
+                .infer_objects(copy=False)
+                .drop(columns=['PrimaryActivity', 'PrimarySector'], errors='ignore')
+                .reset_index(drop=True)
             )
-            .replace(replace_dict)
-            .infer_objects(copy=False)
-            .drop(columns=['PrimaryActivity', 'PrimarySector'], errors='ignore')
-            .reset_index(drop=True)
-        )
         # Reset blank values to nan
         for k in replace_dict.keys():
             if all(replaced_fb[k] == ''):


### PR DESCRIPTION
## Summary
- Reverts the mask/StringDtype approach from #154 which changed column dtype semantics (object -> pd.StringDtype) and caused test failures due to pd.NA vs np.nan differences
- Replaces with pd.option_context('future.no_silent_downcasting', True) wrapping the original replace/fillna calls, which opts into the future pandas behavior without altering downstream dtype expectations
- Affects dataclean.py (add_missing_flow_by_fields) and flowby.py (select_by_fields)

## Test plan
- [x] Confirm eeio_integration tests pass (test_fbs.py, test_fba.py)
- [x] Verify no FutureWarning output during test runs