### PR TITLE
add back missing activities for HFC transport emissions A-90

### DIFF
--- a/bedrock/transform/ghg/GHG_national_Cornerstone_2023.yaml
+++ b/bedrock/transform/ghg/GHG_national_Cornerstone_2023.yaml
@@ -848,15 +848,15 @@ source_names:
     fedefl_mapping: GHGI_AR5_100
     selection_fields:
       PrimaryActivity:
-#        Mobile AC - Passenger Cars: Passenger Cars - Households  # only in flowsa, note in ceda to consider
-#        Mobile AC - Light-Duty Trucks: Light-Duty Trucks - Households  # only in flowsa, note in ceda to consider
-        Mobile AC - Heavy-Duty Vehicles: Heavy-Duty Vehicles  # same as flowsa
-        Comfort Cooling for Trains and Buses - School and Tour Buses: School and Tour Buses  # same as flowsa
-        # Comfort Cooling for Trains and Buses - Transit Buses: Transit Buses #excluded in flowsa too # only in flowsa
-#        Comfort Cooling for Trains and Buses - Rail: Rail  # only in flowsa
-        Refrigerated Transport - Medium- and Heavy-Duty Trucks: Medium- and Heavy-Duty Trucks  # same as flowsa
-        Refrigerated Transport - Rail: Rail  # same as flowsa
-        Refrigerated Transport - Ships and Boats: Ships and Boats  # same as flowsa
+        Mobile AC - Passenger Cars: Passenger Cars - Households
+        Mobile AC - Light-Duty Trucks: Light-Duty Trucks - Households
+        Mobile AC - Heavy-Duty Vehicles: Heavy-Duty Vehicles
+        Comfort Cooling for Trains and Buses - School and Tour Buses: School and Tour Buses
+        Comfort Cooling for Trains and Buses - Transit Buses: Transit Buses
+        Comfort Cooling for Trains and Buses - Rail: Rail
+        Refrigerated Transport - Medium- and Heavy-Duty Trucks: Medium- and Heavy-Duty Trucks
+        Refrigerated Transport - Rail: Rail
+        Refrigerated Transport - Ships and Boats: Ships and Boats
     attribution_method: direct
 
 

--- a/bedrock/transform/ghg/GHG_national_Cornerstone_2023_mobile_combustion.yaml
+++ b/bedrock/transform/ghg/GHG_national_Cornerstone_2023_mobile_combustion.yaml
@@ -207,3 +207,24 @@ source_names: !include:GHG_national_CEDA_2023.yaml:source_names
                   ActivityProducedBy: {'221200': ''} # purchases of natural gas
 
       EPA_GHGI_T_3_15: *mobile #N2O from mobile combustion duplicates method for CH4
+
+      EPA_GHGI_T_A_90: # HFCs from Transportation
+        year: 2023  # same as *ghgi_year in base method
+        activity_to_sector_mapping: EPA_GHGI_Cornerstone
+        clean_fba_before_mapping: !script_function:EPA_GHGI split_HFCs_by_type
+        clean_parameter:
+            # Proportions of specific HFCs are assigned based on national total
+            flow_fba: EPA_GHGI_T_4_122
+        fedefl_mapping: GHGI_AR5_100
+        selection_fields:
+          PrimaryActivity:
+            Mobile AC - Passenger Cars: Passenger Cars - Households  # add back, not in ceda
+            Mobile AC - Light-Duty Trucks: Light-Duty Trucks - Households  # add back, not in ceda
+            Mobile AC - Heavy-Duty Vehicles: Heavy-Duty Vehicles  # same as flowsa
+            Comfort Cooling for Trains and Buses - School and Tour Buses: School and Tour Buses  # same as flowsa
+            Comfort Cooling for Trains and Buses - Transit Buses: Transit Buses # add back, not in ceda
+            Comfort Cooling for Trains and Buses - Rail: Rail  # add back, not in ceda
+            Refrigerated Transport - Medium- and Heavy-Duty Trucks: Medium- and Heavy-Duty Trucks  # same as flowsa
+            Refrigerated Transport - Rail: Rail  # add back, not in ceda
+            Refrigerated Transport - Ships and Boats: Ships and Boats  # same as flowsa
+        attribution_method: direct

--- a/bedrock/utils/mapping/activitytosectormapping/NAICS_Crosswalk_EPA_GHGI_Cornerstone.csv
+++ b/bedrock/utils/mapping/activitytosectormapping/NAICS_Crosswalk_EPA_GHGI_Cornerstone.csv
@@ -554,9 +554,9 @@ EPA_GHGI_Cornerstone,AWACs,NAICS_2017_Code,S00500,,,EPA_GHGI_T_4_132
 EPA_GHGI_Cornerstone,Other Military Applications,NAICS_2017_Code,S00500,,,EPA_GHGI_T_4_132
 EPA_GHGI_Cornerstone,Particle Accelerators,NAICS_2017_Code,54171,,,EPA_GHGI_T_4_132
 EPA_GHGI_Cornerstone,Other Scientific Applications,NAICS_2017_Code,54171,,,EPA_GHGI_T_4_132
-EPA_GHGI_Cornerstone,Heavy-Duty Vehicles,NAICS_2017_Code,484,,484000,EPA_GHGI_T_A_97
-EPA_GHGI_Cornerstone,School and Tour Buses,NAICS_2017_Code,485,,485000,EPA_GHGI_T_A_97
-EPA_GHGI_Cornerstone,Transit Buses,,,,excluded,EPA_GHGI_T_A_97
+EPA_GHGI_Cornerstone,Heavy-Duty Vehicles,NAICS_2017_Code,484,,484000,EPA_GHGI_T_A_90
+EPA_GHGI_Cornerstone,School and Tour Buses,NAICS_2017_Code,485,,485000,EPA_GHGI_T_A_90
+EPA_GHGI_Cornerstone,Transit Buses,NAICS_2017_Code,485,,,EPA_GHGI_T_A_90
 EPA_GHGI_Cornerstone,Buses,NAICS_2017_Code,485,,485000,EPA_GHGI_T_3_13
 EPA_GHGI_Cornerstone,Buses - Distillate Fuel Oil,NAICS_2017_Code,485,,485000,EPA_GHGI_T_3_13
 EPA_GHGI_Cornerstone,Buses - Distillate Fuel Oil,NAICS_2017_Code,487,,48A000,EPA_GHGI_T_3_13

--- a/bedrock/utils/mapping/activitytosectormapping/NAICS_Crosswalk_EPA_GHGI_Cornerstone_mobile_combustion.csv
+++ b/bedrock/utils/mapping/activitytosectormapping/NAICS_Crosswalk_EPA_GHGI_Cornerstone_mobile_combustion.csv
@@ -50,3 +50,6 @@ EPA_GHGI_Cornerstone_mobile_combustion,Rail,NAICS_2017_Code,482,,482000,"EPA_GHG
 EPA_GHGI_Cornerstone_mobile_combustion,Recreational Boats,NAICS_2017_Code,F01000,,F01000,EPA_GHGI_T_3_13
 EPA_GHGI_Cornerstone_mobile_combustion,Ships and Boats,NAICS_2017_Code,483,,483000,"EPA_GHGI_T_3_14, EPA_GHGI_T_3_15, EPA_GHGI_T_A_97"
 EPA_GHGI_Cornerstone_mobile_combustion,Ships and Non-Recreational Boats,NAICS_2017_Code,483,,483000,EPA_GHGI_T_3_13
+EPA_GHGI_Cornerstone_mobile_combustion,Heavy-Duty Vehicles,NAICS_2017_Code,484,,484000,EPA_GHGI_T_A_90
+EPA_GHGI_Cornerstone_mobile_combustion,School and Tour Buses,NAICS_2017_Code,485,,485000,EPA_GHGI_T_A_90
+EPA_GHGI_Cornerstone_mobile_combustion,Transit Buses,NAICS_2017_Code,485,,,EPA_GHGI_T_A_90


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

Follow on to #266 Adds back activities for HFC transport emissions


## Testing

[Mobile combustion diagnostics](https://docs.google.com/spreadsheets/d/1CyecnsoYzVQf7txF_TJjhY0lvU6Gc4x-NHSoGQ0a-MI/edit?usp=sharing) regenerated.

Shows addition of F01000 from Households, and increase to 485 (transit). Rail has no data for 2023 so no change there.

Flow | Sector| Year | MetaSources | AttributionSources | Baseline| Updated| FlowAmount_diff | Percent_Increase
-- | -- | -- | -- | -- | -- | -- | -- | --
HFC-125 | 485 | 2023 | EPA_GHGI_T_A_90 | Direct | 39,528 | 52,704 | 13,176 | 33.3
HFC-134a | 485 | 2023 | EPA_GHGI_T_A_90 | Direct | 57,662 | 76,882 | 19,221 | 33.3
HFC-143a | 485 | 2023 | EPA_GHGI_T_A_90 | Direct | 11,117 | 14,823 | 3,706 | 33.3
HFC-236fa | 485 | 2023 | EPA_GHGI_T_A_90 | Direct | 99 | 131 | 33 | 33.3
HFC-32 | 485 | 2023 | EPA_GHGI_T_A_90 | Direct | 26,743 | 35,657 | 8,914 | 33.3
HFCs and PFCs, unspecified | 485 | 2023 | EPA_GHGI_T_A_90 | Direct | 27,474,854 | 36,633,139 | 9,158,285 | 33.3
HFC-125 | F01000 | 2023 | EPA_GHGI_T_A_90 | Direct |   | 2,121,344 | 2,121,344 |  
HFC-134a | F01000 | 2023 | EPA_GHGI_T_A_90 | Direct |   | 3,094,516 | 3,094,516 |  
HFC-143a | F01000 | 2023 | EPA_GHGI_T_A_90 | Direct |   | 596,611 | 596,611 |  
HFC-236fa | F01000 | 2023 | EPA_GHGI_T_A_90 | Direct |   | 5,287 | 5,287 |  
HFC-32 | F01000 | 2023 | EPA_GHGI_T_A_90 | Direct |   | 1,435,192 | 1,435,192 |  
HFCs and PFCs, unspecified | F01000 | 2023 | EPA_GHGI_T_A_90 | Direct |   | 1,474,483,854 | 1,474,483,854 |  



</body>

</html>

