### PR TITLE
Test price-index-only approach for A matrix derivation (Issue #182)

### DIFF
--- a/bedrock/transform/eeio/derived_cornerstone.py
+++ b/bedrock/transform/eeio/derived_cornerstone.py
@@ -303,6 +303,24 @@ def derive_cornerstone_Aq_scaled() -> SingleRegionAqMatrixSet:
     if cfg.scale_a_matrix_with_useeio_method:
         return base
 
+    # Price index only: inflate 2017 → model_year directly using price index,
+    # skipping the summary table scaling step entirely.
+    if cfg.scale_a_matrix_with_price_index:
+        Adom = inflate_cornerstone_A_matrix(
+            base.Adom, original_year=detail_year, target_year=model_year
+        )
+        Aimp = inflate_cornerstone_A_matrix(
+            base.Aimp, original_year=detail_year, target_year=model_year
+        )
+        q = inflate_cornerstone_q_or_y(
+            base.scaled_q, original_year=detail_year, target_year=model_year
+        )
+        return SingleRegionAqMatrixSet(
+            Adom=pt.DataFrame[CornerstoneAMatrix](Adom),  # type: ignore[arg-type]
+            Aimp=pt.DataFrame[CornerstoneAMatrix](Aimp),  # type: ignore[arg-type]
+            scaled_q=q,
+        )
+
     Adom = inflate_cornerstone_A_matrix(
         scale_cornerstone_A(
             base.Adom,

--- a/bedrock/utils/config/configs/2025_usa_cornerstone_a_price_index.yaml
+++ b/bedrock/utils/config/configs/2025_usa_cornerstone_a_price_index.yaml
@@ -1,0 +1,4 @@
+# Tests price-index-only approach for deriving the A matrix (Issue #182).
+# A is inflated directly 2017 → target year using price index, no summary table scaling.
+use_cornerstone_2026_model_schema: True
+scale_a_matrix_with_price_index: True


### PR DESCRIPTION
## Summary

- Gates `derive_cornerstone_Aq_scaled()` to inflate A directly from 2017 to the model base year using the commodity price index when `scale_a_matrix_with_price_index: True`
- Skips the summary table scaling step entirely — price-index inflation only
- Adds `2025_usa_cornerstone_a_price_index.yaml` config for triggering the diagnostics workflow

**Stack:** depends on #228 (config flags base PR)

## Test plan
- [ ] Trigger diagnostics workflow on this branch with `2025_usa_cornerstone_a_price_index.yaml`
- [ ] Compare EF diffs vs CEDA snapshot baseline in the resulting Google Sheet

🤖 Generated with [Claude Code](https://claude.com/claude-code)