### PR TITLE
GHG track emissions by final users

### DIFF
--- a/bedrock/utils/mapping/activitytosectormapping/NAICS_Crosswalk_EPA_GHGI_Cornerstone_household.csv
+++ b/bedrock/utils/mapping/activitytosectormapping/NAICS_Crosswalk_EPA_GHGI_Cornerstone_household.csv
@@ -1,0 +1,616 @@
+ActivitySourceName,Activity,SectorSourceName,Sector,SectorType,Notes,Table
+EPA_GHGI_Cornerstone_household,Iron and Steel Production & Metallurgical Coke Production,NAICS_2017_Code,3311,,331110,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Cement Production,NAICS_2017_Code,32731,,327310,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Lime Production,NAICS_2017_Code,3274,,327400,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Ammonia Production,NAICS_2017_Code,32531,,325310,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Incineration of Waste,NAICS_2017_Code,562213,,562000,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Aluminum Production,NAICS_2017_Code,331313,,331313,"EPA_GHGI_T_2_1, EPA_GHGI_T_4_80"
+EPA_GHGI_Cornerstone_household,Soda Ash Production,NAICS_2017_Code,32519,,325190,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Ferroalloy Production,NAICS_2017_Code,3311,,331110,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Titanium Dioxide Production,NAICS_2017_Code,32519,,325190,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Zinc Production,NAICS_2017_Code,33142,,331420,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Phosphoric Acid Production,NAICS_2017_Code,32531,,325310,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Glass Production,NAICS_2017_Code,3272,,327200,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Carbide Production and Consumption,NAICS_2017_Code,32518,,325180,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Landfills,NAICS_2017_Code,562212,,562000,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Urea Consumption for Non-Agricultural Purposes,NAICS_2017_Code,31,,"31, 32, 33",EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Urea Consumption for Non-Agricultural Purposes,NAICS_2017_Code,32,,,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Urea Consumption for Non-Agricultural Purposes,NAICS_2017_Code,33,,,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Other Process Uses of Carbonates,NAICS_2017_Code,31,,"31, 32, 33",EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Other Process Uses of Carbonates,NAICS_2017_Code,32,,,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Other Process Uses of Carbonates,NAICS_2017_Code,33,,,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Lead Production,NAICS_2017_Code,33149,,331490,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Coal Mining,NAICS_2017_Code,2121,,212100,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Wastewater Treatment,NAICS_2017_Code,2213,,221300,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Abandoned Oil and Gas Wells,NAICS_2017_Code,211,,211000,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Abandoned Underground Coal Mines,NAICS_2017_Code,2121,,212100,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Composting,NAICS_2017_Code,562219,,562000,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Nitric Acid Production,NAICS_2017_Code,32531,,325310,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Adipic Acid Production,NAICS_2017_Code,32519,,325190,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,N2O from Product Uses,NAICS_2017_Code,621,,"621, 622, 623",EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,N2O from Product Uses,NAICS_2017_Code,622,,,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,N2O from Product Uses,NAICS_2017_Code,623,,,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,"Caprolactam, Glyoxal, and Glyoxylic Acid Production",NAICS_2017_Code,32519,,325190,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Electronics Industry,NAICS_2017_Code,334413,,"334413, name change from Semiconductor Manufacture",EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Electrical Transmission and Distribution,NAICS_2017_Code,2211,,221100,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Electrical Equipment,NAICS_2017_Code,2211,,new activity,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Electric Power,NAICS_2017_Code,2211,,"Commodity: 221100 (or I: 221100, S00101, S00202)",EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Liming,NAICS_2017_Code,11111,,1111A0,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Urea Fertilization,NAICS_2017_Code,111,,"111, 112",EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Urea Fertilization,NAICS_2017_Code,112,,,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Manure Management,NAICS_2017_Code,112,,,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Field Burning of Agricultural Residues,NAICS_2017_Code,111,,,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Rice Cultivation,NAICS_2017_Code,11116,,1111B0,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Anaerobic Digestion at Biogas Facilities,NAICS_2017_Code,562219,,new in GHGI since 2018,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone_household,Agricultural Equipment Non-Road,NAICS_2017_Code,111,,"111, 112, 113, 114","EPA_GHGI_T_3_14, EPA_GHGI_T_3_15"
+EPA_GHGI_Cornerstone_household,Agricultural Equipment Non-Road,NAICS_2017_Code,112,,,"EPA_GHGI_T_3_14, EPA_GHGI_T_3_15"
+EPA_GHGI_Cornerstone_household,Agricultural Equipment Non-Road,NAICS_2017_Code,113,,,"EPA_GHGI_T_3_14, EPA_GHGI_T_3_15"
+EPA_GHGI_Cornerstone_household,Agricultural Equipment Non-Road,NAICS_2017_Code,114,,,"EPA_GHGI_T_3_14, EPA_GHGI_T_3_15"
+EPA_GHGI_Cornerstone_household,Alternative Fuel On-Road,NAICS_2017_Code,485,,"485000, 486000, 48A000, 492000","EPA_GHGI_T_3_14, EPA_GHGI_T_3_15"
+EPA_GHGI_Cornerstone_household,Alternative Fuel On-Road,NAICS_2017_Code,487,,,"EPA_GHGI_T_3_14, EPA_GHGI_T_3_15"
+EPA_GHGI_Cornerstone_household,Alternative Fuel On-Road,NAICS_2017_Code,488,,,"EPA_GHGI_T_3_14, EPA_GHGI_T_3_15"
+EPA_GHGI_Cornerstone_household,Alternative Fuel On-Road,NAICS_2017_Code,492,,,"EPA_GHGI_T_3_14, EPA_GHGI_T_3_15"
+EPA_GHGI_Cornerstone_household,Construction/Mining Equipment Non-Road,NAICS_2017_Code,211,,"211000, 212100, 2122A0, 212230, 212310, 2123AO, 213111","EPA_GHGI_T_3_14, EPA_GHGI_T_3_15"
+EPA_GHGI_Cornerstone_household,Construction/Mining Equipment Non-Road,NAICS_2017_Code,212,,,"EPA_GHGI_T_3_14, EPA_GHGI_T_3_15"
+EPA_GHGI_Cornerstone_household,Construction/Mining Equipment Non-Road,NAICS_2017_Code,213111,,,"EPA_GHGI_T_3_14, EPA_GHGI_T_3_15"
+EPA_GHGI_Cornerstone_household,Construction/Mining Equipment Non-Road,NAICS_2017_Code,213112,,,"EPA_GHGI_T_3_14, EPA_GHGI_T_3_15"
+EPA_GHGI_Cornerstone_household,Medium- and Heavy-Duty Trucks and Buses,NAICS_2017_Code,484,,,"EPA_GHGI_T_3_14, EPA_GHGI_T_3_15"
+EPA_GHGI_Cornerstone_household,Other Non-Road,NAICS_2017_Code,485,,"485000, 48A000, 492000, 532100, 532400, 621900, 713900, 811100, 811300","EPA_GHGI_T_3_14, EPA_GHGI_T_3_15"
+EPA_GHGI_Cornerstone_household,Other Non-Road,NAICS_2017_Code,487,,,"EPA_GHGI_T_3_14, EPA_GHGI_T_3_15"
+EPA_GHGI_Cornerstone_household,Other Non-Road,NAICS_2017_Code,488,,,"EPA_GHGI_T_3_14, EPA_GHGI_T_3_15"
+EPA_GHGI_Cornerstone_household,Other Non-Road,NAICS_2017_Code,492,,,"EPA_GHGI_T_3_14, EPA_GHGI_T_3_15"
+EPA_GHGI_Cornerstone_household,Other Non-Road,NAICS_2017_Code,5321,,,"EPA_GHGI_T_3_14, EPA_GHGI_T_3_15"
+EPA_GHGI_Cornerstone_household,Other Non-Road,NAICS_2017_Code,5324,,,"EPA_GHGI_T_3_14, EPA_GHGI_T_3_15"
+EPA_GHGI_Cornerstone_household,Other Non-Road,NAICS_2017_Code,6219,,,"EPA_GHGI_T_3_14, EPA_GHGI_T_3_15"
+EPA_GHGI_Cornerstone_household,Other Non-Road,NAICS_2017_Code,7139,,,"EPA_GHGI_T_3_14, EPA_GHGI_T_3_15"
+EPA_GHGI_Cornerstone_household,Other Non-Road,NAICS_2017_Code,8111,,,"EPA_GHGI_T_3_14, EPA_GHGI_T_3_15"
+EPA_GHGI_Cornerstone_household,Other Non-Road,NAICS_2017_Code,8113,,,"EPA_GHGI_T_3_14, EPA_GHGI_T_3_15"
+EPA_GHGI_Cornerstone_household,Exploration,NAICS_2017_Code,211120,,211000,"EPA_GHGI_T_3_38, EPA_GHGI_T_3_40, EPA_GHGI_T_3_42, EPA_GHGI_T_3_63, EPA_GHGI_T_3_65, EPA_GHGI_T_3_67"
+EPA_GHGI_Cornerstone_household,Production,NAICS_2017_Code,211130,,211000,"EPA_GHGI_T_3_38, EPA_GHGI_T_3_40, EPA_GHGI_T_3_42, EPA_GHGI_T_3_63, EPA_GHGI_T_3_65, EPA_GHGI_T_3_67"
+EPA_GHGI_Cornerstone_household,Crude Oil Transportation,NAICS_2017_Code,486110,,not mapped,"EPA_GHGI_T_3_38, EPA_GHGI_T_3_40, EPA_GHGI_T_3_42"
+EPA_GHGI_Cornerstone_household,Transportation,NAICS_2017_Code,486110,,not mapped,"EPA_GHGI_T_3_38, EPA_GHGI_T_3_40, EPA_GHGI_T_3_42"
+EPA_GHGI_Cornerstone_household,Refining,NAICS_2017_Code,324110,,324110,"EPA_GHGI_T_3_38, EPA_GHGI_T_3_40, EPA_GHGI_T_3_42"
+EPA_GHGI_Cornerstone_household,Crude Refining,NAICS_2017_Code,324110,,324110,"EPA_GHGI_T_3_38, EPA_GHGI_T_3_40, EPA_GHGI_T_3_42"
+EPA_GHGI_Cornerstone_household,Distribution,NAICS_2017_Code,221210,,221200,"EPA_GHGI_T_3_63, EPA_GHGI_T_3_65, EPA_GHGI_T_3_67"
+EPA_GHGI_Cornerstone_household,Post-Meter,NAICS_2017_Code,221210,,,"EPA_GHGI_T_3_63, EPA_GHGI_T_3_65, EPA_GHGI_T_3_67"
+EPA_GHGI_Cornerstone_household,Processing,NAICS_2017_Code,211130,,211000,"EPA_GHGI_T_3_63, EPA_GHGI_T_3_65, EPA_GHGI_T_3_67"
+EPA_GHGI_Cornerstone_household,Transmission and Storage,NAICS_2017_Code,486210,,486000,"EPA_GHGI_T_3_63, EPA_GHGI_T_3_65, EPA_GHGI_T_3_67"
+EPA_GHGI_Cornerstone_household,Chickpeas,NAICS_2017_Code,11113,,1111B0,EPA_GHGI_T_5_29
+EPA_GHGI_Cornerstone_household,Cotton,NAICS_2017_Code,11192,,111900,EPA_GHGI_T_5_29
+EPA_GHGI_Cornerstone_household,Maize,NAICS_2017_Code,11115,,1111B0,EPA_GHGI_T_5_29
+EPA_GHGI_Cornerstone_household,Corn,NAICS_2017_Code,11115,,1111B0,EPA_GHGI_T_5_29
+EPA_GHGI_Cornerstone_household,Lentils,NAICS_2017_Code,11113,,1111A0,EPA_GHGI_T_5_29
+EPA_GHGI_Cornerstone_household,Sugarcane,NAICS_2017_Code,11119,,mapping to 11119 instead of 11193 so that it maps to 1111B0,EPA_GHGI_T_5_29
+EPA_GHGI_Cornerstone_household,Rice,NAICS_2017_Code,11116,,1111B0,EPA_GHGI_T_5_29
+EPA_GHGI_Cornerstone_household,Soybeans,NAICS_2017_Code,11111,,1111A0,EPA_GHGI_T_5_29
+EPA_GHGI_Cornerstone_household,Wheat,NAICS_2017_Code,11114,,1111B0,EPA_GHGI_T_5_29
+EPA_GHGI_Cornerstone_household,American Bison,NAICS_2017_Code,11299,,112A00,"EPA_GHGI_T_5_3, EPA_GHGI_T_5_7"
+EPA_GHGI_Cornerstone_household,Beef Cattle,NAICS_2017_Code,11211,,1121A0,"EPA_GHGI_T_5_3, EPA_GHGI_T_5_7"
+EPA_GHGI_Cornerstone_household,Dairy Cattle,NAICS_2017_Code,11212,,112120,"EPA_GHGI_T_5_3, EPA_GHGI_T_5_7"
+EPA_GHGI_Cornerstone_household,Goats,NAICS_2017_Code,11242,,112A00,"EPA_GHGI_T_5_3, EPA_GHGI_T_5_7"
+EPA_GHGI_Cornerstone_household,Horses,NAICS_2017_Code,11292,,112A00,"EPA_GHGI_T_5_3, EPA_GHGI_T_5_7"
+EPA_GHGI_Cornerstone_household,Mules and Asses,NAICS_2017_Code,11292,,112A00,"EPA_GHGI_T_5_3, EPA_GHGI_T_5_7"
+EPA_GHGI_Cornerstone_household,Sheep,NAICS_2017_Code,11241,,112A00,"EPA_GHGI_T_5_3, EPA_GHGI_T_5_7"
+EPA_GHGI_Cornerstone_household,Swine,NAICS_2017_Code,1122,,112A00,"EPA_GHGI_T_5_3, EPA_GHGI_T_5_7"
+EPA_GHGI_Cornerstone_household,Poultry,NAICS_2017_Code,1123,,112300,"EPA_GHGI_T_5_3, EPA_GHGI_T_5_7"
+EPA_GHGI_Cornerstone_household,Acrylonitrile,NAICS_2017_Code,325411,,325411 (incorrect in original?),EPA_GHGI_T_4_46
+EPA_GHGI_Cornerstone_household,Carbon Black,NAICS_2017_Code,325212,,3252A0 (incorrect in original?),EPA_GHGI_T_4_46
+EPA_GHGI_Cornerstone_household,Ethylene,NAICS_2017_Code,324110,,324110,EPA_GHGI_T_4_46
+EPA_GHGI_Cornerstone_household,Ethylene Dichloride,NAICS_2017_Code,325120,,not mapped,EPA_GHGI_T_4_46
+EPA_GHGI_Cornerstone_household,Ethylene Oxide,NAICS_2017_Code,325411,,325411 (incorrect in original?),EPA_GHGI_T_4_46
+EPA_GHGI_Cornerstone_household,Methanol,NAICS_2017_Code,325411,,325411 (incorrect in original?),EPA_GHGI_T_4_46
+EPA_GHGI_Cornerstone_household,Industry Industrial Coking Coal,NAICS_2017_Code,212210,,2122A0 (incorrect in original?),EPA_GHGI_T_3_22
+EPA_GHGI_Cornerstone_household,Industry Industrial Other Coal,NAICS_2017_Code,212210,,2122A0 (incorrect in original?),EPA_GHGI_T_3_22
+EPA_GHGI_Cornerstone_household,Industry Petroleum Products Non-energy,NAICS_2017_Code,31,,"31, 32, 33",EPA_GHGI_T_3_22
+EPA_GHGI_Cornerstone_household,Industry Petroleum Products Non-energy,NAICS_2017_Code,324110,,,EPA_GHGI_T_3_22
+EPA_GHGI_Cornerstone_household,Industry Petroleum Products Non-energy,NAICS_2017_Code,324199,,,EPA_GHGI_T_3_22
+EPA_GHGI_Cornerstone_household,Industry Petroleum Products Non-energy,NAICS_2017_Code,32412,,Used in CEDA,
+EPA_GHGI_Cornerstone_household,Industry Petroleum Products Non-energy,NAICS_2017_Code,325,,,EPA_GHGI_T_3_22
+EPA_GHGI_Cornerstone_household,Industry Petroleum Products Non-energy,NAICS_2017_Code,326,,,EPA_GHGI_T_3_22
+EPA_GHGI_Cornerstone_household,Industry Petroleum Products Non-energy,NAICS_2017_Code,327,,,EPA_GHGI_T_3_22
+EPA_GHGI_Cornerstone_household,Industry Petroleum Products Non-energy,NAICS_2017_Code,33,,,EPA_GHGI_T_3_22
+EPA_GHGI_Cornerstone_household,Industry Natural Gas to Chemical Plants,NAICS_2017_Code,31,,,EPA_GHGI_T_3_22
+EPA_GHGI_Cornerstone_household,Industry Natural Gas to Chemical Plants,NAICS_2017_Code,32,,,EPA_GHGI_T_3_22
+EPA_GHGI_Cornerstone_household,Industry Natural Gas to Chemical Plants,NAICS_2017_Code,33,,,EPA_GHGI_T_3_22
+EPA_GHGI_Cornerstone_household,Transportation Lubricants,NAICS_2017_Code,48,,"48, 491, 492, S00500, S00600, GSLGO, S00201, S00203, F01000",EPA_GHGI_T_3_22
+EPA_GHGI_Cornerstone_household,Transportation Lubricants,NAICS_2017_Code,491,,,EPA_GHGI_T_3_22
+EPA_GHGI_Cornerstone_household,Transportation Lubricants,NAICS_2017_Code,492,,,EPA_GHGI_T_3_22
+EPA_GHGI_Cornerstone_household,Transportation Lubricants,NAICS_2017_Code,S00500,,,EPA_GHGI_T_3_22
+EPA_GHGI_Cornerstone_household,Transportation Lubricants,NAICS_2017_Code,S00600,,,EPA_GHGI_T_3_22
+EPA_GHGI_Cornerstone_household,Transportation Lubricants,NAICS_2017_Code,GSLGO,,,EPA_GHGI_T_3_22
+EPA_GHGI_Cornerstone_household,Transportation Lubricants,NAICS_2017_Code,S00203,,,EPA_GHGI_T_3_22
+EPA_GHGI_Cornerstone_household,Transportation Lubricants,NAICS_2017_Code,F01000,,,EPA_GHGI_T_3_22
+EPA_GHGI_Cornerstone_household,Coal Electric Power,NAICS_2017_Code,2211,,"Commodity: 221100 (or I: 221100, S00101, S00202)","EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Fuel Oil Electric Power,NAICS_2017_Code,2211,,"Commodity: 221100 (or I: 221100, S00101, S00202)","EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Natural Gas Electric Power,NAICS_2017_Code,2211,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Wood Electric Power,NAICS_2017_Code,2211,,"Commodity: 221100 (or I: 221100, S00101, S00202)","EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,All activities Electric Power,NAICS_2017_Code,2211,,"Sum of other ""Electric Power"" activities","EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Coal Electric Power,NAICS_2017_Code,S00101,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Fuel Oil Electric Power,NAICS_2017_Code,S00101,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Natural Gas Electric Power,NAICS_2017_Code,S00101,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Wood Electric Power,NAICS_2017_Code,S00101,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Coal Electric Power,NAICS_2017_Code,S00202,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Fuel Oil Electric Power,NAICS_2017_Code,S00202,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Natural Gas Electric Power,NAICS_2017_Code,S00202,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Wood Electric Power,NAICS_2017_Code,S00202,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Coal Residential,NAICS_2017_Code,F01000,,F01000,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Fuel Oil Residential,NAICS_2017_Code,F01000,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Natural Gas Residential,NAICS_2017_Code,F01000,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Wood Residential,NAICS_2017_Code,F01000,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Coal Industrial,NAICS_2017_Code,11,,"11, 21, 2212, 23, 31, 32, 33","EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Coal Industrial,NAICS_2017_Code,21,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Coal Industrial,NAICS_2017_Code,2212,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Coal Industrial,NAICS_2017_Code,23,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Coal Industrial - Manufacturing,NAICS_2017_Code,31,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Coal Industrial - Manufacturing,NAICS_2017_Code,32,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Coal Industrial - Manufacturing,NAICS_2017_Code,33,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Fuel Oil Industrial,NAICS_2017_Code,11,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Fuel Oil Industrial,NAICS_2017_Code,21,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Fuel Oil Industrial,NAICS_2017_Code,2212,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Fuel Oil Industrial,NAICS_2017_Code,23,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Fuel Oil Industrial,NAICS_2017_Code,31,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Fuel Oil Industrial,NAICS_2017_Code,32,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Fuel Oil Industrial,NAICS_2017_Code,33,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Natural gas Industrial - Manufacturing,NAICS_2017_Code,31,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Natural gas Industrial - Manufacturing,NAICS_2017_Code,32,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Natural gas Industrial - Manufacturing,NAICS_2017_Code,33,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Wood Industrial,NAICS_2017_Code,11,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Wood Industrial,NAICS_2017_Code,21,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Wood Industrial,NAICS_2017_Code,2212,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Wood Industrial,NAICS_2017_Code,23,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Wood Industrial,NAICS_2017_Code,31,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Wood Industrial,NAICS_2017_Code,32,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Wood Industrial,NAICS_2017_Code,33,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Coal Commercial,NAICS_2017_Code,2213,,"2213, 42, 44, 45, 493, 5, 6, 7, 8, S00102, GSLGE, GSLGH","EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Coal Commercial,NAICS_2017_Code,42,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Coal Commercial,NAICS_2017_Code,44,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Coal Commercial,NAICS_2017_Code,45,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Coal Commercial,NAICS_2017_Code,493,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Coal Commercial,NAICS_2017_Code,51,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Coal Commercial,NAICS_2017_Code,52,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Coal Commercial,NAICS_2017_Code,53,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Coal Commercial,NAICS_2017_Code,54,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Coal Commercial,NAICS_2017_Code,55,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Coal Commercial,NAICS_2017_Code,56,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Coal Commercial,NAICS_2017_Code,61,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Coal Commercial,NAICS_2017_Code,62,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Coal Commercial,NAICS_2017_Code,71,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Coal Commercial,NAICS_2017_Code,72,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Coal Commercial,NAICS_2017_Code,81,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Coal Commercial,NAICS_2017_Code,S00102,,S00102,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Coal Commercial,NAICS_2017_Code,GSLGE,,GSLGE,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Coal Commercial,NAICS_2017_Code,GSLGH,,GSLGH,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Fuel Oil Commercial,NAICS_2017_Code,2213,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Fuel Oil Commercial,NAICS_2017_Code,42,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Fuel Oil Commercial,NAICS_2017_Code,44,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Fuel Oil Commercial,NAICS_2017_Code,45,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Fuel Oil Commercial,NAICS_2017_Code,493,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Fuel Oil Commercial,NAICS_2017_Code,51,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Fuel Oil Commercial,NAICS_2017_Code,52,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Fuel Oil Commercial,NAICS_2017_Code,53,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Fuel Oil Commercial,NAICS_2017_Code,54,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Fuel Oil Commercial,NAICS_2017_Code,55,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Fuel Oil Commercial,NAICS_2017_Code,56,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Fuel Oil Commercial,NAICS_2017_Code,61,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Fuel Oil Commercial,NAICS_2017_Code,62,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Fuel Oil Commercial,NAICS_2017_Code,71,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Fuel Oil Commercial,NAICS_2017_Code,72,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Fuel Oil Commercial,NAICS_2017_Code,81,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Fuel Oil Commercial,NAICS_2017_Code,S00102,,S00102,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Fuel Oil Commercial,NAICS_2017_Code,GSLGE,,GSLGE,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Fuel Oil Commercial,NAICS_2017_Code,GSLGH,,GSLGH,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Wood Commercial,NAICS_2017_Code,2213,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Wood Commercial,NAICS_2017_Code,42,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Wood Commercial,NAICS_2017_Code,44,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Wood Commercial,NAICS_2017_Code,45,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Wood Commercial,NAICS_2017_Code,493,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Wood Commercial,NAICS_2017_Code,51,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Wood Commercial,NAICS_2017_Code,52,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Wood Commercial,NAICS_2017_Code,53,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Wood Commercial,NAICS_2017_Code,54,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Wood Commercial,NAICS_2017_Code,55,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Wood Commercial,NAICS_2017_Code,56,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Wood Commercial,NAICS_2017_Code,61,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Wood Commercial,NAICS_2017_Code,62,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Wood Commercial,NAICS_2017_Code,71,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Wood Commercial,NAICS_2017_Code,72,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Wood Commercial,NAICS_2017_Code,81,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Wood Commercial,NAICS_2017_Code,S00102,,S00102,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Wood Commercial,NAICS_2017_Code,GSLGE,,GSLGE,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Wood Commercial,NAICS_2017_Code,GSLGH,,GSLGH,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9"
+EPA_GHGI_Cornerstone_household,Drained Organic Soils Cropland,NAICS_2017_Code,111,,"111, excl. 1114",EPA_GHGI_T_5_18
+EPA_GHGI_Cornerstone_household,Mineralization and Asymbiotic Fixation Cropland,NAICS_2017_Code,111,,"111, excl. 1114",EPA_GHGI_T_5_18
+EPA_GHGI_Cornerstone_household,Organic Amendment Cropland,NAICS_2017_Code,111,,111,EPA_GHGI_T_5_18
+EPA_GHGI_Cornerstone_household,Residue N Cropland,NAICS_2017_Code,111,,111,EPA_GHGI_T_5_18
+EPA_GHGI_Cornerstone_household,Synthetic Fertilizer Cropland,NAICS_2017_Code,111,,111,EPA_GHGI_T_5_18
+EPA_GHGI_Cornerstone_household,All activities Grassland,NAICS_2017_Code,112,,112,"EPA_GHGI_T_5_18, EPA_GHGI_T_5_19"
+EPA_GHGI_Cornerstone_household,Volatilization & Atm. Deposition Cropland,NAICS_2017_Code,111,,111,EPA_GHGI_T_5_19
+EPA_GHGI_Cornerstone_household,Surface Leaching & Run-Off Cropland,NAICS_2017_Code,111,,111,EPA_GHGI_T_5_19
+EPA_GHGI_Cornerstone_household,Natural Gas Industrial,NAICS_2017_Code,11,,"11, 21, 2212, 23","EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Natural Gas Industrial,NAICS_2017_Code,21,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Natural Gas Industrial,NAICS_2017_Code,2212,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Natural Gas Industrial,NAICS_2017_Code,23,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Natural Gas Industrial - Manufacturing,NAICS_2017_Code,31,,"31, 32, 33",EPA_GHGI_T_A_14
+EPA_GHGI_Cornerstone_household,Natural Gas Industrial - Manufacturing,NAICS_2017_Code,32,,,EPA_GHGI_T_A_14
+EPA_GHGI_Cornerstone_household,Natural Gas Industrial - Manufacturing,NAICS_2017_Code,33,,,EPA_GHGI_T_A_14
+EPA_GHGI_Cornerstone_household,Total Petroleum Industrial,NAICS_2017_Code,11,,"11, 21, 2212, 23, 31, 32, 33",EPA_GHGI_T_A_14
+EPA_GHGI_Cornerstone_household,Total Petroleum Industrial,NAICS_2017_Code,21,,,EPA_GHGI_T_A_14
+EPA_GHGI_Cornerstone_household,Total Petroleum Industrial,NAICS_2017_Code,2212,,,EPA_GHGI_T_A_14
+EPA_GHGI_Cornerstone_household,Total Petroleum Industrial,NAICS_2017_Code,23,,,EPA_GHGI_T_A_14
+EPA_GHGI_Cornerstone_household,Total Petroleum Industrial,NAICS_2017_Code,31,,,EPA_GHGI_T_A_14
+EPA_GHGI_Cornerstone_household,Total Petroleum Industrial,NAICS_2017_Code,32,,,EPA_GHGI_T_A_14
+EPA_GHGI_Cornerstone_household,Total Petroleum Industrial,NAICS_2017_Code,33,,,EPA_GHGI_T_A_14
+EPA_GHGI_Cornerstone_household,Natural Gas Commercial,NAICS_2017_Code,2213,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Natural Gas Commercial,NAICS_2017_Code,42,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Natural Gas Commercial,NAICS_2017_Code,44,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Natural Gas Commercial,NAICS_2017_Code,45,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Natural Gas Commercial,NAICS_2017_Code,493,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Natural Gas Commercial,NAICS_2017_Code,51,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Natural Gas Commercial,NAICS_2017_Code,52,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Natural Gas Commercial,NAICS_2017_Code,53,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Natural Gas Commercial,NAICS_2017_Code,54,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Natural Gas Commercial,NAICS_2017_Code,55,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Natural Gas Commercial,NAICS_2017_Code,56,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Natural Gas Commercial,NAICS_2017_Code,61,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Natural Gas Commercial,NAICS_2017_Code,62,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Natural Gas Commercial,NAICS_2017_Code,71,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Natural Gas Commercial,NAICS_2017_Code,72,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Natural Gas Commercial,NAICS_2017_Code,81,,,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Natural Gas Commercial,NAICS_2017_Code,S00102,,S00102,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Natural Gas Commercial,NAICS_2017_Code,GSLGE,,GSLGE,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Natural Gas Commercial,NAICS_2017_Code,GSLGH,,GSLGH,"EPA_GHGI_T_3_8, EPA_GHGI_T_3_9, EPA_GHGI_T_A_14"
+EPA_GHGI_Cornerstone_household,Total Petroleum Commercial,NAICS_2017_Code,2213,,,EPA_GHGI_T_A_14
+EPA_GHGI_Cornerstone_household,Total Petroleum Commercial,NAICS_2017_Code,42,,,EPA_GHGI_T_A_14
+EPA_GHGI_Cornerstone_household,Total Petroleum Commercial,NAICS_2017_Code,44,,,EPA_GHGI_T_A_14
+EPA_GHGI_Cornerstone_household,Total Petroleum Commercial,NAICS_2017_Code,45,,,EPA_GHGI_T_A_14
+EPA_GHGI_Cornerstone_household,Total Petroleum Commercial,NAICS_2017_Code,493,,,EPA_GHGI_T_A_14
+EPA_GHGI_Cornerstone_household,Total Petroleum Commercial,NAICS_2017_Code,51,,,EPA_GHGI_T_A_14
+EPA_GHGI_Cornerstone_household,Total Petroleum Commercial,NAICS_2017_Code,52,,,EPA_GHGI_T_A_14
+EPA_GHGI_Cornerstone_household,Total Petroleum Commercial,NAICS_2017_Code,53,,,EPA_GHGI_T_A_14
+EPA_GHGI_Cornerstone_household,Total Petroleum Commercial,NAICS_2017_Code,54,,,EPA_GHGI_T_A_14
+EPA_GHGI_Cornerstone_household,Total Petroleum Commercial,NAICS_2017_Code,55,,,EPA_GHGI_T_A_14
+EPA_GHGI_Cornerstone_household,Total Petroleum Commercial,NAICS_2017_Code,56,,,EPA_GHGI_T_A_14
+EPA_GHGI_Cornerstone_household,Total Petroleum Commercial,NAICS_2017_Code,61,,,EPA_GHGI_T_A_14
+EPA_GHGI_Cornerstone_household,Total Petroleum Commercial,NAICS_2017_Code,62,,,EPA_GHGI_T_A_14
+EPA_GHGI_Cornerstone_household,Total Petroleum Commercial,NAICS_2017_Code,71,,,EPA_GHGI_T_A_14
+EPA_GHGI_Cornerstone_household,Total Petroleum Commercial,NAICS_2017_Code,72,,,EPA_GHGI_T_A_14
+EPA_GHGI_Cornerstone_household,Total Petroleum Commercial,NAICS_2017_Code,81,,,EPA_GHGI_T_A_14
+EPA_GHGI_Cornerstone_household,Total Petroleum Commercial,NAICS_2017_Code,S00102,,S00102,EPA_GHGI_T_A_14
+EPA_GHGI_Cornerstone_household,Total Petroleum Commercial,NAICS_2017_Code,GSLGE,,GSLGE,EPA_GHGI_T_A_14
+EPA_GHGI_Cornerstone_household,Total Petroleum Commercial,NAICS_2017_Code,GSLGH,,GSLGH,EPA_GHGI_T_A_14
+EPA_GHGI_Cornerstone_household,Total (All Fuels) Residential,NAICS_2017_Code,F01000,,F0100,EPA_GHGI_T_A_14
+EPA_GHGI_Cornerstone_household,HCFC-22 Production,NAICS_2017_Code,325120,,325120,EPA_GHGI_T_4_50
+EPA_GHGI_Cornerstone_household,Fluorochemical Production,NAICS_2017_Code,325120,,,EPA_GHGI_T_4_61
+EPA_GHGI_Cornerstone_household,Electronics Production,NAICS_2017_Code,334413,,334413,EPA_GHGI_T_4_94
+EPA_GHGI_Cornerstone_household,Semiconductors,NAICS_2017_Code,334413,,,EPA_GHGI_T_4_121
+EPA_GHGI_Cornerstone_household,MEMS,NAICS_2017_Code,334413,,,EPA_GHGI_T_4_121
+EPA_GHGI_Cornerstone_household,PV,NAICS_2017_Code,334413,,,EPA_GHGI_T_4_121
+EPA_GHGI_Cornerstone_household,Magnesium Production and Processing,NAICS_2017_Code,331410,,"331410, 331490, 331520",EPA_GHGI_T_4_84
+EPA_GHGI_Cornerstone_household,Magnesium Production and Processing,NAICS_2017_Code,33149,,,EPA_GHGI_T_4_84
+EPA_GHGI_Cornerstone_household,Magnesium Production and Processing,NAICS_2017_Code,33152,,,EPA_GHGI_T_4_84
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,211,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,230301,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,230302,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,233210,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,233230,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,233240,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,233262,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,2332A0,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,2332C0,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,2332D0,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,233411,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,233412,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,2334A0,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,31111,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,31122,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,31123,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,3113,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,3114,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,3115,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,31161,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,31171,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,3118,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,31191,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,31199,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,31211,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,31212,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,31223,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,32111,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,3219,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,32212,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,32213,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,32221,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,32311,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,32411,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,32412,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,32518,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,32519,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,32521,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,32541,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,32552,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,3256,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,32592,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,32599,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,32611,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,32614,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,32615,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,32616,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,32619,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,32721,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,32732,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33111,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33141,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33152,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33211,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33221,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,3323,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33241,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33242,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,3327,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33281,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,3329,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33311,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33312,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33324,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33331,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33341,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33351,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33361,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33392,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33399,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33431,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33441,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33451,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33512,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33522,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33531,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33593,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,3361,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33621,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33631,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33633,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33634,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33635,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33636,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33637,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33639,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33641,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33651,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33712,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33721,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33911,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33992,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33993,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33995,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,33999,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,42,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,44,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,45,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,484,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,485,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,486,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,487,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,488,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,51111,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,51113,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,51121,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,5121,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,51521,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,51731,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,51821,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,52111,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,5221,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,5239,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,5324,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,5411,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,54121,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,5413,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,5414,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,54151,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,5416,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,5417,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,5418,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,54191,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,54193,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,54194,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,54199,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,55111,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,56,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,61,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,62,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,7111,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,71121,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,7113,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,71141,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,712,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,713,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,72,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,8111,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,81121,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,81131,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,8121,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,8123,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,8129,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,813,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,GSLGE,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,GSLGH,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,GSLGO,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,S00203,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,S00500,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Refrigeration/Air Conditioning,NAICS_2017_Code,S00600,,,EPA_GHGI_T_4_124
+EPA_GHGI_Cornerstone_household,Domestic Refrigeration,NAICS_2017_Code,F01000,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Residential Stationary Air Conditioning,NAICS_2017_Code,F01000,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Aerosols,,,,excluded,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,230301,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,230302,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,233210,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,233230,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,233240,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,233262,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,2332A0,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,2332C0,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,2332D0,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,233411,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,233412,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,2334A0,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,31122,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,31123,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,3113,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,31142,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,3115,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,31191,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,31193,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,31211,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,31411,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,316,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,32192,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,32199,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,32221,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,32419,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,32519,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,32532,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,32541,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,32551,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,32561,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,32592,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,32599,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,32614,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,32615,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,32619,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,32621,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,32629,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,33232,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,33251,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,33261,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,33291,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,33313,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,33341,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,33391,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,33421,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,33422,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,33441,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,33451,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,33522,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,3361,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,33621,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,33631,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,33632,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,33633,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,33634,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,33635,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,33636,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,33639,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,33712,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,33721,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,3379,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,33911,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,33999,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,42,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,44,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,45,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,48211,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,485,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,487,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,488,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,492,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,493,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,51114,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,51119,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,51121,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,5121,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,51521,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,517,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,51821,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,5321,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,5324,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,5411,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,54121,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,5413,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,5414,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,54151,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,5416,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,5417,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,5418,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,54191,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,54192,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,54193,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,54199,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,55111,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,5614,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,5617,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,5619,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,562,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,61121,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,61131,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,62,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,71151,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,7139,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,72,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,81121,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,81131,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,8114,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,8121,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,81341,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,8139,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,GSLGH,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,GSLGO,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,S00203,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,S00500,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,S00600,,,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Solvents,,,,excluded,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,Fire Protection,,,,excluded,EPA_GHGI_T_4_101
+EPA_GHGI_Cornerstone_household,AWACs,NAICS_2017_Code,S00500,,,EPA_GHGI_T_4_132
+EPA_GHGI_Cornerstone_household,Other Military Applications,NAICS_2017_Code,S00500,,,EPA_GHGI_T_4_132
+EPA_GHGI_Cornerstone_household,Particle Accelerators,NAICS_2017_Code,54171,,,EPA_GHGI_T_4_132
+EPA_GHGI_Cornerstone_household,Other Scientific Applications,NAICS_2017_Code,54171,,,EPA_GHGI_T_4_132
+EPA_GHGI_Cornerstone_household,Heavy-Duty Vehicles,NAICS_2017_Code,484,,484000,EPA_GHGI_T_A_97
+EPA_GHGI_Cornerstone_household,School and Tour Buses,NAICS_2017_Code,485,,485000,EPA_GHGI_T_A_97
+EPA_GHGI_Cornerstone_household,Transit Buses,,,,excluded,EPA_GHGI_T_A_97
+EPA_GHGI_Cornerstone_household,Buses,NAICS_2017_Code,485,,485000,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_household,Buses - Distillate Fuel Oil,NAICS_2017_Code,485,,485000,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_household,Buses - Distillate Fuel Oil,NAICS_2017_Code,487,,48A000,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_household,Commercial Aircraft,NAICS_2017_Code,481,,481000,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_household,General Aviation Aircraft,NAICS_2017_Code,481,,481000,"EPA_GHGI_T_3_13, EPA_GHGI_T_3_14, EPA_GHGI_T_3_15"
+EPA_GHGI_Cornerstone_household,Military Aircraft,NAICS_2017_Code,S00500,,S00500,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_household,Light-Duty Trucks - Households,NAICS_2017_Code,F01000,,F01000,"EPA_GHGI_T_3_13, EPA_GHGI_T_A_97"
+EPA_GHGI_Cornerstone_household,Light-Duty Trucks,NAICS_2017_Code,F01000,,F01000,"EPA_GHGI_T_3_13, EPA_GHGI_T_3_14, EPA_GHGI_T_3_15"
+EPA_GHGI_Cornerstone_household,Light-Duty Trucks,NAICS_2017_Code,492,,492000,"EPA_GHGI_T_3_13, EPA_GHGI_T_3_14, EPA_GHGI_T_3_15"
+EPA_GHGI_Cornerstone_household,Medium- and Heavy-Duty Trucks,NAICS_2017_Code,484,,484000,"EPA_GHGI_T_3_13, EPA_GHGI_T_A_97"
+EPA_GHGI_Cornerstone_household,Medium- and Heavy-Duty Trucks - Distillate Fuel Oil,NAICS_2017_Code,484,,484000,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_household,Medium- and Heavy-Duty Trucks - Distillate Fuel Oil,NAICS_2017_Code,491,,491000,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_household,Medium- and Heavy-Duty Trucks - Distillate Fuel Oil,NAICS_2017_Code,GSLGO,,GSLGO,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_household,Medium- and Heavy-Duty Trucks - Distillate Fuel Oil,NAICS_2017_Code,GSLGE,,GSLGE,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_household,Medium- and Heavy-Duty Trucks - Distillate Fuel Oil,NAICS_2017_Code,GSLGH,,GSLGH,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_household,Medium- and Heavy-Duty Trucks - Distillate Fuel Oil,NAICS_2017_Code,S00102,,,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_household,Medium- and Heavy-Duty Trucks - Distillate Fuel Oil,NAICS_2017_Code,S00203,,,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_household,All Transport - Diesel,NAICS_2017_Code,482,,482000,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_household,All Transport - Diesel,NAICS_2017_Code,483,,483000,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_household,All Transport - Diesel,NAICS_2017_Code,484,,484000,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_household,All Transport - Diesel,NAICS_2017_Code,485,,485000,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_household,All Transport - Diesel,NAICS_2017_Code,487,,48A000,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_household,All Transport - Diesel,NAICS_2017_Code,491,,491000,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_household,All Transport - Diesel,NAICS_2017_Code,F01000,,F01000,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_household,All Transport - Diesel,NAICS_2017_Code,GSLGE,,GSLGE,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_household,All Transport - Diesel,NAICS_2017_Code,GSLGH,,GSLGH,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_household,All Transport - Diesel,NAICS_2017_Code,GSLGO,,GSLGO,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_household,All Transport - Diesel,NAICS_2017_Code,S00102,,S00102,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_household,All Transport - Diesel,NAICS_2017_Code,S00203,,S00203,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_household,All Transport - Gasoline,NAICS_2017_Code,484,,484000,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_household,All Transport - Gasoline,NAICS_2017_Code,485,,485000,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_household,All Transport - Gasoline,NAICS_2017_Code,491,,491000,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_household,All Transport - Gasoline,NAICS_2017_Code,492,,492000,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_household,All Transport - Gasoline,NAICS_2017_Code,F01000,,F01000,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_household,All Transport - Gasoline,NAICS_2017_Code,GSLGO,,GSLGO,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_household,All Transport - Gasoline,NAICS_2017_Code,S00600,,S00600,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_household,Motorcycles,NAICS_2017_Code,F01000,,F01000,"EPA_GHGI_T_3_13, EPA_GHGI_T_3_14, EPA_GHGI_T_3_15"
+EPA_GHGI_Cornerstone_household,Passenger Cars - Households,NAICS_2017_Code,F01000,,F01000,"EPA_GHGI_T_3_13, EPA_GHGI_T_A_97"
+EPA_GHGI_Cornerstone_household,Passenger Cars,NAICS_2017_Code,F01000,,F01000,"EPA_GHGI_T_3_13, EPA_GHGI_T_3_14, EPA_GHGI_T_3_15"
+EPA_GHGI_Cornerstone_household,Passenger Cars,NAICS_2017_Code,S00600,,"S00600, GSLGO","EPA_GHGI_T_3_13, EPA_GHGI_T_3_14, EPA_GHGI_T_3_15"
+EPA_GHGI_Cornerstone_household,Passenger Cars,NAICS_2017_Code,GSLGO,,,"EPA_GHGI_T_3_13, EPA_GHGI_T_3_14, EPA_GHGI_T_3_15"
+EPA_GHGI_Cornerstone_household,Passenger Cars,NAICS_2017_Code,491,,491000,"EPA_GHGI_T_3_13, EPA_GHGI_T_3_14, EPA_GHGI_T_3_15"
+EPA_GHGI_Cornerstone_household,Pipeline Natural Gas,NAICS_2017_Code,486,,,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_household,Rail,NAICS_2017_Code,482,,482000,"EPA_GHGI_T_3_13, EPA_GHGI_T_3_14, EPA_GHGI_T_3_15, EPA_GHGI_T_A_97"
+EPA_GHGI_Cornerstone_household,Recreational Boats,NAICS_2017_Code,F01000,,F01000,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_household,Ships and Boats,NAICS_2017_Code,483,,483000,"EPA_GHGI_T_3_14, EPA_GHGI_T_3_15, EPA_GHGI_T_A_97"
+EPA_GHGI_Cornerstone_household,Ships and Non-Recreational Boats,NAICS_2017_Code,483,,483000,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_household,Foams,NAICS_2017_Code,F01000,,F01000,


### PR DESCRIPTION
cc:
Closes:

Related to method choice #174 and discussion [#41](https://github.com/cornerstone-data/methods/discussions/41)

#248 attributes refrigerants to households

## What changed? Why?

Track emissions by final users -  attribute to `F01000`

## Testing


