### PR TITLE
Fix snapshots generation

### DIFF
--- a/.github/workflows/generate_snapshots.yml
+++ b/.github/workflows/generate_snapshots.yml
@@ -8,11 +8,6 @@ on:
         required: true
         type: string
         default: "v8_ceda_2025_usa"
-      adhoc:
-        description: "Upload to adhoc directory"
-        required: false
-        type: boolean
-        default: false
       snapshot_prefix_override:
         description: "Override snapshot prefix (optional)"
         required: false
@@ -48,11 +43,9 @@ jobs:
         id: generate
         run: |
           CONFIG_NAME="${{ github.event.inputs.config_name || 'v8_ceda_2025_usa' }}"
-          ADHOC="${{ github.event.inputs.adhoc }}"
           PREFIX="${{ github.event.inputs.snapshot_prefix_override }}"
-          uv run python bedrock/publish/snapshots/generate_snapshots.py \
+          uv run python bedrock/utils/snapshots/generate_snapshots.py \
             --config_name "$CONFIG_NAME" \
-            ${ADHOC:+--adhoc} \
             ${PREFIX:+--snapshot_prefix_override "$PREFIX"}
 
   notify_slack_failure:


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

Removed the `adhoc` input parameter from the GitHub workflow for generating snapshots and updated the script path from `bedrock/publish/snapshots/generate_snapshots.py` to `bedrock/utils/snapshots/generate_snapshots.py`. The `--adhoc` flag is no longer passed to the script execution.

## Testing

will run snapshots generation