### PR TITLE
Rename transform_b_matrix_with_useeio_method to use_E_data_year_in_B

### DIFF
--- a/bedrock/transform/eeio/cornerstone_bea_intermediates.py
+++ b/bedrock/transform/eeio/cornerstone_bea_intermediates.py
@@ -133,7 +133,7 @@ def bea_E() -> pd.DataFrame:
 def bea_B() -> pd.DataFrame:
     """B (ghg × BEA_commodity).  B = (E / x) @ V_norm."""
     E = bea_E()
-    if get_usa_config().use_E_data_year_in_B:
+    if get_usa_config().use_E_data_year_for_x_in_B:
         x = derive_gross_output_after_redefinition(
             target_year=get_usa_config().usa_ghg_data_year
         )

--- a/bedrock/transform/eeio/derived_cornerstone.py
+++ b/bedrock/transform/eeio/derived_cornerstone.py
@@ -585,7 +585,7 @@ def derive_cornerstone_B_via_vnorm() -> pd.DataFrame:
     """
     if get_usa_config().load_E_from_flowsa:
         E = derive_E_usa()  # This should be in cornerstone space
-        if get_usa_config().use_E_data_year_in_B:
+        if get_usa_config().use_E_data_year_for_x_in_B:
             x = derive_cornerstone_x_after_redefinition()
         else:
             x = derive_cornerstone_x()  # this is 2017 x
@@ -603,7 +603,7 @@ def derive_cornerstone_B_via_vnorm() -> pd.DataFrame:
 def derive_cornerstone_B_non_finetuned() -> pd.DataFrame:
     """Year-scaled + inflated B, derived self-contained from CEDA v7 → cornerstone."""
     cfg = get_usa_config()
-    if cfg.use_E_data_year_in_B:
+    if cfg.use_E_data_year_for_x_in_B:
         return derive_cornerstone_B_via_vnorm()
     else:
         return inflate_cornerstone_B_matrix(

--- a/bedrock/utils/config/configs/2025_usa_cornerstone_full_model.yaml
+++ b/bedrock/utils/config/configs/2025_usa_cornerstone_full_model.yaml
@@ -10,5 +10,5 @@
 use_cornerstone_2026_model_schema: True
 load_E_from_flowsa: true
 new_ghg_method: true
-use_E_data_year_in_B: True
+use_E_data_year_for_x_in_B: True
 implement_waste_disaggregation: True

--- a/bedrock/utils/config/configs/2025_usa_cornerstone_taxonomy_and_B_transformation.yaml
+++ b/bedrock/utils/config/configs/2025_usa_cornerstone_taxonomy_and_B_transformation.yaml
@@ -12,7 +12,7 @@
 # Methodology selection
 #####
 use_cornerstone_2026_model_schema: True
-use_E_data_year_in_B: True
+use_E_data_year_for_x_in_B: True
 
 
 #####

--- a/bedrock/utils/config/usa_config.py
+++ b/bedrock/utils/config/usa_config.py
@@ -45,7 +45,7 @@ class USAConfig(BaseModel):
     ### Schema/Taxonomy selection
     use_cornerstone_2026_model_schema: bool = False  # DRI: mo.li
     ### IO Methodology selection
-    use_E_data_year_in_B: bool = False  # DRI: mo.li
+    use_E_data_year_for_x_in_B: bool = False  # DRI: mo.li
     implement_waste_disaggregation: bool = False  # DRI: jorge.vendries
     eeio_waste_disaggregation: ta.Optional[EEIOWasteDisaggConfig] = None
     scale_a_matrix_with_useeio_method: bool = False  # DRI: mo.li

--- a/bedrock/utils/validation/calculate_ef_diagnostics.py
+++ b/bedrock/utils/validation/calculate_ef_diagnostics.py
@@ -155,7 +155,7 @@ def calculate_ef_diagnostics(sheet_id: str) -> None:
     )
 
     # Effective x decomposition (Cornerstone method only)
-    if config.use_E_data_year_in_B:
+    if config.use_E_data_year_for_x_in_B:
         from bedrock.utils.validation.diagnostics_helpers import (
             compute_effective_x_comparison,
         )


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

Renamed the config flag `transform_b_matrix_with_useeio_method` to `use_E_data_year_in_B` across 5 files: `bedrock/utils/config/usa_config.py`, `bedrock/transform/eeio/derived_cornerstone.py`, `bedrock/transform/eeio/cornerstone_bea_intermediates.py`, `bedrock/utils/config/configs/2025_usa_cornerstone_taxonomy_and_B_transformation.yaml`, and `bedrock/utils/validation/calculate_ef_diagnostics.py`. The old name was misleading — this flag controls whether the E data year is used when deriving the B matrix.

## Testing

Existing tests; no behavioral change — pure rename.