### PR TITLE
Test USEEIO approach for A matrix derivation (Issue #182)

### DIFF
--- a/bedrock/transform/eeio/derived_cornerstone.py
+++ b/bedrock/transform/eeio/derived_cornerstone.py
@@ -299,6 +299,10 @@ def derive_cornerstone_Aq_scaled() -> SingleRegionAqMatrixSet:
     detail_year = cfg.usa_detail_original_year
     model_year = cfg.model_base_year
 
+    # USEEIO method: return 2017 base A unchanged — no scaling, no inflation.
+    if cfg.scale_a_matrix_with_useeio_method:
+        return base
+
     Adom = inflate_cornerstone_A_matrix(
         scale_cornerstone_A(
             base.Adom,

--- a/bedrock/utils/config/configs/2025_usa_cornerstone_a_useeio.yaml
+++ b/bedrock/utils/config/configs/2025_usa_cornerstone_a_useeio.yaml
@@ -1,0 +1,4 @@
+# Tests USEEIO's approach for deriving the A matrix (Issue #182).
+# No scaling or inflation applied — 2017 technology mix assumed representative of target year.
+use_cornerstone_2026_model_schema: True
+scale_a_matrix_with_useeio_method: True


### PR DESCRIPTION
## Summary

- Gates `derive_cornerstone_Aq_scaled()` to return the 2017 base A matrix unchanged when `scale_a_matrix_with_useeio_method: True`
- USEEIO's assumption: 2017 technology mix is already representative of the target year — no scaling or inflation applied
- Adds `2025_usa_cornerstone_a_useeio.yaml` config for triggering the diagnostics workflow

**Stack:** depends on #228 (config flags base PR)

## Test plan
- [ ] Trigger diagnostics workflow on this branch with `2025_usa_cornerstone_a_useeio.yaml`
- [ ] Compare EF diffs vs CEDA snapshot baseline in the resulting Google Sheet

🤖 Generated with [Claude Code](https://claude.com/claude-code)