### PR TITLE
add per-sector BLy_new vs baseline BLy_old diagnostics tab

### DIFF
--- a/bedrock/utils/validation/__tests__/test_calculate_national_accounting_balance.py
+++ b/bedrock/utils/validation/__tests__/test_calculate_national_accounting_balance.py
@@ -135,3 +135,33 @@ class TestCalculateNationalAccountingBalanceDiagnostics:
             np.asarray(detail["(BLy - E_orig) / E_orig (%)"], dtype=np.float64),
             exp_pct,
         )
+
+    def test_sector_diff_treats_missing_side_as_zero(self) -> None:
+        """BLy/E_orig stay blank when missing; diff uses 0 for missing side."""
+        idx_bly = pd.Index(["1111A0", "1111B0"])
+        n = len(idx_bly)
+        B = pd.DataFrame(np.eye(n), index=idx_bly, columns=idx_bly)
+        Adom = pd.DataFrame(np.zeros((n, n)), index=idx_bly, columns=idx_bly)
+        y = pd.Series([1e9, 2e9], index=idx_bly)
+        E_cols = pd.Index(["1111B0", "221100"])
+        E_orig = pd.DataFrame([[2e9, 3e9]], index=["CO2"], columns=E_cols)
+
+        result = self._run_diagnostics_with_mocked_data(B, Adom, y, E_orig)
+
+        detail = result.iloc[2:]
+        assert list(detail["index"]) == ["1111A0", "1111B0", "221100"]
+
+        assert detail["BLy (MtCO2e)"].iloc[0] == pytest.approx(1.0)
+        assert pd.isna(detail["E_orig (MtCO2e)"].iloc[0])
+        assert detail["BLy - E_orig (MtCO2e)"].iloc[0] == pytest.approx(1.0)
+        assert pd.isna(detail["(BLy - E_orig) / E_orig (%)"].iloc[0])
+
+        assert detail["BLy (MtCO2e)"].iloc[1] == pytest.approx(2.0)
+        assert detail["E_orig (MtCO2e)"].iloc[1] == pytest.approx(2.0)
+        assert detail["BLy - E_orig (MtCO2e)"].iloc[1] == pytest.approx(0.0)
+        assert detail["(BLy - E_orig) / E_orig (%)"].iloc[1] == pytest.approx(0.0)
+
+        assert pd.isna(detail["BLy (MtCO2e)"].iloc[2])
+        assert detail["E_orig (MtCO2e)"].iloc[2] == pytest.approx(3.0)
+        assert detail["BLy - E_orig (MtCO2e)"].iloc[2] == pytest.approx(-3.0)
+        assert detail["(BLy - E_orig) / E_orig (%)"].iloc[2] == pytest.approx(-1.0)

--- a/bedrock/utils/validation/__tests__/test_calculate_national_accounting_balance.py
+++ b/bedrock/utils/validation/__tests__/test_calculate_national_accounting_balance.py
@@ -96,7 +96,15 @@ class TestCalculateNationalAccountingBalanceDiagnostics:
         assert result["BLy - E_orig (MtCO2e)"].iloc[0] == pytest.approx(-3.0)
         assert result["(BLy - E_orig) / E_orig (%)"].iloc[0] == pytest.approx(-1 / 3)
 
-        assert list(result.iloc[1]) == [""] * len(result.columns)
+        sep = result.iloc[1]
+        assert sep["index"] == ""
+        for col in (
+            "BLy (MtCO2e)",
+            "E_orig (MtCO2e)",
+            "BLy - E_orig (MtCO2e)",
+            "(BLy - E_orig) / E_orig (%)",
+        ):
+            assert pd.isna(sep[col])
 
         detail = result.iloc[2:]
         sector_order = list(idx.sort_values())
@@ -124,6 +132,6 @@ class TestCalculateNationalAccountingBalanceDiagnostics:
         valid = np.isfinite(e_arr) & (e_arr != 0)
         exp_pct[valid] = d_arr[valid] / e_arr[valid]
         np.testing.assert_allclose(
-            detail["(BLy - E_orig) / E_orig (%)"].to_numpy(),
+            np.asarray(detail["(BLy - E_orig) / E_orig (%)"], dtype=np.float64),
             exp_pct,
         )

--- a/bedrock/utils/validation/__tests__/test_calculate_national_accounting_balance.py
+++ b/bedrock/utils/validation/__tests__/test_calculate_national_accounting_balance.py
@@ -29,12 +29,27 @@ class TestCalculateNationalAccountingBalanceDiagnostics:
         Adom: pd.DataFrame,
         y: pd.Series[float],
         E_orig: pd.DataFrame,
-    ) -> pd.DataFrame:
-        """Helper to run the NAB function with controlled inputs.
+        *,
+        B_old: pd.DataFrame | None = None,
+        Adom_old: pd.DataFrame | None = None,
+        y_old: pd.Series[float] | None = None,
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
+        """Run NAB diagnostics; return (BLy_vs_E_df, BLy_new_vs_old_df)."""
+        B_old = B if B_old is None else B_old
+        Adom_old = Adom if Adom_old is None else Adom_old
+        y_old = y if y_old is None else y_old
 
-        Returns the DataFrame that would be written to Google Sheets.
-        """
+        def fake_load_snapshot(name: str, key: str) -> pd.DataFrame | pd.Series:
+            if name == "B_USA_non_finetuned":
+                return B_old
+            if name == "Adom_USA":
+                return Adom_old
+            if name == "y_nab_USA":
+                return y_old
+            raise AssertionError(f"unexpected snapshot {name}")
+
         mock_update_sheet = MagicMock()
+
         mock_Aq = MagicMock()
         mock_Aq.Adom = Adom
 
@@ -56,32 +71,40 @@ class TestCalculateNationalAccountingBalanceDiagnostics:
                 return_value=E_orig,
             ),
             patch(
+                "bedrock.utils.validation.calculate_national_accounting_balance_diagnostics.load_snapshot",
+                side_effect=fake_load_snapshot,
+            ),
+            patch(
+                "bedrock.utils.validation.calculate_national_accounting_balance_diagnostics.resolve_snapshot_key",
+                return_value="test_snap_key",
+            ),
+            patch(
                 "bedrock.utils.validation.calculate_national_accounting_balance_diagnostics.update_sheet_tab",
                 mock_update_sheet,
             ),
         ):
             calculate_national_accounting_balance_diagnostics(sheet_id="test_sheet")
 
-        written_df: pd.DataFrame = mock_update_sheet.call_args[0][2]
-        return written_df
+        assert mock_update_sheet.call_count == 2
+        calls = mock_update_sheet.call_args_list
+        assert calls[0][0][1] == "BLy_and_E_orig_diffs"
+        assert calls[1][0][1] == "BLy_new_vs_BLy_old"
+        return calls[0][0][2], calls[1][0][2]
 
-    def test_output_structure_and_units(self) -> None:
-        """USA summary unchanged; blank row; per-sector BLy_i and E_orig_i."""
+    def test_bly_vs_e_national_only(self) -> None:
+        """BLy_and_E_orig_diffs is a single USA row."""
         idx = pd.Index(SECTORS)
         n = len(SECTORS)
 
-        # With B=I and A=0: d=[1,1,1], L=I, BLy = y
         B = pd.DataFrame(np.eye(n), index=idx, columns=idx)
         Adom = pd.DataFrame(np.zeros((n, n)), index=idx, columns=idx)
         y = pd.Series([1e9, 2e9, 3e9], index=idx)
 
-        # BLy_total = 6e9 kgCO2e = 6 MtCO2e
-        # E_orig_total = 9e9 kgCO2e = 9 MtCO2e
         E_orig = pd.DataFrame([[3e9, 3e9, 3e9]], index=["CO2"], columns=idx)
 
-        result = self._run_diagnostics_with_mocked_data(B, Adom, y, E_orig)
+        e_df, bly_diff_df = self._run_diagnostics_with_mocked_data(B, Adom, y, E_orig)
 
-        assert len(result) == 1 + 1 + n
+        assert len(e_df) == 1
         expected_cols = {
             "index",
             "BLy (MtCO2e)",
@@ -89,79 +112,81 @@ class TestCalculateNationalAccountingBalanceDiagnostics:
             "BLy - E_orig (MtCO2e)",
             "(BLy - E_orig) / E_orig (%)",
         }
-        assert set(result.columns) == expected_cols
+        assert set(e_df.columns) == expected_cols
 
-        assert result["BLy (MtCO2e)"].iloc[0] == pytest.approx(6.0)
-        assert result["E_orig (MtCO2e)"].iloc[0] == pytest.approx(9.0)
-        assert result["BLy - E_orig (MtCO2e)"].iloc[0] == pytest.approx(-3.0)
-        assert result["(BLy - E_orig) / E_orig (%)"].iloc[0] == pytest.approx(-1 / 3)
+        assert e_df["BLy (MtCO2e)"].iloc[0] == pytest.approx(6.0)
+        assert e_df["E_orig (MtCO2e)"].iloc[0] == pytest.approx(9.0)
+        assert e_df["BLy - E_orig (MtCO2e)"].iloc[0] == pytest.approx(-3.0)
+        assert e_df["(BLy - E_orig) / E_orig (%)"].iloc[0] == pytest.approx(-1 / 3)
 
-        sep = result.iloc[1]
-        assert sep["index"] == ""
-        for col in (
-            "BLy (MtCO2e)",
-            "E_orig (MtCO2e)",
-            "BLy - E_orig (MtCO2e)",
-            "(BLy - E_orig) / E_orig (%)",
-        ):
-            assert pd.isna(sep[col])
-
-        detail = result.iloc[2:]
+        assert len(bly_diff_df) == n
+        bly_cols = {
+            "index",
+            "BLy_new (MtCO2e)",
+            "BLy_old (MtCO2e)",
+            "BLy_new - BLy_old (MtCO2e)",
+            "(BLy_new - BLy_old) / BLy_old (%)",
+        }
+        assert set(bly_diff_df.columns) == bly_cols
         sector_order = list(idx.sort_values())
-        assert list(detail["index"]) == sector_order
+        assert list(bly_diff_df["index"]) == sector_order
         y_mt = y.reindex(sector_order) / 1e9
-        e_mt = E_orig.sum(axis=0).reindex(sector_order) / 1e9
-        pd.testing.assert_series_equal(
-            detail["BLy (MtCO2e)"].reset_index(drop=True),
-            y_mt.reset_index(drop=True),
-            check_names=False,
-        )
-        pd.testing.assert_series_equal(
-            detail["E_orig (MtCO2e)"].reset_index(drop=True),
-            e_mt.reset_index(drop=True),
-            check_names=False,
-        )
-        pd.testing.assert_series_equal(
-            detail["BLy - E_orig (MtCO2e)"].reset_index(drop=True),
-            (y_mt - e_mt).reset_index(drop=True),
-            check_names=False,
-        )
-        e_arr = e_mt.to_numpy(dtype=float)
-        d_arr = (y_mt - e_mt).to_numpy(dtype=float)
-        exp_pct = np.zeros(len(sector_order), dtype=float)
-        valid = np.isfinite(e_arr) & (e_arr != 0)
-        exp_pct[valid] = d_arr[valid] / e_arr[valid]
         np.testing.assert_allclose(
-            np.asarray(detail["(BLy - E_orig) / E_orig (%)"], dtype=np.float64),
-            exp_pct,
+            np.asarray(bly_diff_df["BLy_new (MtCO2e)"], dtype=np.float64),
+            y_mt.to_numpy(),
+        )
+        np.testing.assert_allclose(
+            np.asarray(bly_diff_df["BLy_old (MtCO2e)"], dtype=np.float64),
+            y_mt.to_numpy(),
+        )
+        assert np.allclose(
+            np.asarray(bly_diff_df["BLy_new - BLy_old (MtCO2e)"], dtype=np.float64),
+            0.0,
+        )
+        assert np.allclose(
+            np.asarray(
+                bly_diff_df["(BLy_new - BLy_old) / BLy_old (%)"], dtype=np.float64
+            ),
+            0.0,
         )
 
-    def test_sector_diff_treats_missing_side_as_zero(self) -> None:
-        """BLy/E_orig stay blank when missing; diff uses 0 for missing side."""
-        idx_bly = pd.Index(["1111A0", "1111B0"])
-        n = len(idx_bly)
-        B = pd.DataFrame(np.eye(n), index=idx_bly, columns=idx_bly)
-        Adom = pd.DataFrame(np.zeros((n, n)), index=idx_bly, columns=idx_bly)
-        y = pd.Series([1e9, 2e9], index=idx_bly)
-        E_cols = pd.Index(["1111B0", "221100"])
-        E_orig = pd.DataFrame([[2e9, 3e9]], index=["CO2"], columns=E_cols)
+    def test_bly_new_vs_old_missing_old_sector(self) -> None:
+        """Baseline BLy missing a sector: new column filled, old blank, diff uses 0 for old."""
+        idx_live = pd.Index(SECTORS)
+        n_live = len(idx_live)
+        B = pd.DataFrame(np.eye(n_live), index=idx_live, columns=idx_live)
+        Adom = pd.DataFrame(
+            np.zeros((n_live, n_live)), index=idx_live, columns=idx_live
+        )
+        y = pd.Series([1e9, 2e9, 3e9], index=idx_live)
 
-        result = self._run_diagnostics_with_mocked_data(B, Adom, y, E_orig)
+        idx_old = pd.Index(["1111A0", "1111B0"])
+        n_old = len(idx_old)
+        B_old = pd.DataFrame(np.eye(n_old), index=idx_old, columns=idx_old)
+        Adom_old = pd.DataFrame(
+            np.zeros((n_old, n_old)), index=idx_old, columns=idx_old
+        )
+        y_old = pd.Series([1e9, 2e9], index=idx_old)
 
-        detail = result.iloc[2:]
+        E_orig = pd.DataFrame([[3e9, 3e9, 3e9]], index=["CO2"], columns=idx_live)
+
+        _e_df, detail = self._run_diagnostics_with_mocked_data(
+            B,
+            Adom,
+            y,
+            E_orig,
+            B_old=B_old,
+            Adom_old=Adom_old,
+            y_old=y_old,
+        )
+
         assert list(detail["index"]) == ["1111A0", "1111B0", "221100"]
 
-        assert detail["BLy (MtCO2e)"].iloc[0] == pytest.approx(1.0)
-        assert pd.isna(detail["E_orig (MtCO2e)"].iloc[0])
-        assert detail["BLy - E_orig (MtCO2e)"].iloc[0] == pytest.approx(1.0)
-        assert pd.isna(detail["(BLy - E_orig) / E_orig (%)"].iloc[0])
+        assert detail["BLy_new (MtCO2e)"].iloc[0] == pytest.approx(1.0)
+        assert detail["BLy_old (MtCO2e)"].iloc[0] == pytest.approx(1.0)
+        assert detail["BLy_new - BLy_old (MtCO2e)"].iloc[0] == pytest.approx(0.0)
 
-        assert detail["BLy (MtCO2e)"].iloc[1] == pytest.approx(2.0)
-        assert detail["E_orig (MtCO2e)"].iloc[1] == pytest.approx(2.0)
-        assert detail["BLy - E_orig (MtCO2e)"].iloc[1] == pytest.approx(0.0)
-        assert detail["(BLy - E_orig) / E_orig (%)"].iloc[1] == pytest.approx(0.0)
-
-        assert pd.isna(detail["BLy (MtCO2e)"].iloc[2])
-        assert detail["E_orig (MtCO2e)"].iloc[2] == pytest.approx(3.0)
-        assert detail["BLy - E_orig (MtCO2e)"].iloc[2] == pytest.approx(-3.0)
-        assert detail["(BLy - E_orig) / E_orig (%)"].iloc[2] == pytest.approx(-1.0)
+        assert detail["BLy_new (MtCO2e)"].iloc[2] == pytest.approx(3.0)
+        assert pd.isna(detail["BLy_old (MtCO2e)"].iloc[2])
+        assert detail["BLy_new - BLy_old (MtCO2e)"].iloc[2] == pytest.approx(3.0)
+        assert pd.isna(detail["(BLy_new - BLy_old) / BLy_old (%)"].iloc[2])

--- a/bedrock/utils/validation/__tests__/test_calculate_national_accounting_balance.py
+++ b/bedrock/utils/validation/__tests__/test_calculate_national_accounting_balance.py
@@ -66,7 +66,7 @@ class TestCalculateNationalAccountingBalanceDiagnostics:
         return written_df
 
     def test_output_structure_and_units(self) -> None:
-        """Output should be a single row in MtCO2e with correct columns and values."""
+        """USA summary unchanged; blank row; per-sector BLy_i and E_orig_i."""
         idx = pd.Index(SECTORS)
         n = len(SECTORS)
 
@@ -81,7 +81,7 @@ class TestCalculateNationalAccountingBalanceDiagnostics:
 
         result = self._run_diagnostics_with_mocked_data(B, Adom, y, E_orig)
 
-        assert len(result) == 1
+        assert len(result) == 1 + 1 + n
         expected_cols = {
             "index",
             "BLy (MtCO2e)",
@@ -95,3 +95,35 @@ class TestCalculateNationalAccountingBalanceDiagnostics:
         assert result["E_orig (MtCO2e)"].iloc[0] == pytest.approx(9.0)
         assert result["BLy - E_orig (MtCO2e)"].iloc[0] == pytest.approx(-3.0)
         assert result["(BLy - E_orig) / E_orig (%)"].iloc[0] == pytest.approx(-1 / 3)
+
+        assert list(result.iloc[1]) == [""] * len(result.columns)
+
+        detail = result.iloc[2:]
+        sector_order = list(idx.sort_values())
+        assert list(detail["index"]) == sector_order
+        y_mt = y.reindex(sector_order) / 1e9
+        e_mt = E_orig.sum(axis=0).reindex(sector_order) / 1e9
+        pd.testing.assert_series_equal(
+            detail["BLy (MtCO2e)"].reset_index(drop=True),
+            y_mt.reset_index(drop=True),
+            check_names=False,
+        )
+        pd.testing.assert_series_equal(
+            detail["E_orig (MtCO2e)"].reset_index(drop=True),
+            e_mt.reset_index(drop=True),
+            check_names=False,
+        )
+        pd.testing.assert_series_equal(
+            detail["BLy - E_orig (MtCO2e)"].reset_index(drop=True),
+            (y_mt - e_mt).reset_index(drop=True),
+            check_names=False,
+        )
+        e_arr = e_mt.to_numpy(dtype=float)
+        d_arr = (y_mt - e_mt).to_numpy(dtype=float)
+        exp_pct = np.zeros(len(sector_order), dtype=float)
+        valid = np.isfinite(e_arr) & (e_arr != 0)
+        exp_pct[valid] = d_arr[valid] / e_arr[valid]
+        np.testing.assert_allclose(
+            detail["(BLy - E_orig) / E_orig (%)"].to_numpy(),
+            exp_pct,
+        )

--- a/bedrock/utils/validation/calculate_national_accounting_balance_diagnostics.py
+++ b/bedrock/utils/validation/calculate_national_accounting_balance_diagnostics.py
@@ -29,6 +29,9 @@ def calculate_national_accounting_balance_diagnostics(
     - y_nab = final demand vector for national accounting balance
 
     If the model is balanced, sum(BLy) should equal sum(E_orig).
+
+    The ``BLy_and_E_orig_diffs`` sheet lists the USA total first, a blank row,
+    then per-sector BLy_i vs E_orig_i (same columns; sector-level % uses E_orig_i).
     """
     # Late-binding imports - depend on global config
     from bedrock.transform.eeio.derived import (
@@ -76,9 +79,40 @@ def calculate_national_accounting_balance_diagnostics(
         },
         index=pd.Index(["USA"]),
     )
+    summary_out = comparison.reset_index()
+
+    _bly = BLy_new
+    if isinstance(_bly, pd.DataFrame):
+        _bly = _bly.iloc[:, 0] if _bly.shape[1] == 1 else _bly.squeeze()
+    bly_s = _bly.astype(float)
+
+    sector_index = bly_s.index.union(E_orig_by_sector.index).sort_values()
+    bly_by_sec = bly_s.reindex(sector_index)
+    e_by_sec = E_orig_by_sector.reindex(sector_index)
+    diff_by_sec = bly_by_sec - e_by_sec.astype(float)
+    e_arr = e_by_sec.to_numpy(dtype=float, copy=True)
+    d_arr = diff_by_sec.to_numpy(dtype=float, copy=True)
+    perc_arr = np.zeros(len(sector_index), dtype=float)
+    valid = np.isfinite(e_arr) & (e_arr != 0)
+    perc_arr[valid] = d_arr[valid] / e_arr[valid]
+
+    detail_out = pd.DataFrame(
+        {
+            "index": sector_index,
+            "BLy (MtCO2e)": bly_by_sec / 1e9,
+            "E_orig (MtCO2e)": e_by_sec / 1e9,
+            "BLy - E_orig (MtCO2e)": diff_by_sec / 1e9,
+            "(BLy - E_orig) / E_orig (%)": perc_arr,
+        }
+    )
+    separator = pd.DataFrame([{c: "" for c in summary_out.columns}])
+    combined = pd.concat(
+        [summary_out, separator, detail_out],
+        ignore_index=True,
+    )
 
     update_sheet_tab(
         sheet_id,
         "BLy_and_E_orig_diffs",
-        comparison.reset_index(),
+        combined,
     )

--- a/bedrock/utils/validation/calculate_national_accounting_balance_diagnostics.py
+++ b/bedrock/utils/validation/calculate_national_accounting_balance_diagnostics.py
@@ -115,8 +115,10 @@ def calculate_national_accounting_balance_diagnostics(
         ignore_index=True,
     )
 
+    # NaN in payload breaks the Sheets JSON API; map to null via clean_nans.
     update_sheet_tab(
         sheet_id,
         "BLy_and_E_orig_diffs",
         combined,
+        clean_nans=True,
     )

--- a/bedrock/utils/validation/calculate_national_accounting_balance_diagnostics.py
+++ b/bedrock/utils/validation/calculate_national_accounting_balance_diagnostics.py
@@ -31,7 +31,10 @@ def calculate_national_accounting_balance_diagnostics(
     If the model is balanced, sum(BLy) should equal sum(E_orig).
 
     The ``BLy_and_E_orig_diffs`` sheet lists the USA total first, a blank row,
-    then per-sector BLy_i vs E_orig_i (same columns; sector-level % uses E_orig_i).
+    then per-sector rows: BLy_i and E_orig_i stay blank where that side has no
+    sector, while ``BLy - E_orig`` uses 0 for missing sides. Sector-level % is
+    ``diff / E_orig_i`` only when ``E_orig_i`` is finite and non-zero; otherwise
+    blank.
     """
     # Late-binding imports - depend on global config
     from bedrock.transform.eeio.derived import (
@@ -89,19 +92,27 @@ def calculate_national_accounting_balance_diagnostics(
     sector_index = bly_s.index.union(E_orig_by_sector.index).sort_values()
     bly_by_sec = bly_s.reindex(sector_index)
     e_by_sec = E_orig_by_sector.reindex(sector_index)
-    diff_by_sec = bly_by_sec - e_by_sec.astype(float)
+    diff_kg = bly_by_sec.fillna(0) - e_by_sec.fillna(0)
     e_arr = e_by_sec.to_numpy(dtype=float, copy=True)
-    d_arr = diff_by_sec.to_numpy(dtype=float, copy=True)
-    perc_arr = np.zeros(len(sector_index), dtype=float)
-    valid = np.isfinite(e_arr) & (e_arr != 0)
-    perc_arr[valid] = d_arr[valid] / e_arr[valid]
+    d_kg = diff_kg.to_numpy(dtype=float, copy=True)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        ratio = np.where(
+            np.isfinite(e_arr) & (e_arr != 0),
+            d_kg / e_arr,
+            np.nan,
+        )
+    perc_arr = np.where(
+        np.isfinite(ratio),
+        ratio,
+        np.where(np.isfinite(d_kg) & (d_kg == 0), 0.0, np.nan),
+    )
 
     detail_out = pd.DataFrame(
         {
             "index": sector_index,
             "BLy (MtCO2e)": bly_by_sec / 1e9,
             "E_orig (MtCO2e)": e_by_sec / 1e9,
-            "BLy - E_orig (MtCO2e)": diff_by_sec / 1e9,
+            "BLy - E_orig (MtCO2e)": diff_kg / 1e9,
             "(BLy - E_orig) / E_orig (%)": perc_arr,
         }
     )

--- a/bedrock/utils/validation/calculate_national_accounting_balance_diagnostics.py
+++ b/bedrock/utils/validation/calculate_national_accounting_balance_diagnostics.py
@@ -18,11 +18,12 @@ logger = logging.getLogger(__name__)
 
 
 def _series_from_1d_frame_or_series(obj: pd.DataFrame | pd.Series) -> pd.Series[float]:
+    """Parquet ``y_nab_USA`` is a one-column frame or a Series; avoid ``squeeze()`` for mypy."""
     if isinstance(obj, pd.Series):
         return obj.astype(float)
     if obj.shape[1] == 1:
         return obj.iloc[:, 0].astype(float)
-    return obj.squeeze().astype(float)
+    raise ValueError(f"y_nab snapshot expected 1 column, got shape {obj.shape}")
 
 
 def _compute_bly_series(
@@ -35,14 +36,14 @@ def _compute_bly_series(
 
     L = compute_L_matrix(A=Adom)
     d = compute_d(B=B)
-    raw = (
-        pd.DataFrame(np.diag(d), index=L.index, columns=L.columns)
-        @ L
-        @ y
-    )
-    if isinstance(raw, pd.DataFrame):
-        raw = raw.iloc[:, 0] if raw.shape[1] == 1 else raw.squeeze()
-    return raw.astype(float)
+    raw = pd.DataFrame(np.diag(d), index=L.index, columns=L.columns) @ L @ y
+    if isinstance(raw, pd.Series):
+        return raw.astype(float)
+    if raw.shape[1] == 1:
+        return raw.iloc[:, 0].astype(float)
+    if raw.shape[0] == 1:
+        return raw.iloc[0, :].astype(float)
+    raise TypeError(f"unexpected BLy shape {raw.shape}")
 
 
 def _percent_diff_vs_denominator(

--- a/bedrock/utils/validation/calculate_national_accounting_balance_diagnostics.py
+++ b/bedrock/utils/validation/calculate_national_accounting_balance_diagnostics.py
@@ -105,7 +105,11 @@ def calculate_national_accounting_balance_diagnostics(
             "(BLy - E_orig) / E_orig (%)": perc_arr,
         }
     )
-    separator = pd.DataFrame([{c: "" for c in summary_out.columns}])
+    # NaN for numeric columns keeps float dtypes after concat; empty index cell only.
+    sep_row: dict[str, object] = {
+        c: ("" if c == "index" else np.nan) for c in summary_out.columns
+    }
+    separator = pd.DataFrame([sep_row])
     combined = pd.concat(
         [summary_out, separator, detail_out],
         ignore_index=True,

--- a/bedrock/utils/validation/calculate_national_accounting_balance_diagnostics.py
+++ b/bedrock/utils/validation/calculate_national_accounting_balance_diagnostics.py
@@ -8,9 +8,58 @@ import numpy as np
 import pandas as pd
 
 from bedrock.utils.io.gcp import update_sheet_tab
-from bedrock.utils.snapshots.loader import load_configured_snapshot
+from bedrock.utils.snapshots.loader import (
+    load_configured_snapshot,
+    load_snapshot,
+    resolve_snapshot_key,
+)
 
 logger = logging.getLogger(__name__)
+
+
+def _series_from_1d_frame_or_series(obj: pd.DataFrame | pd.Series) -> pd.Series[float]:
+    if isinstance(obj, pd.Series):
+        return obj.astype(float)
+    if obj.shape[1] == 1:
+        return obj.iloc[:, 0].astype(float)
+    return obj.squeeze().astype(float)
+
+
+def _compute_bly_series(
+    *,
+    B: pd.DataFrame,
+    Adom: pd.DataFrame,
+    y: pd.Series[float],
+) -> pd.Series[float]:
+    from bedrock.utils.math.formulas import compute_d, compute_L_matrix
+
+    L = compute_L_matrix(A=Adom)
+    d = compute_d(B=B)
+    raw = (
+        pd.DataFrame(np.diag(d), index=L.index, columns=L.columns)
+        @ L
+        @ y
+    )
+    if isinstance(raw, pd.DataFrame):
+        raw = raw.iloc[:, 0] if raw.shape[1] == 1 else raw.squeeze()
+    return raw.astype(float)
+
+
+def _percent_diff_vs_denominator(
+    diff_kg: np.ndarray,
+    denom_kg: np.ndarray,
+) -> np.ndarray:
+    with np.errstate(divide="ignore", invalid="ignore"):
+        ratio = np.where(
+            np.isfinite(denom_kg) & (denom_kg != 0),
+            diff_kg / denom_kg,
+            np.nan,
+        )
+    return np.where(
+        np.isfinite(ratio),
+        ratio,
+        np.where(np.isfinite(diff_kg) & (diff_kg == 0), 0.0, np.nan),
+    )
 
 
 def calculate_national_accounting_balance_diagnostics(
@@ -30,11 +79,12 @@ def calculate_national_accounting_balance_diagnostics(
 
     If the model is balanced, sum(BLy) should equal sum(E_orig).
 
-    The ``BLy_and_E_orig_diffs`` sheet lists the USA total first, a blank row,
-    then per-sector rows: BLy_i and E_orig_i stay blank where that side has no
-    sector, while ``BLy - E_orig`` uses 0 for missing sides. Sector-level % is
-    ``diff / E_orig_i`` only when ``E_orig_i`` is finite and non-zero; otherwise
-    blank.
+    Writes two tabs:
+    - ``BLy_and_E_orig_diffs``: USA totals only (live BLy vs snapshot E).
+    - ``BLy_new_vs_BLy_old``: per-sector live BLy vs BLy recomputed from baseline
+      parquet (``B_USA_non_finetuned``, ``Adom_USA``, ``y_nab_USA`` at the
+      configured snapshot key). Missing sides stay blank; diff uses 0 for missing;
+      % uses BLy_old as denominator when defined.
     """
     # Late-binding imports - depend on global config
     from bedrock.transform.eeio.derived import (
@@ -42,37 +92,26 @@ def calculate_national_accounting_balance_diagnostics(
         derive_B_usa_non_finetuned,
         derive_y_for_national_accounting_balance_usa,
     )
-    from bedrock.utils.math.formulas import compute_d, compute_L_matrix
 
     logger.info("------ Calculating national accounting balance diagnostics ------")
 
-    # Derive B, L, y from current model
     B_new = derive_B_usa_non_finetuned()
     Aq_set = derive_Aq_usa()
-    L_new = compute_L_matrix(A=Aq_set.Adom)
     y_new = derive_y_for_national_accounting_balance_usa()
 
-    # BLy = diag(d) @ L @ y
-    logger.info("1. Calculating BLy...")
-    d_new = compute_d(B=B_new)
-    BLy_new = (
-        pd.DataFrame(np.diag(d_new), index=L_new.index, columns=L_new.columns)
-        @ L_new
-        @ y_new
-    )
+    logger.info("1. Calculating BLy (live)...")
+    BLy_new = _compute_bly_series(B=B_new, Adom=Aq_set.Adom, y=y_new)
 
-    # E_orig: original emissions from snapshot (gas x sector matrix)
     logger.info("2. Loading E_orig from snapshot...")
     E_orig = load_configured_snapshot("E_USA_ES")
     E_orig_by_sector = ta.cast("pd.Series[float]", E_orig.sum(axis=0))
 
-    # National-level totals
     BLy_total = float(BLy_new.sum())
     E_orig_total = float(E_orig_by_sector.sum())
     diff = BLy_total - E_orig_total
     perc_diff = diff / E_orig_total if E_orig_total != 0 else 0.0
 
-    logger.info("3. Building national accounting balance summary...")
+    logger.info("3. Writing BLy vs E (national totals)...")
     comparison = pd.DataFrame(
         {
             "BLy (MtCO2e)": [BLy_total / 1e9],
@@ -82,54 +121,41 @@ def calculate_national_accounting_balance_diagnostics(
         },
         index=pd.Index(["USA"]),
     )
-    summary_out = comparison.reset_index()
-
-    _bly = BLy_new
-    if isinstance(_bly, pd.DataFrame):
-        _bly = _bly.iloc[:, 0] if _bly.shape[1] == 1 else _bly.squeeze()
-    bly_s = _bly.astype(float)
-
-    sector_index = bly_s.index.union(E_orig_by_sector.index).sort_values()
-    bly_by_sec = bly_s.reindex(sector_index)
-    e_by_sec = E_orig_by_sector.reindex(sector_index)
-    diff_kg = bly_by_sec.fillna(0) - e_by_sec.fillna(0)
-    e_arr = e_by_sec.to_numpy(dtype=float, copy=True)
-    d_kg = diff_kg.to_numpy(dtype=float, copy=True)
-    with np.errstate(divide="ignore", invalid="ignore"):
-        ratio = np.where(
-            np.isfinite(e_arr) & (e_arr != 0),
-            d_kg / e_arr,
-            np.nan,
-        )
-    perc_arr = np.where(
-        np.isfinite(ratio),
-        ratio,
-        np.where(np.isfinite(d_kg) & (d_kg == 0), 0.0, np.nan),
-    )
-
-    detail_out = pd.DataFrame(
-        {
-            "index": sector_index,
-            "BLy (MtCO2e)": bly_by_sec / 1e9,
-            "E_orig (MtCO2e)": e_by_sec / 1e9,
-            "BLy - E_orig (MtCO2e)": diff_kg / 1e9,
-            "(BLy - E_orig) / E_orig (%)": perc_arr,
-        }
-    )
-    # NaN for numeric columns keeps float dtypes after concat; empty index cell only.
-    sep_row: dict[str, object] = {
-        c: ("" if c == "index" else np.nan) for c in summary_out.columns
-    }
-    separator = pd.DataFrame([sep_row])
-    combined = pd.concat(
-        [summary_out, separator, detail_out],
-        ignore_index=True,
-    )
-
-    # NaN in payload breaks the Sheets JSON API; map to null via clean_nans.
     update_sheet_tab(
         sheet_id,
         "BLy_and_E_orig_diffs",
-        combined,
+        comparison.reset_index(),
+        clean_nans=True,
+    )
+
+    logger.info("4. Loading baseline B, Adom, y_nab; computing BLy_old...")
+    snap_key = resolve_snapshot_key()
+    B_old = load_snapshot("B_USA_non_finetuned", snap_key)
+    Adom_old = load_snapshot("Adom_USA", snap_key)
+    y_old = _series_from_1d_frame_or_series(load_snapshot("y_nab_USA", snap_key))
+    BLy_old = _compute_bly_series(B=B_old, Adom=Adom_old, y=y_old)
+
+    sector_index = BLy_new.index.union(BLy_old.index).sort_values()
+    bly_new_by_sec = BLy_new.reindex(sector_index)
+    bly_old_by_sec = BLy_old.reindex(sector_index)
+    diff_kg = bly_new_by_sec.fillna(0) - bly_old_by_sec.fillna(0)
+    old_arr = bly_old_by_sec.to_numpy(dtype=float, copy=True)
+    d_kg = diff_kg.to_numpy(dtype=float, copy=True)
+    perc_arr = _percent_diff_vs_denominator(d_kg, old_arr)
+
+    bly_diff_out = pd.DataFrame(
+        {
+            "index": sector_index,
+            "BLy_new (MtCO2e)": bly_new_by_sec / 1e9,
+            "BLy_old (MtCO2e)": bly_old_by_sec / 1e9,
+            "BLy_new - BLy_old (MtCO2e)": diff_kg / 1e9,
+            "(BLy_new - BLy_old) / BLy_old (%)": perc_arr,
+        }
+    )
+    logger.info("5. Writing BLy_new vs BLy_old (by sector)...")
+    update_sheet_tab(
+        sheet_id,
+        "BLy_new_vs_BLy_old",
+        bly_diff_out,
         clean_nans=True,
     )


### PR DESCRIPTION

cc: @WesIngwersen 
Closes:

## What changed? Why?

**New sheet tab: BLy_new_vs_BLy_old**

- Per-sector comparison of live `BLy (diag(d) · L · y_nab` from current `B`, `Adom`, `y_nab`) vs **baseline** `BLy` from the same formula using snapshot parquets at `resolve_snapshot_key()`: `B_USA_non_finetuned`, `Adom_USA`, `y_nab_USA`.
- Rows use the sorted union of sector indices; `BLy_new` / `BLy_old` cells stay empty where that side has no sector; difference uses 0 for missing values so net deltas still show when schemas differ.
- Percent column uses `BLy_old` as denominator when defined (same style of edge-case handling as elsewhere for zero / missing denominators).


## Testing

Sample diagnostics run [added here](https://docs.google.com/spreadsheets/d/17Nye04btLp1VSF7hWrK-d8EdARAgnbavy8EUBcnRAds/edit?usp=sharing) with new `BLy_new_vs_BLy_old` tab

