### PR TITLE
GHG: Use FLOWSA method for N2O emissions from field burning

### DIFF
--- a/bedrock/transform/ghg/GHG_national_Cornerstone_2023.yaml
+++ b/bedrock/transform/ghg/GHG_national_Cornerstone_2023.yaml
@@ -133,9 +133,9 @@ source_names:
           FlowName: ["N2O"] # ch4 pulled from T_5_29
         attribution_method: proportional
         attribution_source:
-          EPA_GHGI_T_5_29:
+          EPA_GHGI_T_5_29: &field_burning
             year: *ghgi_year
-            activity_to_sector_mapping: EPA_GHGI_CEDA
+            activity_to_sector_mapping: EPA_GHGI_Cornerstone
             selection_fields:
               PrimaryActivity:
                 - Chickpeas
@@ -144,12 +144,32 @@ source_names:
                 - Rice
                 - Soybeans
                 - Wheat
-                - Corn
                 - Lentils
                 - Sugarcane
               FlowName:
                 CH4: N2O # replacing flow name
             attribution_method: direct
+
+      field_burning_ch4:
+        selection_fields:
+          PrimaryActivity:
+            - Field Burning of Agricultural Residues
+          FlowName: ["CH4"]
+        attribution_method: proportional
+        attribution_source:
+          EPA_GHGI_T_5_29:
+            <<: *field_burning
+            selection_fields:
+              PrimaryActivity:
+                - Chickpeas
+                - Cotton
+                - Maize
+                - Rice
+                - Soybeans
+                - Wheat
+                - Lentils
+                - Sugarcane
+              FlowName: ["CH4"]
 
 
 ## Fossil Fuels
@@ -186,29 +206,6 @@ source_names:
   EPA_GHGI_T_3_49: *petroleum # N2O from Petroleum Systems mimics CH4
 
 ## Agriculture
-  # note - field burning is allocated differently in flowsa. ch4 emissions are pulled from 5_29 and directly attributed.
-  # However, n2O data totals are pulled table 2_1 and the T_5_29 data are used to proportionally attribute
-  # flowsa only directly attributes data from 5_29, does not use T 2_1 data
-  EPA_GHGI_T_5_29: #CH4, N2O, CO and NOx from field burning of residues
-    year: *ghgi_year
-    activity_to_sector_mapping: EPA_GHGI_CEDA
-    fedefl_mapping: GHGI_AR5_100
-    activity_sets:
-      direct_ch4:  # ch4
-        selection_fields:
-          PrimaryActivity:
-    #        - Chickpeas  # only in flowsa, not in ceda
-            - Cotton  # same as flowsa
-    #        - Maize  # only in flowsa, not in ceda - same as corn?
-            - Rice  # same as flowsa
-            - Soybeans  # same as flowsa
-            - Wheat  # same as flowsa
-            - Corn  # not included in flowsa, only in ceda -  same as maize?
-            - Lentils  # not included in flowsa, only in ceda
-            - Sugarcane  # not included in flowsa, only in ceda
-          FlowName: ["CH4"]
-        attribution_method: direct
-
   EPA_GHGI_T_5_3:  &animals #CH4 from Enteric Fermentation
     year: *ghgi_year
     activity_to_sector_mapping: EPA_GHGI_CEDA


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

Updated `bedrock/transform/ghg/GHG_national_Cornerstone_2023.yaml` to include all crop types (`Chickpeas`, `Maize`, `Corn`, `Lentils`, `Sugarcane`) for N2O emissions from field burning, aligning with the FLOWSA method. Removed outdated comments about CEDA vs FLOWSA differences that were no longer accurate.

## Testing

Will run GHG national Cornerstone pipeline to verify N2O field burning emissions.