### PR TITLE
After redefinitions Make table is non-optional in computation of co-production ratios

### DIFF
--- a/bedrock/transform/iot/__tests__/test_derive_gross_output.py
+++ b/bedrock/transform/iot/__tests__/test_derive_gross_output.py
@@ -48,7 +48,8 @@ class TestComputeCoproductionRatios:
     def test_known_ratios(self) -> None:
         """Ratios match hand computation: value / row total."""
         V = _make_V([[800, 200], [50, 950]], ['A', 'B'])
-        ratios = compute_coproduction_ratios(V)
+        V_after = _make_V([[1000, 0], [0, 1000]], ['A', 'B'])
+        ratios = compute_coproduction_ratios(V, V_after)
 
         a_to_b = ratios[ratios['source_industry'] == 'A']
         assert a_to_b['ratio'].iloc[0] == pytest.approx(200 / 1000)
@@ -70,7 +71,8 @@ class TestAdjustGrossOutput:
                 B = 1000 + 200 - 100 = 1100
         """
         V = _make_V([[900, 100], [50, 450]], ['A', 'B'])
-        ratios = compute_coproduction_ratios(V)
+        V_after = _make_V([[1000, 0], [0, 500]], ['A', 'B'])
+        ratios = compute_coproduction_ratios(V, V_after)
 
         go_before = pd.Series([2000.0, 1000.0], index=pd.Index(['A', 'B']))
         go_after = adjust_gross_output(go_before, ratios)

--- a/bedrock/transform/iot/derived_gross_industry_output.py
+++ b/bedrock/transform/iot/derived_gross_industry_output.py
@@ -119,18 +119,13 @@ def extract_coproduction_entries(V_before_redef: pd.DataFrame) -> pd.DataFrame:
 
 def compute_coproduction_ratios(
     V_before_redef: pd.DataFrame,
-    V_after_redef: pd.DataFrame | None = None,
+    V_after_redef: pd.DataFrame,
 ) -> pd.DataFrame:
     """
     Compute co-production movement ratios from the benchmark Make tables.
 
-    When only *V_before_redef* is supplied the ratio uses the full
-    off-diagonal value (original behaviour)::
-
-        ratio(i, c) = V_before_redef[i, c] / g_before[i]
-
-    When *V_after_redef* is also supplied the ratio is **constrained** to
-    the amount actually moved during BEA's redefinition process::
+    The ratio is constrained to the amount actually moved during BEA's
+    redefinition process::
 
         ratio(i, c) = (V_before_redef[i, c] - V_after_redef[i, c]) / g_before[i]
 
@@ -145,10 +140,9 @@ def compute_coproduction_ratios(
     ----------
     V_before_redef : pd.DataFrame
         Make table (industry x commodity), before redefinitions.
-    V_after_redef : pd.DataFrame or None
-        Make table (industry x commodity), after redefinitions.  When
-        provided the movement delta ``V_before_redef - V_after_redef``
-        is used as the numerator.
+    V_after_redef : pd.DataFrame
+        Make table (industry x commodity), after redefinitions.  The movement
+        delta ``V_before_redef - V_after_redef`` is used as the numerator.
 
     Returns
     -------
@@ -156,19 +150,16 @@ def compute_coproduction_ratios(
         DataFrame with columns ``source_industry``, ``destination_industry``,
         ``ratio``.
     """
-    if V_after_redef is not None:
-        if not V_before_redef.index.equals(V_after_redef.index):
-            raise ValueError(
-                'V_before_redef and V_after_redef industry indexes must match exactly.'
-            )
-        if not V_before_redef.columns.equals(V_after_redef.columns):
-            raise ValueError(
-                'V_before_redef and V_after_redef commodity columns must match exactly.'
-            )
+    if not V_before_redef.index.equals(V_after_redef.index):
+        raise ValueError(
+            'V_before_redef and V_after_redef industry indexes must match exactly.'
+        )
+    if not V_before_redef.columns.equals(V_after_redef.columns):
+        raise ValueError(
+            'V_before_redef and V_after_redef commodity columns must match exactly.'
+        )
 
-    V_movement = (
-        V_before_redef - V_after_redef if V_after_redef is not None else V_before_redef
-    )
+    V_movement = V_before_redef - V_after_redef
     if V_movement.isna().any().any():
         raise ValueError('NaN encountered in V_movement; check input table alignment.')
     coproduction = extract_coproduction_entries(V_movement)


### PR DESCRIPTION
cc: @jvendries 
Closes: [this comment](https://github.com/cornerstone-data/bedrock/pull/205#discussion_r2834160643)

## What changed? Why?

The `compute_coproduction_ratios` function now requires both `V_before_redef` and `V_after_redef` parameters instead of making the latter optional. Previously, when only the before table was provided, the function would use the full off-diagonal values. Now it consistently calculates ratios based on the actual movement delta between the two tables (`V_before_redef - V_after_redef`).

This change ensures that coproduction ratios are always constrained to the amount actually moved during BEA's redefinition process, providing more accurate calculations.

## Testing

Updated existing unit tests to pass both required parameters to `compute_coproduction_ratios`. The tests for `test_known_ratios` and `test_bidirectional_coproduction` now provide appropriate `V_after` matrices alongside the existing `V_before` matrices, confirming the function works correctly with the new required parameter structure.