### PR TITLE
Add config flags for A matrix derivation methods (Issue #182)

### DIFF
--- a/bedrock/utils/config/usa_config.py
+++ b/bedrock/utils/config/usa_config.py
@@ -40,7 +40,9 @@ class USAConfig(BaseModel):
     ### IO Methodology selection
     transform_b_matrix_with_useeio_method: bool = False  # DRI: mo.li
     implement_waste_disaggregation: bool = False  # DRI: jorge.vendries
-    # TODO: Add transform_a_matrix after we decide what to do
+    scale_a_matrix_with_useeio_method: bool = False  # DRI: mo.li
+    scale_a_matrix_with_summary_tables: bool = False  # DRI: mo.li
+    scale_a_matrix_with_price_index: bool = False  # DRI: mo.li
     ### GHG Methodology selection
     usa_ghg_methodology: ta.Literal["national", "state"] = "national"
     update_transportation_ghg_method: bool = False  # DRI: catherine.birney


### PR DESCRIPTION
## Summary

- Adds three boolean config flags to `USAConfig` for testing alternative approaches to derive the A matrix (Issue #182):
  - `scale_a_matrix_with_useeio_method` — do nothing; treat 2017 A as representative of target year
  - `scale_a_matrix_with_summary_tables` — scale 2017→target year using summary table ratios only
  - `scale_a_matrix_with_price_index` — inflate 2017→target year using price index only
- Each flag will be wired up in a separate stacked PR, one per method

## Test plan
- [ ] Stacked PRs add gating logic and YAML configs; each tested independently via the diagnostics GitHub Actions workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)