### PR TITLE
refactor(eeio): remove use_cornerstone_2026_model_schema gating

### DIFF
--- a/bedrock/extract/allocation/__tests__/test_bea_use_table_schema.py
+++ b/bedrock/extract/allocation/__tests__/test_bea_use_table_schema.py
@@ -2,63 +2,19 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
-
 import pytest
 
-from bedrock.extract.allocation.bea import (
-    _load_bea_use_table_cached,
-    load_bea_use_table,
-)
-from bedrock.utils.config.usa_config import USAConfig
-from bedrock.utils.taxonomy.bea.ceda_v7 import CEDA_V7_SECTORS
+from bedrock.extract.allocation.bea import load_bea_use_table
 from bedrock.utils.taxonomy.cornerstone.industries import INDUSTRIES
-
-
-def _clear_use_table_cache() -> None:
-    _load_bea_use_table_cached.cache_clear()
-
-
-@pytest.mark.eeio_integration
-def test_load_bea_use_table_ceda_shape() -> None:
-    """With CEDA config, table has CEDA v7 industry rows + PCE row."""
-    _clear_use_table_cache()
-    config = USAConfig(use_cornerstone_2026_model_schema=False)
-    with patch("bedrock.extract.allocation.bea.get_usa_config", return_value=config):
-        table = load_bea_use_table()
-    # Rows = CEDA industries + one PCE row
-    industry_rows = [i for i in table.index if i in CEDA_V7_SECTORS]
-    assert len(industry_rows) == len(CEDA_V7_SECTORS)
-    assert "221200" in table.columns
-    assert table.shape[0] >= len(CEDA_V7_SECTORS)
-    assert table.shape[1] > 0
 
 
 @pytest.mark.eeio_integration
 def test_load_bea_use_table_cornerstone_shape() -> None:
-    """With Cornerstone config, table has Cornerstone industry rows + PCE row."""
-    _clear_use_table_cache()
-    config = USAConfig(use_cornerstone_2026_model_schema=True)
-    with patch("bedrock.extract.allocation.bea.get_usa_config", return_value=config):
-        table = load_bea_use_table()
+    """Table should have Cornerstone industry rows + PCE row."""
+    load_bea_use_table.cache_clear()
+    table = load_bea_use_table()
     industry_rows = [i for i in table.index if i in INDUSTRIES]
     assert len(industry_rows) == len(INDUSTRIES)
     assert "221200" in table.columns
     assert table.shape[0] >= len(INDUSTRIES)
     assert table.shape[1] > 0
-
-
-@pytest.mark.eeio_integration
-def test_load_bea_use_table_cache_per_schema() -> None:
-    """CEDA and Cornerstone calls return different shapes (cache keyed by schema)."""
-    _clear_use_table_cache()
-    config_ceda = USAConfig(use_cornerstone_2026_model_schema=False)
-    config_cs = USAConfig(use_cornerstone_2026_model_schema=True)
-    with patch(
-        "bedrock.extract.allocation.bea.get_usa_config", return_value=config_ceda
-    ):
-        table_ceda = load_bea_use_table()
-    with patch("bedrock.extract.allocation.bea.get_usa_config", return_value=config_cs):
-        table_cs = load_bea_use_table()
-    assert table_ceda.shape[0] != table_cs.shape[0]
-    assert set(table_ceda.index) != set(table_cs.index)

--- a/bedrock/extract/allocation/bea.py
+++ b/bedrock/extract/allocation/bea.py
@@ -7,11 +7,7 @@ from collections.abc import Sequence
 
 import pandas as pd
 
-from bedrock.transform.eeio.derived_2017 import (
-    derive_2017_U_set_usa,
-    derive_2017_V_usa,
-    derive_2017_Y_personal_consumption_expenditure_usa,
-)
+from bedrock.transform.eeio.derived_2017 import derive_2017_V_usa
 from bedrock.utils.config.usa_config import get_usa_config
 from bedrock.utils.io.gcp import load_from_gcs
 from bedrock.utils.io.gcp_paths import GCS_CEDA_INPUT_DIR
@@ -51,34 +47,21 @@ def load_bea_make_table() -> pd.DataFrame:
 
 
 @functools.cache
-def _load_bea_use_table_cached(use_cornerstone: bool) -> pd.DataFrame:
-    """Inner loader keyed by schema so both CEDA and Cornerstone can be cached."""
-    if use_cornerstone:
-        from bedrock.transform.eeio import derived_cornerstone  # noqa: PLC0415
-
-        uset = derived_cornerstone.derive_cornerstone_U_set()
-        U_combined = (uset.Udom + uset.Uimp).T
-        Y_cs = (
-            derived_cornerstone.derive_cornerstone_Y_personal_consumption_expenditure()
-            .to_frame()
-            .T
-        )
-        return pd.concat([U_combined, Y_cs])
-    U_set = derive_2017_U_set_usa()
-    Y_usa = derive_2017_Y_personal_consumption_expenditure_usa().to_frame()
-    return pd.concat([(U_set.Udom + U_set.Uimp).T, Y_usa.T])
-
-
 def load_bea_use_table() -> pd.DataFrame:
-    """
-    Load BEA Use and Final Demand tables aligned to the model schema.
+    """Load BEA Use and Final Demand tables in Cornerstone schema.
 
-    When use_cornerstone_2026_model_schema is False, returns CEDA v7 industry rows.
-    When True, returns Cornerstone industry rows (from derive_cornerstone_U_set and Y).
-    Rows = industries + one PCE row; columns = commodities. Result is cached per schema.
+    Rows = industries + one PCE row; columns = commodities. Result is cached.
     """
-    use_cornerstone = get_usa_config().use_cornerstone_2026_model_schema
-    return _load_bea_use_table_cached(use_cornerstone)
+    from bedrock.transform.eeio import derived_cornerstone
+
+    uset = derived_cornerstone.derive_cornerstone_U_set()
+    U_combined = (uset.Udom + uset.Uimp).T
+    Y_cs = (
+        derived_cornerstone.derive_cornerstone_Y_personal_consumption_expenditure()
+        .to_frame()
+        .T
+    )
+    return pd.concat([U_combined, Y_cs])
 
 
 def _use_table_value_ceda_sector_cornerstone_aligned(

--- a/bedrock/transform/allocation/co2/industrial_coal.py
+++ b/bedrock/transform/allocation/co2/industrial_coal.py
@@ -17,13 +17,8 @@ from bedrock.transform.allocation.mappings.cornerstone import (
     CORNERSTONE_INDUSTRY_TO_MECS_3_1_NAICS_MAPPING,
     CORNERSTONE_INDUSTRY_TO_MECS_3_1_NAICS_SUBTRACTION_MAPPING,
 )
-from bedrock.transform.allocation.mappings.v7.ceda_mecs import (
-    CEDA_INDUSTRY_TO_MECS_3_1_NAICS_MAPPING,
-    CEDA_INDUSTRY_TO_MECS_3_1_NAICS_SUBTRACTION_MAPPING,
-    NON_MECS_INDUSTRIES,
-)
+from bedrock.transform.allocation.mappings.v7.ceda_mecs import NON_MECS_INDUSTRIES
 from bedrock.transform.allocation.utils import get_allocation_sectors
-from bedrock.utils.config.usa_config import get_usa_config
 from bedrock.utils.economic.units import COAL_MMBTU_PER_SHORT_TONNE, MEGATONNE_TO_KG
 
 load_table_a17_tbtu = functools.cache(_load_table_a17_tbtu)
@@ -38,15 +33,10 @@ def _get_mecs_3_1_naics_mappings() -> tuple[
     dict[tuple[str, ...], tuple[str, ...]],
     dict[tuple[str, ...], tuple[tuple[str, ...], tuple[str, ...]]],
 ]:
-    """Return (mapping, subtraction_mapping) for MECS 3.1 NAICS; use CORNERSTONE when schema flag is on."""
-    if get_usa_config().use_cornerstone_2026_model_schema:
-        return (
-            CORNERSTONE_INDUSTRY_TO_MECS_3_1_NAICS_MAPPING,
-            CORNERSTONE_INDUSTRY_TO_MECS_3_1_NAICS_SUBTRACTION_MAPPING,
-        )
+    """Return (mapping, subtraction_mapping) for MECS 3.1 NAICS."""
     return (
-        CEDA_INDUSTRY_TO_MECS_3_1_NAICS_MAPPING,
-        CEDA_INDUSTRY_TO_MECS_3_1_NAICS_SUBTRACTION_MAPPING,
+        CORNERSTONE_INDUSTRY_TO_MECS_3_1_NAICS_MAPPING,
+        CORNERSTONE_INDUSTRY_TO_MECS_3_1_NAICS_SUBTRACTION_MAPPING,
     )
 
 

--- a/bedrock/transform/allocation/co2/industrial_natural_gas.py
+++ b/bedrock/transform/allocation/co2/industrial_natural_gas.py
@@ -16,13 +16,8 @@ from bedrock.transform.allocation.mappings.cornerstone import (
     CORNERSTONE_INDUSTRY_TO_MECS_3_1_NAICS_MAPPING,
     CORNERSTONE_INDUSTRY_TO_MECS_3_1_NAICS_SUBTRACTION_MAPPING,
 )
-from bedrock.transform.allocation.mappings.v7.ceda_mecs import (
-    CEDA_INDUSTRY_TO_MECS_3_1_NAICS_MAPPING,
-    CEDA_INDUSTRY_TO_MECS_3_1_NAICS_SUBTRACTION_MAPPING,
-    NON_MECS_INDUSTRIES,
-)
+from bedrock.transform.allocation.mappings.v7.ceda_mecs import NON_MECS_INDUSTRIES
 from bedrock.transform.allocation.utils import get_allocation_sectors
-from bedrock.utils.config.usa_config import get_usa_config
 from bedrock.utils.economic.units import MEGATONNE_TO_KG, NAT_GAS_BCF_TO_TRILLION_BTU
 
 load_table_a17_tbtu = functools.cache(_load_table_a17_tbtu)
@@ -47,15 +42,10 @@ def _get_mecs_3_1_naics_mappings() -> tuple[
     dict[tuple[str, ...], tuple[str, ...]],
     dict[tuple[str, ...], tuple[tuple[str, ...], tuple[str, ...]]],
 ]:
-    """Return (mapping, subtraction_mapping) for MECS 3.1 NAICS; use CORNERSTONE when schema flag is on."""
-    if get_usa_config().use_cornerstone_2026_model_schema:
-        return (
-            CORNERSTONE_INDUSTRY_TO_MECS_3_1_NAICS_MAPPING,
-            CORNERSTONE_INDUSTRY_TO_MECS_3_1_NAICS_SUBTRACTION_MAPPING,
-        )
+    """Return (mapping, subtraction_mapping) for MECS 3.1 NAICS."""
     return (
-        CEDA_INDUSTRY_TO_MECS_3_1_NAICS_MAPPING,
-        CEDA_INDUSTRY_TO_MECS_3_1_NAICS_SUBTRACTION_MAPPING,
+        CORNERSTONE_INDUSTRY_TO_MECS_3_1_NAICS_MAPPING,
+        CORNERSTONE_INDUSTRY_TO_MECS_3_1_NAICS_SUBTRACTION_MAPPING,
     )
 
 

--- a/bedrock/transform/allocation/co2/non_energy_fuels_natural_gas.py
+++ b/bedrock/transform/allocation/co2/non_energy_fuels_natural_gas.py
@@ -17,12 +17,7 @@ from bedrock.transform.allocation.mappings.cornerstone import (
     CORNERSTONE_INDUSTRY_TO_MECS_2_1_NAICS_MAPPING,
     CORNERSTONE_INDUSTRY_TO_MECS_2_1_NAICS_SUBTRACTION_MAPPING,
 )
-from bedrock.transform.allocation.mappings.v7.ceda_mecs import (
-    CEDA_INDUSTRY_TO_MECS_2_1_NAICS_MAPPING,
-    CEDA_INDUSTRY_TO_MECS_2_1_NAICS_SUBTRACTION_MAPPING,
-)
 from bedrock.transform.allocation.utils import get_allocation_sectors
-from bedrock.utils.config.usa_config import get_usa_config
 from bedrock.utils.economic.units import MEGATONNE_TO_KG
 
 logger = logging.getLogger(__name__)
@@ -32,15 +27,10 @@ def _get_mecs_2_1_naics_mappings() -> tuple[
     dict[tuple[str, ...], tuple[str, ...]],
     dict[tuple[str, ...], tuple[tuple[str, ...], tuple[str, ...]]],
 ]:
-    """Return (mapping, subtraction_mapping) for MECS 2.1 NAICS; use CORNERSTONE when schema flag is on."""
-    if get_usa_config().use_cornerstone_2026_model_schema:
-        return (
-            CORNERSTONE_INDUSTRY_TO_MECS_2_1_NAICS_MAPPING,
-            CORNERSTONE_INDUSTRY_TO_MECS_2_1_NAICS_SUBTRACTION_MAPPING,
-        )
+    """Return (mapping, subtraction_mapping) for MECS 2.1 NAICS."""
     return (
-        CEDA_INDUSTRY_TO_MECS_2_1_NAICS_MAPPING,
-        CEDA_INDUSTRY_TO_MECS_2_1_NAICS_SUBTRACTION_MAPPING,
+        CORNERSTONE_INDUSTRY_TO_MECS_2_1_NAICS_MAPPING,
+        CORNERSTONE_INDUSTRY_TO_MECS_2_1_NAICS_SUBTRACTION_MAPPING,
     )
 
 

--- a/bedrock/transform/allocation/co2/non_energy_fuels_petrol.py
+++ b/bedrock/transform/allocation/co2/non_energy_fuels_petrol.py
@@ -17,12 +17,7 @@ from bedrock.transform.allocation.mappings.cornerstone import (
     CORNERSTONE_INDUSTRY_TO_MECS_2_1_NAICS_MAPPING,
     CORNERSTONE_INDUSTRY_TO_MECS_2_1_NAICS_SUBTRACTION_MAPPING,
 )
-from bedrock.transform.allocation.mappings.v7.ceda_mecs import (
-    CEDA_INDUSTRY_TO_MECS_2_1_NAICS_MAPPING,
-    CEDA_INDUSTRY_TO_MECS_2_1_NAICS_SUBTRACTION_MAPPING,
-)
 from bedrock.transform.allocation.utils import get_allocation_sectors
-from bedrock.utils.config.usa_config import get_usa_config
 from bedrock.utils.economic.units import MEGATONNE_TO_KG
 
 logger = logging.getLogger(__name__)
@@ -32,15 +27,10 @@ def _get_mecs_2_1_naics_mappings() -> tuple[
     dict[tuple[str, ...], tuple[str, ...]],
     dict[tuple[str, ...], tuple[tuple[str, ...], tuple[str, ...]]],
 ]:
-    """Return (mapping, subtraction_mapping) for MECS 2.1 NAICS; use CORNERSTONE when schema flag is on."""
-    if get_usa_config().use_cornerstone_2026_model_schema:
-        return (
-            CORNERSTONE_INDUSTRY_TO_MECS_2_1_NAICS_MAPPING,
-            CORNERSTONE_INDUSTRY_TO_MECS_2_1_NAICS_SUBTRACTION_MAPPING,
-        )
+    """Return (mapping, subtraction_mapping) for MECS 2.1 NAICS."""
     return (
-        CEDA_INDUSTRY_TO_MECS_2_1_NAICS_MAPPING,
-        CEDA_INDUSTRY_TO_MECS_2_1_NAICS_SUBTRACTION_MAPPING,
+        CORNERSTONE_INDUSTRY_TO_MECS_2_1_NAICS_MAPPING,
+        CORNERSTONE_INDUSTRY_TO_MECS_2_1_NAICS_SUBTRACTION_MAPPING,
     )
 
 
@@ -99,7 +89,6 @@ def allocate_non_energy_fuels_petrol() -> pd.Series[float]:
     use = use_table_series_ceda_allocator_to_cornerstone_schema(
         load_bea_use_table(), get_allocation_sectors(), "324110"
     )
-    use_cornerstone = get_usa_config().use_cornerstone_2026_model_schema
     mapping, subtraction_mapping = _get_mecs_2_1_naics_mappings()
     for (
         ceda_industries,
@@ -121,15 +110,6 @@ def allocate_non_energy_fuels_petrol() -> pd.Series[float]:
 
         for ceda_industry in ceda_industries:
             industry_use = float(total_use_ser[ceda_industry])
-            if not use_cornerstone:
-                if len(ceda_industries) == 1:
-                    assert (
-                        industry_use == total_use
-                    ), f"There is only one sector in ceda_industries {ceda_industries}, but use by the industry {industry_use} != total_use ({total_use})"
-                else:
-                    assert (
-                        industry_use <= total_use
-                    ), f"There are more than one sector in ceda_industries {ceda_industries}, but use by a child industry {ceda_industry} ({industry_use}) > total_use ({total_use})"
             if ceda_industry in ("324121", "324122"):
                 # Allocate asphalt and HGL emissions to asphalt industries (324121 and 324122)
                 allocated[ceda_industry] = (

--- a/bedrock/transform/allocation/utils.py
+++ b/bedrock/transform/allocation/utils.py
@@ -5,21 +5,12 @@ from collections.abc import Iterable
 
 import pandas as pd
 
-from bedrock.utils.config.usa_config import get_usa_config
-from bedrock.utils.taxonomy.bea.ceda_v7 import CEDA_V7_SECTORS
 from bedrock.utils.taxonomy.cornerstone.industries import INDUSTRIES
 
 
 def get_allocation_sectors() -> list[str]:
-    """
-    Return the sector list (taxonomy) for allocation based on model config.
-
-    When use_cornerstone_2026_model_schema is True, returns Cornerstone INDUSTRIES;
-    otherwise returns CEDA v7 sectors.
-    """
-    if get_usa_config().use_cornerstone_2026_model_schema:
-        return list(INDUSTRIES)
-    return list(CEDA_V7_SECTORS)
+    """Return the Cornerstone INDUSTRIES sector list for allocation."""
+    return list(INDUSTRIES)
 
 
 def parse_index_with_aggregates(

--- a/bedrock/transform/allocation/waste_utils.py
+++ b/bedrock/transform/allocation/waste_utils.py
@@ -2,27 +2,15 @@ from __future__ import annotations
 
 import pandas as pd
 
-from bedrock.utils.config.usa_config import get_usa_config
 from bedrock.utils.taxonomy.cornerstone.industries import WASTE_DISAGG_INDUSTRIES
 
 
 def waste_562000_allocation_series_ceda_allocator_to_cornerstone_schema(
     total_emission: float,
 ) -> pd.Series[float]:
-    """Return a sector-indexed Series for waste (562000) that is schema-aware.
-
-    When the Cornerstone 2026 schema is active, the total emission for the
-    CEDA aggregate sector 562000 is split equally across the Cornerstone
-    waste industries corresponding to that aggregate. When the Cornerstone
-    schema is not active, the emission is kept on the CEDA sector 562000.
-    """
-    cfg = get_usa_config()
-
-    if cfg.use_cornerstone_2026_model_schema:
-        waste_inds = WASTE_DISAGG_INDUSTRIES["562000"]
-        if not waste_inds:
-            return pd.Series({"562000": float(total_emission)})
-        per_industry = float(total_emission) / float(len(waste_inds))
-        return pd.Series({code: per_industry for code in waste_inds}, dtype=float)
-
-    return pd.Series({"562000": float(total_emission)})
+    """Return a sector-indexed Series for waste (562000) split across Cornerstone waste industries."""
+    waste_inds = WASTE_DISAGG_INDUSTRIES["562000"]
+    if not waste_inds:
+        return pd.Series({"562000": float(total_emission)})
+    per_industry = float(total_emission) / float(len(waste_inds))
+    return pd.Series({code: per_industry for code in waste_inds}, dtype=float)

--- a/bedrock/transform/eeio/derived.py
+++ b/bedrock/transform/eeio/derived.py
@@ -1,29 +1,9 @@
 from __future__ import annotations
 
 import functools
-import logging
 
 import pandas as pd
-import pandera.typing as pt
 
-from bedrock.extract.iot.io_2012 import (
-    load_2012_PC_usa,
-    load_2012_PI_usa,
-    load_2012_UR_usa,
-    load_2012_URdom_usa,
-    load_2012_YR_usa,
-)
-from bedrock.extract.iot.io_2017 import load_summary_Uimp_usa
-from bedrock.transform.allocation.derived import derive_E_usa
-from bedrock.transform.eeio.derived_2017 import (
-    derive_2017_Aq_usa,
-    derive_2017_U_set_usa,
-    derive_2017_Vnorm_scrap_corrected,
-    derive_2017_x_usa,
-    derive_2017_Ytot_usa_matrix_set,
-    derive_summary_Yimp_usa,
-    derive_summary_Ytot_usa_matrix_set,
-)
 from bedrock.transform.eeio.derived_cornerstone import (
     derive_cornerstone_Aq_scaled,
     derive_cornerstone_B_non_finetuned,
@@ -32,416 +12,38 @@ from bedrock.transform.eeio.derived_cornerstone import (
     derive_cornerstone_y_nab,
     derive_cornerstone_ydom_and_yimp,
 )
-from bedrock.transform.eeio.scale_abq_via_summary import (
-    scale_detail_A_based_on_summary_A,
-    scale_detail_B_based_on_summary_q,
-    scale_detail_q_based_on_summary_q,
-)
-from bedrock.utils.config.usa_config import get_usa_config
-from bedrock.utils.economic.inflate_to_target_year import (
-    inflate_A_matrix,
-    inflate_B_matrix,
-    inflate_q_or_y,
-)
-from bedrock.utils.math.disaggregation import disaggregate_vector
-from bedrock.utils.math.formulas import (
-    compute_B_ind_matrix,
-    compute_B_matrix,
-    compute_y_for_national_accounting_balance,
-    compute_y_imp,
-)
-from bedrock.utils.math.handle_negatives import handle_negative_vector_values
-from bedrock.utils.math.split_using_aggregated_weights import (
-    split_vector_using_agg_ratio,
-)
-from bedrock.utils.schemas.single_region_schemas import (
-    AMatrix,
-    BMatrix,
-    ExportsVectorSchema,
-    ImportsVectorSchema,
-    QVectorSchema,
-    UMatrix,
-    YVectorSchema,
-)
 from bedrock.utils.schemas.single_region_types import (
     SingleRegionAqMatrixSet,
-    SingleRegionUMatrixSet,
     SingleRegionYtotAndTradeVectorSet,
     SingleRegionYVectorSet,
 )
-from bedrock.utils.taxonomy.bea.v2017_final_demand import (
-    USA_2017_FINAL_DEMAND_EXPORT_CODE,
-    USA_2017_FINAL_DEMAND_IMPORT_CODE,
-)
-from bedrock.utils.taxonomy.bea.v2017_industry_summary import (
-    USA_2017_SUMMARY_INDUSTRY_CODES,
-)
-from bedrock.utils.taxonomy.bea_v2017_to_ceda_v7_helpers import (
-    get_bea_v2017_summary_to_ceda_corresp_df,
-)
-from bedrock.utils.taxonomy.mappings.ceda_v7__ceda_v5 import CEDA_V5_TO_CEDA_V7_CODES
-
-logger = logging.getLogger(__name__)
 
 
 @functools.cache
 def derive_B_usa_non_finetuned() -> pd.DataFrame:
-    if get_usa_config().use_cornerstone_2026_model_schema:
-        return derive_cornerstone_B_non_finetuned()
-    else:
-        E_usa = derive_E_usa()
-        # B_usa_2017 has 2022 emissions but 2017 economic data
-        b_usa_2017 = derive_B_usa_via_vnorm(E_usa=E_usa)
-        # Scale the economic data part of B_usa_2017 to 2022
-        B_usa = inflate_B_matrix(
-            scale_detail_B_based_on_summary_q(
-                B=b_usa_2017,
-                original_year=get_usa_config().usa_detail_original_year,
-                target_year=get_usa_config().usa_io_data_year,
-            ),
-            original_year=get_usa_config().usa_io_data_year,
-            target_year=get_usa_config().model_base_year,
-        )
-
-        return pt.DataFrame[BMatrix](BMatrix.validate(B_usa))
+    return derive_cornerstone_B_non_finetuned()
 
 
 def derive_Y_and_trade_matrix_usa_from_summary_target_year_ytot_and_structural_reflection() -> (
     SingleRegionYtotAndTradeVectorSet
 ):
-    """
-    We get detail Y and Trade Matrix in the following steps:
-    - get `target_year` summary Y and Trade Matrix and 2017 detail Y and Trade Matrix
-    - structurally reflect `target_year` summary Y and Trade Matrix into `target_year` detail Y and Trade Matrix using 2017 detail Y and Trade Matrix
-    - split the reflected `target_year` detail Y and Trade Matrix into `target_year` detail Y and Trade Matrix,
-      using weights derived from `target_year` summary Y and Trade Matrix
-    """
-    if get_usa_config().use_cornerstone_2026_model_schema:
-        return derive_cornerstone_Y_and_trade_scaled()
-    else:
-        detail_2017_YandTradeset = derive_2017_Ytot_usa_matrix_set()
-
-        summary_to_ceda_corresp_df = get_bea_v2017_summary_to_ceda_corresp_df()
-
-        summary_Y_matrix_set = derive_summary_Ytot_usa_matrix_set(
-            get_usa_config().usa_io_data_year
-        )
-
-        ytot = inflate_q_or_y(
-            disaggregate_vector(
-                base_series=summary_Y_matrix_set.ytot,
-                weight_series=detail_2017_YandTradeset.ytot,
-                corresp_df=summary_to_ceda_corresp_df,
-            ),
-            original_year=get_usa_config().usa_io_data_year,
-            target_year=get_usa_config().model_base_year,
-        )
-        exports = inflate_q_or_y(
-            disaggregate_vector(
-                base_series=summary_Y_matrix_set.exports,
-                weight_series=detail_2017_YandTradeset.exports,
-                corresp_df=summary_to_ceda_corresp_df,
-            ),
-            original_year=get_usa_config().usa_io_data_year,
-            target_year=get_usa_config().model_base_year,
-        )
-        imports = inflate_q_or_y(
-            handle_negative_vector_values(
-                disaggregate_vector(
-                    base_series=summary_Y_matrix_set.imports,
-                    weight_series=detail_2017_YandTradeset.imports,
-                    corresp_df=summary_to_ceda_corresp_df,
-                )
-            ),
-            original_year=get_usa_config().usa_io_data_year,
-            target_year=get_usa_config().model_base_year,
-        )
-
-        return SingleRegionYtotAndTradeVectorSet(
-            ytot=YVectorSchema.validate(ytot),
-            exports=ExportsVectorSchema.validate(exports),
-            imports=ImportsVectorSchema.validate(imports),
-        )
+    return derive_cornerstone_Y_and_trade_scaled()
 
 
 @functools.cache
 def derive_y_for_national_accounting_balance_usa() -> pd.Series[float]:
-    """
-    We get Y for national accounting balance via the following equations:
-
-        y_nab = y_dom + exports
-        y_nab = (y_tot - y_imp) + exports
-        y_nab = (y_tot - (imports - Uimp_row_sum)) + exports
-
-    Because we only have Uimp in 2017 detail, we get 2022 detail y in the
-    following steps:
-    - calculate 2017 detail y_nab
-    - calculate 2022 summary y_nab
-    - scale 2017 detail y_nab to 2022 detail y_nab using 2022 summary y_nab
-    """
-    if get_usa_config().use_cornerstone_2026_model_schema:
-        return derive_cornerstone_y_nab()
-    else:
-        detail_2017_YandTradeset = derive_2017_Ytot_usa_matrix_set()
-
-        y_national_acct_balance_detail_2017 = compute_y_for_national_accounting_balance(
-            y_tot=detail_2017_YandTradeset.ytot,
-            y_imp=compute_y_imp(
-                imports=detail_2017_YandTradeset.imports,
-                Uimp=derive_2017_U_set_usa().Uimp,
-            ),
-            exports=detail_2017_YandTradeset.exports,
-        )
-
-        summary_2022_Y_matrix_set = derive_summary_Ytot_usa_matrix_set(
-            get_usa_config().usa_io_data_year
-        )
-
-        y_national_acct_balance_summary_2022 = (
-            compute_y_for_national_accounting_balance(
-                y_tot=summary_2022_Y_matrix_set.ytot,
-                y_imp=compute_y_imp(
-                    imports=summary_2022_Y_matrix_set.imports,
-                    Uimp=load_summary_Uimp_usa(get_usa_config().usa_io_data_year).loc[
-                        USA_2017_SUMMARY_INDUSTRY_CODES,
-                        USA_2017_SUMMARY_INDUSTRY_CODES,
-                    ],
-                ),
-                exports=summary_2022_Y_matrix_set.exports,
-            )
-        )
-
-        summary_to_ceda_corresp_df = get_bea_v2017_summary_to_ceda_corresp_df()
-        y_national_acct_balance_detail_2022 = inflate_q_or_y(
-            disaggregate_vector(
-                corresp_df=summary_to_ceda_corresp_df,
-                base_series=y_national_acct_balance_summary_2022,
-                weight_series=y_national_acct_balance_detail_2017,
-            ),
-            original_year=get_usa_config().usa_io_data_year,
-            target_year=get_usa_config().model_base_year,
-        )
-
-        # NOTE: original y values have some negative values
-        # that will distort the scaling process that uses the ytot here in non-US countries.
-        # We make a data assumption here to set them to 0 in order to make the scaling process valid.
-        # TODO: this is a temporary solution, we need a y pandera type to enforce this data assumption.
-        return YVectorSchema.validate(
-            handle_negative_vector_values(y_national_acct_balance_detail_2022)
-        )
+    return derive_cornerstone_y_nab()
 
 
 def derive_ydom_and_yimp_usa() -> SingleRegionYVectorSet:
-    """
-    This function is only used in derivation of Y_oecd, where we need y_dom and y_imp separately
-    to populate the diagonal and off-diagonal elements of Y_oecd.
-    We get ydom and yimp in the following steps:
-    1. Get 2022 detail ytot
-    2. Get 2022 summary ydom and yimp
-    3. Split 2022 detail ytot to ydom and yimp using 2022 summary ydom and yimp ratios
-    """
-    if get_usa_config().use_cornerstone_2026_model_schema:
-        return derive_cornerstone_ydom_and_yimp()
-    else:
-        # Load summary 2022 ytot and yimp
-        summary_2022_ytot = derive_summary_Ytot_usa_matrix_set(2022).ytot
-        summary_2022_yimp = derive_summary_Yimp_usa(2022).sum(axis=1)
-        # Derive ydom over ytot ratio
-        # NOTE: in case some yimp values are larger than ytot values, causing ydom to be negative,
-        # which could be reasonable but we don't want to take negative ydom values.
-        # We handle this by setting ydom to 0 when yimp is larger than ytot.
-        summary_2022_ydom_over_ytot_ratio = handle_negative_vector_values(
-            1 - (summary_2022_yimp / summary_2022_ytot).fillna(0.0)
-        )
-
-        # Derive 2022 detail ytot
-        detail_2022_ytot = disaggregate_vector(
-            corresp_df=get_bea_v2017_summary_to_ceda_corresp_df(),
-            base_series=summary_2022_ytot,
-            weight_series=derive_2017_Ytot_usa_matrix_set().ytot,
-        )
-        # Split detail 2022 ytot to ydom and yimp
-        ydom, yimp = split_vector_using_agg_ratio(
-            base_series=detail_2022_ytot,
-            agg_ratio_series=summary_2022_ydom_over_ytot_ratio,
-            corresp_df=get_bea_v2017_summary_to_ceda_corresp_df(),
-        )
-        return SingleRegionYVectorSet(
-            ydom=YVectorSchema.validate(ydom), yimp=YVectorSchema.validate(yimp)
-        )
+    return derive_cornerstone_ydom_and_yimp()
 
 
 @functools.cache
 def derive_Aq_usa() -> SingleRegionAqMatrixSet:
-    """
-    This function derives Aq_usa in `target_year` USD.
-
-    For Adom and Aimp, we get `target_year` detail matrices by
-    year-scaling 2017 detail Adom and Aimp separately using the
-    `target_year` summary Adom and Aimp, respectively
-
-    For q, we get 2017 detail q from 2017 detail IOTs, then inflate it to `target_year` USD.
-    """
-    if get_usa_config().use_cornerstone_2026_model_schema:
-        return derive_cornerstone_Aq_scaled()
-    else:
-        detail_2017_Aq_set = derive_2017_Aq_usa()
-
-        target_year = get_usa_config().usa_io_data_year
-        original_year = get_usa_config().usa_detail_original_year
-
-        Adom = scale_detail_A_based_on_summary_A(
-            A=detail_2017_Aq_set.Adom,
-            target_year=target_year,
-            original_year=original_year,
-            dom_or_imp_or_total='dom',
-        )
-        Aimp = scale_detail_A_based_on_summary_A(
-            A=detail_2017_Aq_set.Aimp,
-            target_year=target_year,
-            original_year=original_year,
-            dom_or_imp_or_total='imp',
-        )
-
-        q = scale_detail_q_based_on_summary_q(
-            q=detail_2017_Aq_set.scaled_q,
-            target_year=target_year,
-            original_year=original_year,
-        )
-        assert q is not None, 'q in derive_Aq_usa() is None'
-
-        # NOTE: the Adom/Aimp/q being passed in are already in `target_year`.
-        # We just need to inflate them to CEDA base year.
-        # TODO: type inflate_A_matrix as DataFrame[AMatrix]
-        Adom = inflate_A_matrix(  # type: ignore[assignment]
-            Adom,
-            target_year=get_usa_config().model_base_year,
-            original_year=target_year,
-        )
-        Aimp = inflate_A_matrix(  # type: ignore[assignment]
-            Aimp,
-            target_year=get_usa_config().model_base_year,
-            original_year=target_year,
-        )
-        q = inflate_q_or_y(
-            q,
-            target_year=get_usa_config().model_base_year,
-            original_year=target_year,
-        )
-
-        return SingleRegionAqMatrixSet(
-            Adom=pt.DataFrame[AMatrix](Adom),
-            Aimp=pt.DataFrame[AMatrix](Aimp),
-            scaled_q=QVectorSchema.validate(q),
-        )
-
-
-def derive_B_usa_via_vnorm(*, E_usa: pd.DataFrame) -> pd.DataFrame:
-    x = derive_2017_x_usa()
-    Vnorm = derive_2017_Vnorm_scrap_corrected()
-
-    Bi = compute_B_ind_matrix(E=E_usa, x=x)
-    Bc = compute_B_matrix(B_ind=Bi, V_norm=Vnorm)
-
-    Bc.columns.name = 'sector'
-    Bc.index.name = 'ghg'
-    return Bc
-
-
-def derive_v5_U_usa() -> SingleRegionUMatrixSet:
-    URtot_usa = load_2012_UR_usa()
-    URdom_usa = load_2012_URdom_usa()
-
-    PI = load_2012_PI_usa()
-    PC = load_2012_PC_usa()
-
-    # squarize all matrices by using 400 commodity or industry classification
-    URimp_usa = URtot_usa - URdom_usa
-
-    URdom = PC.T @ URdom_usa @ PI.T
-    URimp = PC.T @ URimp_usa @ PI.T
-
-    URdom.rename(
-        columns=CEDA_V5_TO_CEDA_V7_CODES, index=CEDA_V5_TO_CEDA_V7_CODES, inplace=True
-    )
-    URimp.rename(
-        columns=CEDA_V5_TO_CEDA_V7_CODES, inplace=True, index=CEDA_V5_TO_CEDA_V7_CODES
-    )
-
-    return SingleRegionUMatrixSet(
-        Udom=pt.DataFrame[UMatrix](URdom), Uimp=pt.DataFrame[UMatrix](URimp)
-    )
-
-
-@functools.cache
-def derive_v5_detail_Ytot_usa_matrix_set() -> SingleRegionYtotAndTradeVectorSet:
-    """
-    Derive US Ytot and trade vectors using v5 USA IO tables.
-
-    NOTE: Ytot_usa can't be negative, because we need to use it to ABSR Ytot of other countries.
-    """
-
-    Ytot_with_trade_usa = load_2012_PC_usa().T @ load_2012_YR_usa()
-
-    return SingleRegionYtotAndTradeVectorSet(
-        ytot=YVectorSchema.validate(
-            handle_negative_vector_values(
-                Ytot_with_trade_usa.drop(
-                    columns=[
-                        USA_2017_FINAL_DEMAND_EXPORT_CODE,
-                        USA_2017_FINAL_DEMAND_IMPORT_CODE,
-                    ]
-                ).sum(axis=1)
-            )
-        ),
-        exports=ExportsVectorSchema.validate(
-            Ytot_with_trade_usa[USA_2017_FINAL_DEMAND_EXPORT_CODE]
-        ),
-        imports=ImportsVectorSchema.validate(
-            -1
-            * Ytot_with_trade_usa[USA_2017_FINAL_DEMAND_IMPORT_CODE].apply(
-                lambda x: min(x, 0)
-            )
-        ),
-    )
+    return derive_cornerstone_Aq_scaled()
 
 
 @functools.cache
 def derive_v7_detail_Ytot_usa_matrix_set() -> SingleRegionYtotAndTradeVectorSet:
-    """
-    Derive US Ytot and trade vectors using v7 USA IO tables.
-
-    NOTE: Ytot_usa can't be negative, because we need to use it to ABSR Ytot of other countries.
-    """
-    if get_usa_config().use_cornerstone_2026_model_schema:
-        return derive_cornerstone_detail_Ytot_matrix_set()
-    else:
-        detail_2017_YandTradeset = derive_2017_Ytot_usa_matrix_set()
-
-        summary_to_ceda_corresp_df = get_bea_v2017_summary_to_ceda_corresp_df()
-
-        summary_Y_matrix_set = derive_summary_Ytot_usa_matrix_set(year=2022)
-
-        ytot = disaggregate_vector(
-            base_series=summary_Y_matrix_set.ytot,
-            weight_series=detail_2017_YandTradeset.ytot,
-            corresp_df=summary_to_ceda_corresp_df,
-        )
-        exports = disaggregate_vector(
-            base_series=summary_Y_matrix_set.exports,
-            weight_series=detail_2017_YandTradeset.exports,
-            corresp_df=summary_to_ceda_corresp_df,
-        )
-        imports = handle_negative_vector_values(
-            disaggregate_vector(
-                base_series=summary_Y_matrix_set.imports,
-                weight_series=detail_2017_YandTradeset.imports,
-                corresp_df=summary_to_ceda_corresp_df,
-            )
-        )
-
-        return SingleRegionYtotAndTradeVectorSet(
-            ytot=YVectorSchema.validate(ytot),
-            exports=ExportsVectorSchema.validate(exports),
-            imports=ImportsVectorSchema.validate(imports),
-        )
+    return derive_cornerstone_detail_Ytot_matrix_set()


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

Keep only Cornerstone branches in ~10 files. Simplify MECS mapping selectors in 4 CO2 allocators (`industrial_coal.py`, `industrial_natural_gas.py`, `non_energy_fuels_natural_gas.py`, `non_energy_fuels_petrol.py`), `get_allocation_sectors()` in `utils.py`, `waste_562000_allocation_series_ceda_allocator_to_cornerstone_schema()` in `waste_utils.py`, and `load_bea_use_table()` in `extract/allocation/bea.py`. Simplify 6 functions in `eeio/derived.py` to thin wrappers delegating to `derived_cornerstone.py`. Delete CEDA v7 dead code: `derive_B_usa_via_vnorm`, `derive_v5_U_usa`, `derive_v5_detail_Ytot_usa_matrix_set`.

**Stack: 2/5** — depends on #1 (GHG method cleanup).

## Testing

Updated `test_bea_use_table_schema.py` for Cornerstone-only BEA loader. Existing allocation and EEIO tests pass.

Made with [Cursor](https://cursor.com)