### PR TITLE
Fix snapshot downloads for SHA-keyed folders

### DIFF
--- a/bedrock/utils/__tests__/test_gcp.py
+++ b/bedrock/utils/__tests__/test_gcp.py
@@ -1,6 +1,9 @@
 import os
+from unittest.mock import patch
 
-from bedrock.utils.io.gcp import download_gcs_file
+import pandas as pd
+
+from bedrock.utils.io.gcp import download_gcs_file, get_most_recent_from_bucket
 
 
 def test_download_gcs_file() -> None:
@@ -12,3 +15,28 @@ def test_download_gcs_file() -> None:
         assert os.path.getsize(tmp_path) > 0
     finally:
         os.remove(tmp_path)
+
+
+def test_get_most_recent_from_bucket_ignores_snapshot_folder_sha() -> None:
+    df = pd.DataFrame(
+        [
+            {
+                "full_path": "snapshots/ff3c5a0ea73b26cecd09fd0613b8b34e1f30bcdc/B_USA_non_finetuned.parquet",
+                "created": pd.Timestamp("2026-03-10T13:19:19Z"),
+                "extension": ".parquet",
+                "version": None,
+                "hash": None,
+                "base_name": "B_USA_non_finetuned",
+                "filename": "B_USA_non_finetuned.parquet",
+                "year": None,
+            }
+        ]
+    )
+
+    with patch("bedrock.utils.io.gcp.list_bucket_files", return_value=df):
+        result = get_most_recent_from_bucket(
+            "B_USA_non_finetuned.parquet",
+            "snapshots/ff3c5a0ea73b26cecd09fd0613b8b34e1f30bcdc",
+        )
+
+    assert result == ["B_USA_non_finetuned.parquet"]

--- a/bedrock/utils/io/gcp.py
+++ b/bedrock/utils/io/gcp.py
@@ -299,14 +299,17 @@ def list_bucket_files(sub_bucket: str = "") -> pd.DataFrame:
             # Remove extension
             return ".".join(name_part.split('.')[:-1])
 
-    df['version'] = df['full_path'].apply(
+    df['filename'] = df['full_path'].apply(
+        lambda x: re.split(r"/", x)[-1] if isinstance(x, str) else None
+    )
+    df['version'] = df['filename'].apply(
         lambda x: (
             re.search(version_pattern, x).group(0)  # type: ignore
             if isinstance(x, str) and re.search(version_pattern, x)
             else None
         )
     )
-    df['hash'] = df['full_path'].apply(
+    df['hash'] = df['filename'].apply(
         lambda x: (
             re.search(hash_pattern, x).group(0)  # type: ignore
             if isinstance(x, str) and re.search(hash_pattern, x)
@@ -314,9 +317,6 @@ def list_bucket_files(sub_bucket: str = "") -> pd.DataFrame:
         )
     )
     df['base_name'] = df['full_path'].apply(extract_base_name)
-    df['filename'] = df['full_path'].apply(
-        lambda x: re.split(r"/", x)[-1] if isinstance(x, str) else None
-    )
     # Extract year if base_name ends with 4 digits
     df['year'] = df['base_name'].apply(
         lambda x: (


### PR DESCRIPTION
## Summary
- fix GCS snapshot file selection so SHA-keyed snapshot directories do not get mistaken for filename hashes
- allow diagnostics to download files like `B_USA_non_finetuned.parquet` from `snapshots/<git_sha>/...` correctly
- add a regression test covering the SHA-folder case that was breaking baseline diagnostics

## Test plan
- [x] `uv run python -m black -S --check bedrock/utils/io/gcp.py bedrock/utils/__tests__/test_gcp.py`
- [x] `uv run ruff check bedrock/utils/io/gcp.py bedrock/utils/__tests__/test_gcp.py`
- [x] `uv run python -m mypy bedrock/utils/io/gcp.py`
- [x] `uv run pytest bedrock/utils/__tests__/test_gcp.py`

Made with [Cursor](https://cursor.com)