### PR TITLE
Consolidate 3 GHG attribution config flags with minimal to no effect into 1 flag

### DIFF
--- a/bedrock/utils/config/usa_config.py
+++ b/bedrock/utils/config/usa_config.py
@@ -43,10 +43,10 @@ class USAConfig(BaseModel):
     # TODO: Add transform_a_matrix after we decide what to do
     ### GHG Methodology selection
     usa_ghg_methodology: ta.Literal["national", "state"] = "national"
-    update_transportation_ghg_method: bool = False  # DRI: catherine.birney
-    attribute_electricity_ghg_to_221100: bool = False  # DRI: catherine.birney
-    use_full_ghg_for_ng_and_petro_systems: bool = False  # DRI: ben.young
-    soda_ash_ghg_from_table_2_1: bool = False  # DRI: catherine.birney
+    update_transportation_ghg_method: bool = False  # DRI: ben.young
+    update_ghg_attribution_method_for_electricity_soda_ash_and_ng_and_petrol_systems: (
+        bool
+    ) = False  # DRI: catherine.birney
     hybrid_bea_naics_schema_in_ghg_attribution: bool = False  # DRI: ben.young
 
     @property


### PR DESCRIPTION
cc: @catherine.birney
Closes:

## What changed? Why?

Consolidated three separate GHG methodology configuration flags (`attribute_electricity_ghg_to_221100`, `use_full_ghg_for_ng_and_petro_systems`, and `soda_ash_ghg_from_table_2_1`) into a single unified flag `update_ghg_attribution_method_for_electricity_soda_ash_and_ng_and_petrol_systems`. 

Updated DRI ownership for `update_transportation_ghg_method` from catherine.birney to ben.young.

This consolidation simplifies the configuration interface by reducing the number of related boolean flags that likely need to be managed together.

[Command Center](https://docs.google.com/spreadsheets/d/1P0PYXDf4GrJHItmo_kH4_WNOQfaHYsx1-sD3hfQZfo8/edit?gid=0#gid=0) is also updated

![image.png](https://app.graphite.com/user-attachments/assets/f64eb500-5311-401e-a608-f897622739b0.png)

## Testing