### PR TITLE
Per-sector BLy_new vs E_orig diagnostics tab

### DIFF
--- a/bedrock/utils/validation/__tests__/test_calculate_national_accounting_balance.py
+++ b/bedrock/utils/validation/__tests__/test_calculate_national_accounting_balance.py
@@ -91,8 +91,8 @@ class TestCalculateNationalAccountingBalanceDiagnostics:
         assert calls[1][0][1] == "BLy_new_vs_BLy_old"
         return calls[0][0][2], calls[1][0][2]
 
-    def test_bly_vs_e_national_only(self) -> None:
-        """BLy_and_E_orig_diffs is a single USA row."""
+    def test_bly_vs_e_by_sector(self) -> None:
+        """BLy_and_E_orig_diffs is per-sector: BLy_new vs E_orig per sector."""
         idx = pd.Index(SECTORS)
         n = len(SECTORS)
 
@@ -104,20 +104,37 @@ class TestCalculateNationalAccountingBalanceDiagnostics:
 
         e_df, bly_diff_df = self._run_diagnostics_with_mocked_data(B, Adom, y, E_orig)
 
-        assert len(e_df) == 1
+        assert len(e_df) == n
         expected_cols = {
             "index",
-            "BLy (MtCO2e)",
+            "BLy_new (MtCO2e)",
             "E_orig (MtCO2e)",
-            "BLy - E_orig (MtCO2e)",
-            "(BLy - E_orig) / E_orig (%)",
+            "BLy_new - E_orig (MtCO2e)",
+            "(BLy_new - E_orig) / E_orig (%)",
         }
         assert set(e_df.columns) == expected_cols
 
-        assert e_df["BLy (MtCO2e)"].iloc[0] == pytest.approx(6.0)
-        assert e_df["E_orig (MtCO2e)"].iloc[0] == pytest.approx(9.0)
-        assert e_df["BLy - E_orig (MtCO2e)"].iloc[0] == pytest.approx(-3.0)
-        assert e_df["(BLy - E_orig) / E_orig (%)"].iloc[0] == pytest.approx(-1 / 3)
+        sector_order = list(idx.sort_values())
+        assert list(e_df["index"]) == sector_order
+
+        y_mt = y.reindex(sector_order) / 1e9
+        e_mt = pd.Series([3.0, 3.0, 3.0], index=sector_order)
+        np.testing.assert_allclose(
+            np.asarray(e_df["BLy_new (MtCO2e)"], dtype=np.float64),
+            y_mt.to_numpy(),
+        )
+        np.testing.assert_allclose(
+            np.asarray(e_df["E_orig (MtCO2e)"], dtype=np.float64),
+            e_mt.to_numpy(),
+        )
+        np.testing.assert_allclose(
+            np.asarray(e_df["BLy_new - E_orig (MtCO2e)"], dtype=np.float64),
+            (y_mt - e_mt).to_numpy(),
+        )
+        np.testing.assert_allclose(
+            np.asarray(e_df["(BLy_new - E_orig) / E_orig (%)"], dtype=np.float64),
+            ((y_mt - e_mt) / e_mt).to_numpy(),
+        )
 
         assert len(bly_diff_df) == n
         bly_cols = {

--- a/bedrock/utils/validation/calculate_national_accounting_balance_diagnostics.py
+++ b/bedrock/utils/validation/calculate_national_accounting_balance_diagnostics.py
@@ -81,7 +81,9 @@ def calculate_national_accounting_balance_diagnostics(
     If the model is balanced, sum(BLy) should equal sum(E_orig).
 
     Writes two tabs:
-    - ``BLy_and_E_orig_diffs``: USA totals only (live BLy vs snapshot E).
+    - ``BLy_and_E_orig_diffs``: per-sector live BLy vs snapshot E_orig
+      (sector totals from ``E_USA_ES`` summed over ghg flows).
+      % uses E_orig as denominator when defined.
     - ``BLy_new_vs_BLy_old``: per-sector live BLy vs BLy recomputed from baseline
       parquet (``B_USA_non_finetuned``, ``Adom_USA``, ``y_nab_USA`` at the
       configured snapshot key). Missing sides stay blank; diff uses 0 for missing;
@@ -107,25 +109,28 @@ def calculate_national_accounting_balance_diagnostics(
     E_orig = load_configured_snapshot("E_USA_ES")
     E_orig_by_sector = ta.cast("pd.Series[float]", E_orig.sum(axis=0))
 
-    BLy_total = float(BLy_new.sum())
-    E_orig_total = float(E_orig_by_sector.sum())
-    diff = BLy_total - E_orig_total
-    perc_diff = diff / E_orig_total if E_orig_total != 0 else 0.0
+    logger.info("3. Writing BLy vs E_orig (by sector)...")
+    sector_idx_e = BLy_new.index.union(E_orig_by_sector.index).sort_values()
+    bly_by_sec = BLy_new.reindex(sector_idx_e)
+    e_by_sec = E_orig_by_sector.reindex(sector_idx_e)
+    bly_e_diff_kg = bly_by_sec.fillna(0) - e_by_sec.fillna(0)
+    e_arr = e_by_sec.to_numpy(dtype=float, copy=True)
+    bly_e_d_kg = bly_e_diff_kg.to_numpy(dtype=float, copy=True)
+    bly_e_perc = _percent_diff_vs_denominator(bly_e_d_kg, e_arr)
 
-    logger.info("3. Writing BLy vs E (national totals)...")
-    comparison = pd.DataFrame(
+    bly_e_diff_out = pd.DataFrame(
         {
-            "BLy (MtCO2e)": [BLy_total / 1e9],
-            "E_orig (MtCO2e)": [E_orig_total / 1e9],
-            "BLy - E_orig (MtCO2e)": [diff / 1e9],
-            "(BLy - E_orig) / E_orig (%)": [perc_diff],
-        },
-        index=pd.Index(["USA"]),
+            "index": sector_idx_e,
+            "BLy_new (MtCO2e)": bly_by_sec / 1e9,
+            "E_orig (MtCO2e)": e_by_sec / 1e9,
+            "BLy_new - E_orig (MtCO2e)": bly_e_diff_kg / 1e9,
+            "(BLy_new - E_orig) / E_orig (%)": bly_e_perc,
+        }
     )
     update_sheet_tab(
         sheet_id,
         "BLy_and_E_orig_diffs",
-        comparison.reset_index(),
+        bly_e_diff_out,
         clean_nans=True,
     )
 


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

Expanded the `BLy_and_E_orig_diffs` tab in `calculate_national_accounting_balance_diagnostics.py` from a single USA-totals row to per-sector rows. Each row compares live `BLy_new` against `E_orig` (sector totals from `E_USA_ES` summed over GHG flows), with `(BLy_new - E_orig) / E_orig (%)` computed per sector via `_percent_diff_vs_denominator`. Columns renamed to `BLy_new (MtCO2e)`, `E_orig (MtCO2e)`, `BLy_new - E_orig (MtCO2e)`, `(BLy_new - E_orig) / E_orig (%)`. Test `test_bly_vs_e_national_only` renamed to `test_bly_vs_e_by_sector` and rewritten to assert per-sector output (n rows, sorted sector index, element-wise value checks).

## Testing

unit test `test_bly_vs_e_by_sector` updated; will verify on next diagnostics run