### PR TITLE
add interim config with b transformation and waste disaggregation

### DIFF
--- a/bedrock/utils/config/configs/2025_usa_cornerstone_B_transformation_and_waste_disaggregation.yaml
+++ b/bedrock/utils/config/configs/2025_usa_cornerstone_B_transformation_and_waste_disaggregation.yaml
@@ -1,0 +1,23 @@
+# This config is used to run the Cornerstone 2026 model schema on the 2025 USA data.
+# It enables comparisons of the B transformation while also using the waste disaggregation.
+
+#####
+# Model base settings
+#####
+
+#####
+# Data selection
+#####
+
+#####
+# Methodology selection
+#####
+use_cornerstone_2026_model_schema: True
+use_E_data_year_for_x_in_B: True
+load_E_from_flowsa: True
+implement_waste_disaggregation: True
+
+
+#####
+# Bugfix
+#####


### PR DESCRIPTION
cc: @MoLi7 
Closes:

## What changed? Why?

This combination is required to assess the impact of the B transformation _including_ waste disaggregation, which otherwise muddles the evaluation if its not present.

## Testing

[Diagnostics](https://docs.google.com/spreadsheets/d/1zN7vSlAscaZFf99yRBNEPSx5bHOK2iLwFJBMWeYI2lk/edit?usp=drive_link)

