### PR TITLE
Ignore `.claude/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ __pycache__/
 # Ignore Cursor files
 .cursor/
 .cursorrules
+.claude/


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

Added `.claude/` directory to `.gitignore` to exclude Claude-related configuration files from version control.

## Testing

Verified that `.claude/` directory and its contents are properly ignored by git.