### PR TITLE
Update Graphite skill: never commit plan markdown files

### DIFF
--- a/.claude/skills/graphite-stacked-prs/SKILL.md
+++ b/.claude/skills/graphite-stacked-prs/SKILL.md
@@ -124,6 +124,8 @@ Steps after `gt submit`:
 
 **Always use `gt` commands — never plain `git` when a `gt` equivalent exists.**
 
+**NEVER commit plan or scratch markdown files** (e.g., `*_plan.md`, `plan_*.md`, `*_plan_*.md`). These are local working documents and must not be pushed to the repository. When staging files, always review the list and exclude any plan/scratch docs. Prefer staging specific files by name over `git add -A` or `gt create -a`.
+
 ---
 
 ## Claude Output Checklist


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

Updated `.claude/skills/graphite-stacked-prs/SKILL.md` to explicitly forbid committing plan/scratch markdown files (e.g., `*_plan.md`, `plan_*.md`). Also instructs to prefer staging specific files by name over `git add -A` or `gt create -a` to avoid accidentally including local working documents.

## Testing

N/A — documentation-only change.