### PR TITLE
fix(epa): fix data year validation and remove diagnostics gating

### DIFF
--- a/bedrock/extract/allocation/epa.py
+++ b/bedrock/extract/allocation/epa.py
@@ -8,7 +8,6 @@ import typing as ta
 import pandas as pd
 
 from bedrock.extract.allocation.epa_constants import (
-    EPA_TABLE_NAME_TO_TABLE_NUMBER_MAP_2022,
     EPA_TABLE_NAME_TO_TABLE_NUMBER_MAP_2023,
     EPA_TABLE_NAMES,
     TBL_NUMBERS,
@@ -25,7 +24,7 @@ IN_DIR = os.path.join(os.path.dirname(__file__), "..", "input_data")
 def _get_epa_data_year() -> int:
     """Get EPA main and annex table years from config"""
     year = get_usa_config().usa_ghg_data_year
-    if year not in [2022, 2023]:
+    if year not in [2023, 2024]:
         raise ValueError(f"Unsupported EPA GHG data year: {year}")
     return year
 
@@ -33,66 +32,33 @@ def _get_epa_data_year() -> int:
 def _get_epa_table_name_to_table_number_map() -> (
     ta.Mapping[EPA_TABLE_NAMES, TBL_NUMBERS]
 ):
-    year = _get_epa_data_year()
-    if year == 2022:
-        return EPA_TABLE_NAME_TO_TABLE_NUMBER_MAP_2022
-    elif year == 2023:
-        return EPA_TABLE_NAME_TO_TABLE_NUMBER_MAP_2023
-    else:
-        raise ValueError(f"Unsupported EPA GHG data year: {year}")
+    return EPA_TABLE_NAME_TO_TABLE_NUMBER_MAP_2023
 
 
 def _get_gcs_epa_dir_for_table(tbl_name: TBL_NUMBERS) -> str:
     """Get GCS EPA directories based on config year"""
-    year = _get_epa_data_year()
     section = tbl_name.split("-")[0]
 
-    main_or_annex_dir = (
-        {
-            "main": "EPA_GHGI_2022_Main_Tables",
-            "annex": "EPA_GHGI_2022_Annex_Tables",
-        }
-        if year == 2022
-        else {
-            "main": "EPA_GHGI_2023_Selected_Tables",
-            "annex": posixpath.join("EPA_GHGI_2023_Selected_Tables", "Annex"),
-        }
-    )
-    # # TODO: eventually go to the full set of csv tables for 2023
-    # # replacing the above if else chunk
-    # main_or_annex_dir = {
-    #     "main": f"EPA_GHGI_{year}_Main_Tables",
-    #     "annex": f"EPA_GHGI_{year}_Annex_Tables",
-    # }
+    main_or_annex_dir = {
+        "main": "EPA_GHGI_2023_Selected_Tables",
+        "annex": posixpath.join("EPA_GHGI_2023_Selected_Tables", "Annex"),
+    }
 
     if section == "A":
         return posixpath.join(
             GCS_CEDA_INPUT_DIR, main_or_annex_dir["annex"], f"Table {tbl_name}.csv"
         )
 
-    chapter_dir = (
-        {
-            1: "Introduction",
-            2: "Trends in Greenhouse Gas Emissions and Removals",
-            3: "Energy",
-            4: "Industrial Processes",
-            5: "Agriculture",
-            6: "LULUCF",  # Land Use, Land-Use Change, and Forestry
-            7: "Waste",
-            9: "Recalculations and Improvements",
-        }
-        if year == 2022
-        else {
-            1: "Chapter 1 - Introduction",
-            2: "Chapter 2 - Trends in Greenhouse Gas Emissions and Removals",
-            3: "Chapter 3 - Energy",
-            4: "Chapter 4 - Industrial Processes and Product Use",
-            5: "Chapter 5 - Agriculture",
-            6: "Chatper 6 - LULUCF",
-            7: "Chapter 7 - Waste",
-            9: "Chatper 9 - Recalculations and Improvements",
-        }
-    )
+    chapter_dir = {
+        1: "Chapter 1 - Introduction",
+        2: "Chapter 2 - Trends in Greenhouse Gas Emissions and Removals",
+        3: "Chapter 3 - Energy",
+        4: "Chapter 4 - Industrial Processes and Product Use",
+        5: "Chapter 5 - Agriculture",
+        6: "Chatper 6 - LULUCF",
+        7: "Chapter 7 - Waste",
+        9: "Chatper 9 - Recalculations and Improvements",
+    }
     return posixpath.join(
         GCS_CEDA_INPUT_DIR,
         main_or_annex_dir["main"],

--- a/bedrock/transform/__tests__/test_fbs.py
+++ b/bedrock/transform/__tests__/test_fbs.py
@@ -16,7 +16,7 @@ def test_generate_fbs() -> None:
 
 
 METHODS = [
-    pytest.param('GHG_national_CEDA_2023', id='GHG_national_CEDA_2023'),
+    pytest.param('GHG_national_Cornerstone_2023', id='GHG_national_Cornerstone_2023'),
 ]
 
 
@@ -47,4 +47,4 @@ def test_generate_fbs_compare_to_remote(method: str) -> None:
 
 if __name__ == '__main__':
     # test_generate_fbs()
-    test_generate_fbs_compare_to_remote(method='GHG_national_CEDA_2023')
+    test_generate_fbs_compare_to_remote(method='GHG_national_Cornerstone_2023')

--- a/bedrock/utils/validation/calculate_ef_diagnostics.py
+++ b/bedrock/utils/validation/calculate_ef_diagnostics.py
@@ -8,7 +8,6 @@ import typing as ta
 import numpy as np
 import pandas as pd
 
-from bedrock.utils.config.usa_config import get_usa_config
 from bedrock.utils.io.gcp import update_sheet_tab
 from bedrock.utils.snapshots.loader import load_configured_snapshot
 from bedrock.utils.taxonomy.bea.ceda_v7 import CEDA_V7_SECTOR_DESC
@@ -68,15 +67,13 @@ def calculate_ef_diagnostics(sheet_id: str) -> None:
     - D_and_diffs: Direct EFs new vs old.
     - D_and_N_significant_sectors: Combined D and N comparisons for significant sectors.
     - N_and_D_summary_stats: Summary statistics of percent diffs.
+    - x_decomposition: Effective x comparison decomposition.
     - output_contrib_new_vs_old: Top N contributing sectors to each EF's change,
       derived from the output contribution matrix.
-    - sector_mapping_notes (cornerstone only): Documents mapped/excluded sectors.
+    - sector_mapping_notes: Documents mapped/excluded sectors.
 
-    Old EFs are inflation-adjusted to the current base year before comparison.
-
-    When ``use_cornerstone_2026_model_schema`` is active, old (CEDA v7) and new
-    (cornerstone) EF vectors are aligned before comparison so that sectors with
-    different granularity are still comparable.
+    Old (CEDA v7) and new (cornerstone) EF vectors are aligned before comparison
+    so that sectors with different granularity are still comparable.
 
     Args:
         sheet_id: Google Sheets spreadsheet ID to write results to.
@@ -89,24 +86,16 @@ def calculate_ef_diagnostics(sheet_id: str) -> None:
     )
     from bedrock.utils.validation.diagnostics_helpers import pull_efs_for_diagnostics
 
-    config = get_usa_config()
-    use_cornerstone = config.use_cornerstone_2026_model_schema
-
     t0 = time.time()
     efs_raw = pull_efs_for_diagnostics()
     logger.info(
         f'[TIMING] pull_efs_for_diagnostics completed in {time.time() - t0:.1f}s'
     )
 
-    # When the cornerstone schema is active, align old/new sector indices
-    active_mappings: ta.Dict[str, str] = {}
-    if use_cornerstone:
-        logger.info('Aligning EF vectors across CEDA v7 / cornerstone schemas')
-        efs, active_mappings = align_efs_across_schemas(efs_raw)
-        sector_desc: ta.Optional[ta.Dict[str, str]] = get_aligned_sector_desc()
-    else:
-        efs = efs_raw
-        sector_desc = None  # use default CEDA_V7_SECTOR_DESC
+    # Align old (CEDA v7) / new (cornerstone) sector indices
+    logger.info('Aligning EF vectors across CEDA v7 / cornerstone schemas')
+    efs, active_mappings = align_efs_across_schemas(efs_raw)
+    sector_desc: ta.Optional[ta.Dict[str, str]] = get_aligned_sector_desc()
 
     logger.info('------ Calculating EF Diagnostics ------')
 
@@ -117,9 +106,7 @@ def calculate_ef_diagnostics(sheet_id: str) -> None:
         ef_old=efs.N_old,
         sector_desc=sector_desc,
     )
-
-    if use_cornerstone:
-        _add_comparison_type_column(N_comparison, active_mappings)
+    _add_comparison_type_column(N_comparison, active_mappings)
 
     t0 = time.time()
     update_sheet_tab(
@@ -139,9 +126,7 @@ def calculate_ef_diagnostics(sheet_id: str) -> None:
         ef_old=efs.D_old,
         sector_desc=sector_desc,
     )
-
-    if use_cornerstone:
-        _add_comparison_type_column(D_comparison, active_mappings)
+    _add_comparison_type_column(D_comparison, active_mappings)
 
     t0 = time.time()
     update_sheet_tab(
@@ -154,29 +139,26 @@ def calculate_ef_diagnostics(sheet_id: str) -> None:
         f'[TIMING] Write D_and_diffs to Google Sheets in {time.time() - t0:.1f}s'
     )
 
-    # Effective x decomposition (Cornerstone method only)
-    if config.use_E_data_year_for_x_in_B:
-        from bedrock.utils.validation.diagnostics_helpers import (
-            compute_effective_x_comparison,
-        )
+    # Effective x decomposition
+    from bedrock.utils.validation.diagnostics_helpers import (
+        compute_effective_x_comparison,
+    )
 
-        t0 = time.time()
-        x_comparison = compute_effective_x_comparison()
-        update_sheet_tab(
-            sheet_id, 'x_decomposition', x_comparison.reset_index(), clean_nans=True
-        )
-        logger.info(
-            f'[TIMING] Write x_decomposition to Google Sheets in {time.time() - t0:.1f}s'
-        )
+    t0 = time.time()
+    x_comparison = compute_effective_x_comparison()
+    update_sheet_tab(
+        sheet_id, 'x_decomposition', x_comparison.reset_index(), clean_nans=True
+    )
+    logger.info(
+        f'[TIMING] Write x_decomposition to Google Sheets in {time.time() - t0:.1f}s'
+    )
 
     # Compare D and N for significant sectors
     significant_sectors = [sector['sector'] for sector in SIGNIFICANT_SECTORS]
     # When aligned, some significant sectors may not be in the index (e.g. if
     # they were removed).  Filter to those present.
     available_significant = [s for s in significant_sectors if s in D_comparison.index]
-    drop_cols = ['sector_name']
-    if use_cornerstone:
-        drop_cols.append('comparison_type')
+    drop_cols = ['sector_name', 'comparison_type']
     significant_sectors_comparison = D_comparison.loc[available_significant].join(
         N_comparison.loc[available_significant].drop(columns=drop_cols)
     )
@@ -223,17 +205,16 @@ def calculate_ef_diagnostics(sheet_id: str) -> None:
         f'[TIMING] Write N_and_D_summary_stats to Google Sheets in {time.time() - t0:.1f}s'
     )
 
-    # Sector mapping notes (cornerstone only)
-    if use_cornerstone:
-        mapping_notes = _build_sector_mapping_notes(
-            active_mappings,
-            old_ef=efs_raw.D_old.raw,
-            new_ef=efs_raw.D_new,
-        )
-        update_sheet_tab(
-            sheet_id, 'sector_mapping_notes', mapping_notes, clean_nans=True
-        )
-        logger.info('Wrote sector_mapping_notes tab')
+    # Sector mapping notes
+    mapping_notes = _build_sector_mapping_notes(
+        active_mappings,
+        old_ef=efs_raw.D_old.raw,
+        new_ef=efs_raw.D_new,
+    )
+    update_sheet_tab(
+        sheet_id, 'sector_mapping_notes', mapping_notes, clean_nans=True
+    )
+    logger.info('Wrote sector_mapping_notes tab')
 
     # Compare output contribution
     t0 = time.time()
@@ -252,11 +233,10 @@ def calculate_ef_diagnostics(sheet_id: str) -> None:
         L=L_old, D=ta.cast('pd.Series[float]', efs_raw.D_old.inflated.squeeze())
     )
 
-    if use_cornerstone:
-        full_idx = OC_new.index.union(OC_old.index).sort_values()
-        full_cols = OC_new.columns.union(OC_old.columns).sort_values()
-        OC_new = OC_new.reindex(index=full_idx, columns=full_cols, fill_value=0.0)
-        OC_old = OC_old.reindex(index=full_idx, columns=full_cols, fill_value=0.0)
+    full_idx = OC_new.index.union(OC_old.index).sort_values()
+    full_cols = OC_new.columns.union(OC_old.columns).sort_values()
+    OC_new = OC_new.reindex(index=full_idx, columns=full_cols, fill_value=0.0)
+    OC_old = OC_old.reindex(index=full_idx, columns=full_cols, fill_value=0.0)
 
     OC_comparison = diff_and_perc_diff_two_output_contribution_matrices(
         OC_old,

--- a/bedrock/utils/validation/run_method_diff.py
+++ b/bedrock/utils/validation/run_method_diff.py
@@ -5,8 +5,8 @@ from bedrock.transform.flowbysector import FlowBySector, getFlowBySector
 from bedrock.utils.config.schema import dq_fields
 from bedrock.utils.validation.validation import compare_FBS
 
-baseline = "GHG_national_CEDA_2023"
-test_method = "GHG_national_Cornerstone_2023_mobile_combustion"
+baseline = "GHG_national_Cornerstone_2023"
+test_method = "GHG_national_Cornerstone_2023"
 
 # Optional: show all data (baseline vs test side by side) for these MetaSources.
 # Leave empty to skip. Uses merge only — does not filter to differences.


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

Fix `_get_epa_data_year()` in `extract/allocation/epa.py` to accept `[2023, 2024]` for `usa_ghg_data_year` (was incorrectly accepting 2022 and rejecting 2024). Remove `year == 2022` conditional branches from `_get_gcs_epa_dir_for_table()`. Clean up `calculate_ef_diagnostics.py`: remove all `use_cornerstone` conditional branches, always running Cornerstone-only diagnostics. Update `run_method_diff.py` and `test_fbs.py` to use `GHG_national_Cornerstone_2023`.

**Stack: 4/5** — depends on #3 (waste disagg gating removal).

## Testing

Existing EPA and diagnostics tests pass. FBS test methods updated.

Made with [Cursor](https://cursor.com)