### PR TITLE
Add baseline snapshot comparison scripts

### DIFF
--- a/bedrock/analysis/baseline_snapshot_comparison/compare_B_Adom.py
+++ b/bedrock/analysis/baseline_snapshot_comparison/compare_B_Adom.py
@@ -1,0 +1,204 @@
+"""Compare B and Adom (live vs v0 snapshot) under 2025_usa_cornerstone_full_model."""
+from __future__ import annotations
+
+import logging
+import os
+import time
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(message)s")
+log = logging.getLogger("compare_ba")
+
+OUT = os.path.join(os.path.dirname(__file__), "output")
+os.makedirs(OUT, exist_ok=True)
+
+from bedrock.utils.config.usa_config import set_global_usa_config
+
+set_global_usa_config("2025_usa_cornerstone_full_model")
+
+from bedrock.transform.eeio.derived import derive_Aq_usa, derive_B_usa_non_finetuned
+from bedrock.utils.snapshots.loader import load_snapshot, resolve_snapshot_key
+
+snap_key = resolve_snapshot_key()
+log.info("snap key: %s", snap_key)
+
+log.info("computing B_new, Aq (live)...")
+t0 = time.time()
+B_new = derive_B_usa_non_finetuned()
+Aq = derive_Aq_usa()
+Adom_new = Aq.Adom
+log.info(
+    "live matrices in %.1fs — B_new=%s, Adom_new=%s",
+    time.time() - t0,
+    B_new.shape,
+    Adom_new.shape,
+)
+
+log.info("loading B_old, Adom_old from v0...")
+B_old = load_snapshot("B_USA_non_finetuned", snap_key)
+Adom_old = load_snapshot("Adom_USA", snap_key)
+log.info("snapshot shapes — B_old=%s, Adom_old=%s", B_old.shape, Adom_old.shape)
+
+
+def pct(a_arr: np.ndarray, b_arr: np.ndarray) -> np.ndarray:
+    with np.errstate(divide="ignore", invalid="ignore"):
+        return np.where(
+            np.isfinite(b_arr) & (b_arr != 0), (a_arr - b_arr) / b_arr, np.nan
+        )
+
+
+def compare_series(a: pd.Series, b: pd.Series, name: str) -> pd.DataFrame:
+    idx = a.index.union(b.index).sort_values()
+    a_r = a.reindex(idx)
+    b_r = b.reindex(idx)
+    diff = a_r.fillna(0) - b_r.fillna(0)
+    p = pct(a_r.to_numpy(dtype=float), b_r.to_numpy(dtype=float))
+    df = pd.DataFrame(
+        {"new": a_r, "old": b_r, "diff": diff, "abs_diff": diff.abs(), "pct": p},
+        index=idx,
+    )
+    df.index.name = "sector"
+
+    tot_n, tot_o = float(a_r.sum(skipna=True)), float(b_r.sum(skipna=True))
+    only_new = sorted(set(a.dropna().index) - set(b.dropna().index))
+    only_old = sorted(set(b.dropna().index) - set(a.dropna().index))
+    print(f"\n=== {name} SUMMARY ===")
+    print(f"|sectors| union={len(idx)}  new_only={len(only_new)}  old_only={len(only_old)}")
+    print(
+        f"sum(new)={tot_n:.3e}  sum(old)={tot_o:.3e}  diff={tot_n - tot_o:.3e}  "
+        f"({(tot_n - tot_o) / tot_o * 100 if tot_o else 0:.3f}%)"
+    )
+    print(f"max |diff|={df['abs_diff'].max():.3e} at {df['abs_diff'].idxmax()}")
+    finite_p = p[np.isfinite(p)]
+    print(
+        f"pct diff (n={len(finite_p)}):  mean={np.mean(finite_p) * 100:.4f}%  "
+        f"median={np.median(finite_p) * 100:.4f}%  max|pct|={np.max(np.abs(finite_p)) * 100:.3f}%"
+    )
+
+    df.to_csv(os.path.join(OUT, f"{name}_per_sector.csv"))
+
+    fig, ax = plt.subplots(figsize=(6.5, 6.5))
+    mask = a_r.notna() & b_r.notna()
+    ax.scatter(b_r[mask], a_r[mask], s=8, alpha=0.4)
+    lo = min(b_r[mask].min(), a_r[mask].min())
+    hi = max(b_r[mask].max(), a_r[mask].max())
+    ax.plot([lo, hi], [lo, hi], "r--", lw=1, label="y=x")
+    ax.set_xscale("symlog")
+    ax.set_yscale("symlog")
+    ax.set_xlabel(f"{name}_old (v0)")
+    ax.set_ylabel(f"{name}_new (live)")
+    ax.set_title(f"{name}: new vs old — per sector (symlog)")
+    ax.legend()
+    ax.grid(True, which="both", ls=":", alpha=0.3)
+    fig.tight_layout()
+    fig.savefig(os.path.join(OUT, f"{name}_scatter.png"), dpi=120)
+    plt.close(fig)
+
+    top = df.dropna(subset=["diff"]).nlargest(20, "abs_diff")
+    fig, ax = plt.subplots(figsize=(10, 7))
+    y_pos = np.arange(len(top))
+    ax.barh(
+        y_pos,
+        top["diff"],
+        color=["tab:red" if v < 0 else "tab:green" for v in top["diff"]],
+    )
+    ax.set_yticks(y_pos)
+    ax.set_yticklabels([str(s)[:50] for s in top.index], fontsize=8)
+    ax.invert_yaxis()
+    ax.set_xlabel(f"{name}_new − {name}_old")
+    ax.set_title(f"Top 20 sectors by |{name}_new − {name}_old|")
+    ax.axvline(0, color="k", lw=0.5)
+    ax.grid(True, axis="x", ls=":", alpha=0.3)
+    fig.tight_layout()
+    fig.savefig(os.path.join(OUT, f"{name}_top20_diff.png"), dpi=120)
+    plt.close(fig)
+
+    finite = p[np.isfinite(p)]
+    fig, ax = plt.subplots(figsize=(9, 4.5))
+    ax.hist(np.clip(finite * 100, -100, 100), bins=60, color="tab:blue", alpha=0.8)
+    ax.axvline(0, color="k", lw=0.5)
+    ax.set_xlabel(f"% diff = ({name}_new − {name}_old) / {name}_old × 100 (clipped ±100%)")
+    ax.set_ylabel("sector count")
+    ax.set_title(f"{name}: per-sector % diff distribution (n={len(finite)})")
+    ax.grid(True, ls=":", alpha=0.3)
+    fig.tight_layout()
+    fig.savefig(os.path.join(OUT, f"{name}_pct_hist.png"), dpi=120)
+    plt.close(fig)
+
+    return df
+
+
+# === B: d = column sums (direct emission intensity per $ output per sector) ===
+def column_sum_to_sector_series(M: pd.DataFrame, label: str) -> pd.Series:
+    n_y = 405
+    if M.shape[1] == n_y or abs(M.shape[1] - n_y) < abs(M.shape[0] - n_y):
+        s = M.sum(axis=0)
+    else:
+        s = M.sum(axis=1)
+    log.info("[%s] shape=%s  result_len=%d", label, M.shape, len(s))
+    return s.astype(float)
+
+
+d_new = column_sum_to_sector_series(B_new, "B_new")
+d_old = column_sum_to_sector_series(B_old, "B_old")
+compare_series(d_new, d_old, "d_B_colsum")
+
+common_rows = B_new.index.intersection(B_old.index)
+common_cols = B_new.columns.intersection(B_old.columns)
+bn = B_new.loc[common_rows, common_cols].astype(float).to_numpy()
+bo = B_old.loc[common_rows, common_cols].astype(float).to_numpy()
+B_elem_diff = bn - bo
+print("\n=== B RAW ELEMENT-WISE (intersection) ===")
+print(f"intersection shape: {bn.shape}")
+print(f"max |diff|: {np.abs(B_elem_diff).max():.3e}")
+print(
+    f"frobenius(diff) / frobenius(old): "
+    f"{np.linalg.norm(B_elem_diff) / np.linalg.norm(bo):.3e}"
+)
+finite_bp = pct(bn.ravel(), bo.ravel())
+finite_bp = finite_bp[np.isfinite(finite_bp)]
+print(
+    f"nonzero-cell % diff: n={len(finite_bp)}  mean={np.mean(finite_bp) * 100:.4f}%  "
+    f"median={np.median(finite_bp) * 100:.4f}%  max|%|={np.max(np.abs(finite_bp)) * 100:.3f}%"
+)
+
+# === Adom: column sums ===
+cs_new = Adom_new.sum(axis=0).astype(float)
+cs_old = Adom_old.sum(axis=0).astype(float)
+compare_series(cs_new, cs_old, "Adom_colsum")
+
+common_rows_a = Adom_new.index.intersection(Adom_old.index)
+common_cols_a = Adom_new.columns.intersection(Adom_old.columns)
+an = Adom_new.loc[common_rows_a, common_cols_a].astype(float).to_numpy()
+ao = Adom_old.loc[common_rows_a, common_cols_a].astype(float).to_numpy()
+A_elem_diff = an - ao
+print("\n=== Adom RAW ELEMENT-WISE (intersection) ===")
+print(f"intersection shape: {an.shape}")
+print(f"max |diff|: {np.abs(A_elem_diff).max():.3e} (entries in [0,1])")
+print(
+    f"frobenius(diff) / frobenius(old): "
+    f"{np.linalg.norm(A_elem_diff) / np.linalg.norm(ao):.3e}"
+)
+finite_ap = pct(an.ravel(), ao.ravel())
+finite_ap = finite_ap[np.isfinite(finite_ap)]
+print(
+    f"nonzero-cell % diff: n={len(finite_ap)}  mean={np.mean(finite_ap) * 100:.4f}%  "
+    f"median={np.median(finite_ap) * 100:.4f}%  max|%|={np.max(np.abs(finite_ap)) * 100:.3f}%"
+)
+
+fig, ax = plt.subplots(figsize=(8, 7))
+with np.errstate(divide="ignore"):
+    hm = np.log10(np.abs(A_elem_diff) + 1e-20)
+im = ax.imshow(hm, cmap="viridis", aspect="auto", vmin=-10, vmax=0)
+ax.set_xlabel("consuming sector (col)")
+ax.set_ylabel("producing sector (row)")
+ax.set_title("log10 |Adom_new − Adom_old| element-wise")
+fig.colorbar(im, ax=ax, label="log10 |diff|")
+fig.tight_layout()
+fig.savefig(os.path.join(OUT, "Adom_diff_heatmap.png"), dpi=120)
+plt.close(fig)
+
+print(f"\nOutputs written to: {OUT}")

--- a/bedrock/analysis/baseline_snapshot_comparison/compare_B_Adom.py
+++ b/bedrock/analysis/baseline_snapshot_comparison/compare_B_Adom.py
@@ -1,4 +1,5 @@
 """Compare B and Adom (live vs v0 snapshot) under 2025_usa_cornerstone_full_model."""
+
 from __future__ import annotations
 
 import logging
@@ -9,42 +10,48 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(message)s")
-log = logging.getLogger("compare_ba")
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(name)s %(message)s')
+log = logging.getLogger('compare_ba')
 
-OUT = os.path.join(os.path.dirname(__file__), "output")
+OUT = os.path.join(os.path.dirname(__file__), 'output')
 os.makedirs(OUT, exist_ok=True)
 
-from bedrock.utils.config.usa_config import set_global_usa_config
+from bedrock.utils.config.usa_config import set_global_usa_config  # noqa: E402
 
-set_global_usa_config("2025_usa_cornerstone_full_model")
+set_global_usa_config('2025_usa_cornerstone_full_model')
 
-from bedrock.transform.eeio.derived import derive_Aq_usa, derive_B_usa_non_finetuned
-from bedrock.utils.snapshots.loader import load_snapshot, resolve_snapshot_key
+from bedrock.transform.eeio.derived import (  # noqa: E402
+    derive_Aq_usa,
+    derive_B_usa_non_finetuned,
+)
+from bedrock.utils.snapshots.loader import (  # noqa: E402
+    load_snapshot,
+    resolve_snapshot_key,
+)
 
 snap_key = resolve_snapshot_key()
-log.info("snap key: %s", snap_key)
+log.info('snap key: %s', snap_key)
 
-log.info("computing B_new, Aq (live)...")
+log.info('computing B_new, Aq (live)...')
 t0 = time.time()
 B_new = derive_B_usa_non_finetuned()
 Aq = derive_Aq_usa()
 Adom_new = Aq.Adom
 log.info(
-    "live matrices in %.1fs — B_new=%s, Adom_new=%s",
+    'live matrices in %.1fs — B_new=%s, Adom_new=%s',
     time.time() - t0,
     B_new.shape,
     Adom_new.shape,
 )
 
-log.info("loading B_old, Adom_old from v0...")
-B_old = load_snapshot("B_USA_non_finetuned", snap_key)
-Adom_old = load_snapshot("Adom_USA", snap_key)
-log.info("snapshot shapes — B_old=%s, Adom_old=%s", B_old.shape, Adom_old.shape)
+log.info('loading B_old, Adom_old from v0...')
+B_old = load_snapshot('B_USA_non_finetuned', snap_key)
+Adom_old = load_snapshot('Adom_USA', snap_key)
+log.info('snapshot shapes — B_old=%s, Adom_old=%s', B_old.shape, Adom_old.shape)
 
 
 def pct(a_arr: np.ndarray, b_arr: np.ndarray) -> np.ndarray:
-    with np.errstate(divide="ignore", invalid="ignore"):
+    with np.errstate(divide='ignore', invalid='ignore'):
         return np.where(
             np.isfinite(b_arr) & (b_arr != 0), (a_arr - b_arr) / b_arr, np.nan
         )
@@ -57,75 +64,79 @@ def compare_series(a: pd.Series, b: pd.Series, name: str) -> pd.DataFrame:
     diff = a_r.fillna(0) - b_r.fillna(0)
     p = pct(a_r.to_numpy(dtype=float), b_r.to_numpy(dtype=float))
     df = pd.DataFrame(
-        {"new": a_r, "old": b_r, "diff": diff, "abs_diff": diff.abs(), "pct": p},
+        {'new': a_r, 'old': b_r, 'diff': diff, 'abs_diff': diff.abs(), 'pct': p},
         index=idx,
     )
-    df.index.name = "sector"
+    df.index.name = 'sector'
 
     tot_n, tot_o = float(a_r.sum(skipna=True)), float(b_r.sum(skipna=True))
     only_new = sorted(set(a.dropna().index) - set(b.dropna().index))
     only_old = sorted(set(b.dropna().index) - set(a.dropna().index))
-    print(f"\n=== {name} SUMMARY ===")
-    print(f"|sectors| union={len(idx)}  new_only={len(only_new)}  old_only={len(only_old)}")
+    print(f'\n=== {name} SUMMARY ===')
     print(
-        f"sum(new)={tot_n:.3e}  sum(old)={tot_o:.3e}  diff={tot_n - tot_o:.3e}  "
-        f"({(tot_n - tot_o) / tot_o * 100 if tot_o else 0:.3f}%)"
+        f'|sectors| union={len(idx)}  new_only={len(only_new)}  old_only={len(only_old)}'
     )
-    print(f"max |diff|={df['abs_diff'].max():.3e} at {df['abs_diff'].idxmax()}")
+    print(
+        f'sum(new)={tot_n:.3e}  sum(old)={tot_o:.3e}  diff={tot_n - tot_o:.3e}  '
+        f'({(tot_n - tot_o) / tot_o * 100 if tot_o else 0:.3f}%)'
+    )
+    print(f'max |diff|={df["abs_diff"].max():.3e} at {df["abs_diff"].idxmax()}')
     finite_p = p[np.isfinite(p)]
     print(
-        f"pct diff (n={len(finite_p)}):  mean={np.mean(finite_p) * 100:.4f}%  "
-        f"median={np.median(finite_p) * 100:.4f}%  max|pct|={np.max(np.abs(finite_p)) * 100:.3f}%"
+        f'pct diff (n={len(finite_p)}):  mean={np.mean(finite_p) * 100:.4f}%  '
+        f'median={np.median(finite_p) * 100:.4f}%  max|pct|={np.max(np.abs(finite_p)) * 100:.3f}%'
     )
 
-    df.to_csv(os.path.join(OUT, f"{name}_per_sector.csv"))
+    df.to_csv(os.path.join(OUT, f'{name}_per_sector.csv'))
 
     fig, ax = plt.subplots(figsize=(6.5, 6.5))
     mask = a_r.notna() & b_r.notna()
     ax.scatter(b_r[mask], a_r[mask], s=8, alpha=0.4)
     lo = min(b_r[mask].min(), a_r[mask].min())
     hi = max(b_r[mask].max(), a_r[mask].max())
-    ax.plot([lo, hi], [lo, hi], "r--", lw=1, label="y=x")
-    ax.set_xscale("symlog")
-    ax.set_yscale("symlog")
-    ax.set_xlabel(f"{name}_old (v0)")
-    ax.set_ylabel(f"{name}_new (live)")
-    ax.set_title(f"{name}: new vs old — per sector (symlog)")
+    ax.plot([lo, hi], [lo, hi], 'r--', lw=1, label='y=x')
+    ax.set_xscale('symlog')
+    ax.set_yscale('symlog')
+    ax.set_xlabel(f'{name}_old (v0)')
+    ax.set_ylabel(f'{name}_new (live)')
+    ax.set_title(f'{name}: new vs old — per sector (symlog)')
     ax.legend()
-    ax.grid(True, which="both", ls=":", alpha=0.3)
+    ax.grid(True, which='both', ls=':', alpha=0.3)
     fig.tight_layout()
-    fig.savefig(os.path.join(OUT, f"{name}_scatter.png"), dpi=120)
+    fig.savefig(os.path.join(OUT, f'{name}_scatter.png'), dpi=120)
     plt.close(fig)
 
-    top = df.dropna(subset=["diff"]).nlargest(20, "abs_diff")
+    top = df.dropna(subset=['diff']).nlargest(20, 'abs_diff')
     fig, ax = plt.subplots(figsize=(10, 7))
     y_pos = np.arange(len(top))
     ax.barh(
         y_pos,
-        top["diff"],
-        color=["tab:red" if v < 0 else "tab:green" for v in top["diff"]],
+        top['diff'],
+        color=['tab:red' if v < 0 else 'tab:green' for v in top['diff']],
     )
     ax.set_yticks(y_pos)
     ax.set_yticklabels([str(s)[:50] for s in top.index], fontsize=8)
     ax.invert_yaxis()
-    ax.set_xlabel(f"{name}_new − {name}_old")
-    ax.set_title(f"Top 20 sectors by |{name}_new − {name}_old|")
-    ax.axvline(0, color="k", lw=0.5)
-    ax.grid(True, axis="x", ls=":", alpha=0.3)
+    ax.set_xlabel(f'{name}_new − {name}_old')
+    ax.set_title(f'Top 20 sectors by |{name}_new − {name}_old|')
+    ax.axvline(0, color='k', lw=0.5)
+    ax.grid(True, axis='x', ls=':', alpha=0.3)
     fig.tight_layout()
-    fig.savefig(os.path.join(OUT, f"{name}_top20_diff.png"), dpi=120)
+    fig.savefig(os.path.join(OUT, f'{name}_top20_diff.png'), dpi=120)
     plt.close(fig)
 
     finite = p[np.isfinite(p)]
     fig, ax = plt.subplots(figsize=(9, 4.5))
-    ax.hist(np.clip(finite * 100, -100, 100), bins=60, color="tab:blue", alpha=0.8)
-    ax.axvline(0, color="k", lw=0.5)
-    ax.set_xlabel(f"% diff = ({name}_new − {name}_old) / {name}_old × 100 (clipped ±100%)")
-    ax.set_ylabel("sector count")
-    ax.set_title(f"{name}: per-sector % diff distribution (n={len(finite)})")
-    ax.grid(True, ls=":", alpha=0.3)
+    ax.hist(np.clip(finite * 100, -100, 100), bins=60, color='tab:blue', alpha=0.8)
+    ax.axvline(0, color='k', lw=0.5)
+    ax.set_xlabel(
+        f'% diff = ({name}_new − {name}_old) / {name}_old × 100 (clipped ±100%)'
+    )
+    ax.set_ylabel('sector count')
+    ax.set_title(f'{name}: per-sector % diff distribution (n={len(finite)})')
+    ax.grid(True, ls=':', alpha=0.3)
     fig.tight_layout()
-    fig.savefig(os.path.join(OUT, f"{name}_pct_hist.png"), dpi=120)
+    fig.savefig(os.path.join(OUT, f'{name}_pct_hist.png'), dpi=120)
     plt.close(fig)
 
     return df
@@ -138,67 +149,67 @@ def column_sum_to_sector_series(M: pd.DataFrame, label: str) -> pd.Series:
         s = M.sum(axis=0)
     else:
         s = M.sum(axis=1)
-    log.info("[%s] shape=%s  result_len=%d", label, M.shape, len(s))
+    log.info('[%s] shape=%s  result_len=%d', label, M.shape, len(s))
     return s.astype(float)
 
 
-d_new = column_sum_to_sector_series(B_new, "B_new")
-d_old = column_sum_to_sector_series(B_old, "B_old")
-compare_series(d_new, d_old, "d_B_colsum")
+d_new = column_sum_to_sector_series(B_new, 'B_new')
+d_old = column_sum_to_sector_series(B_old, 'B_old')
+compare_series(d_new, d_old, 'd_B_colsum')
 
 common_rows = B_new.index.intersection(B_old.index)
 common_cols = B_new.columns.intersection(B_old.columns)
 bn = B_new.loc[common_rows, common_cols].astype(float).to_numpy()
 bo = B_old.loc[common_rows, common_cols].astype(float).to_numpy()
 B_elem_diff = bn - bo
-print("\n=== B RAW ELEMENT-WISE (intersection) ===")
-print(f"intersection shape: {bn.shape}")
-print(f"max |diff|: {np.abs(B_elem_diff).max():.3e}")
+print('\n=== B RAW ELEMENT-WISE (intersection) ===')
+print(f'intersection shape: {bn.shape}')
+print(f'max |diff|: {np.abs(B_elem_diff).max():.3e}')
 print(
-    f"frobenius(diff) / frobenius(old): "
-    f"{np.linalg.norm(B_elem_diff) / np.linalg.norm(bo):.3e}"
+    f'frobenius(diff) / frobenius(old): '
+    f'{np.linalg.norm(B_elem_diff) / np.linalg.norm(bo):.3e}'
 )
 finite_bp = pct(bn.ravel(), bo.ravel())
 finite_bp = finite_bp[np.isfinite(finite_bp)]
 print(
-    f"nonzero-cell % diff: n={len(finite_bp)}  mean={np.mean(finite_bp) * 100:.4f}%  "
-    f"median={np.median(finite_bp) * 100:.4f}%  max|%|={np.max(np.abs(finite_bp)) * 100:.3f}%"
+    f'nonzero-cell % diff: n={len(finite_bp)}  mean={np.mean(finite_bp) * 100:.4f}%  '
+    f'median={np.median(finite_bp) * 100:.4f}%  max|%|={np.max(np.abs(finite_bp)) * 100:.3f}%'
 )
 
 # === Adom: column sums ===
 cs_new = Adom_new.sum(axis=0).astype(float)
 cs_old = Adom_old.sum(axis=0).astype(float)
-compare_series(cs_new, cs_old, "Adom_colsum")
+compare_series(cs_new, cs_old, 'Adom_colsum')
 
 common_rows_a = Adom_new.index.intersection(Adom_old.index)
 common_cols_a = Adom_new.columns.intersection(Adom_old.columns)
 an = Adom_new.loc[common_rows_a, common_cols_a].astype(float).to_numpy()
 ao = Adom_old.loc[common_rows_a, common_cols_a].astype(float).to_numpy()
 A_elem_diff = an - ao
-print("\n=== Adom RAW ELEMENT-WISE (intersection) ===")
-print(f"intersection shape: {an.shape}")
-print(f"max |diff|: {np.abs(A_elem_diff).max():.3e} (entries in [0,1])")
+print('\n=== Adom RAW ELEMENT-WISE (intersection) ===')
+print(f'intersection shape: {an.shape}')
+print(f'max |diff|: {np.abs(A_elem_diff).max():.3e} (entries in [0,1])')
 print(
-    f"frobenius(diff) / frobenius(old): "
-    f"{np.linalg.norm(A_elem_diff) / np.linalg.norm(ao):.3e}"
+    f'frobenius(diff) / frobenius(old): '
+    f'{np.linalg.norm(A_elem_diff) / np.linalg.norm(ao):.3e}'
 )
 finite_ap = pct(an.ravel(), ao.ravel())
 finite_ap = finite_ap[np.isfinite(finite_ap)]
 print(
-    f"nonzero-cell % diff: n={len(finite_ap)}  mean={np.mean(finite_ap) * 100:.4f}%  "
-    f"median={np.median(finite_ap) * 100:.4f}%  max|%|={np.max(np.abs(finite_ap)) * 100:.3f}%"
+    f'nonzero-cell % diff: n={len(finite_ap)}  mean={np.mean(finite_ap) * 100:.4f}%  '
+    f'median={np.median(finite_ap) * 100:.4f}%  max|%|={np.max(np.abs(finite_ap)) * 100:.3f}%'
 )
 
 fig, ax = plt.subplots(figsize=(8, 7))
-with np.errstate(divide="ignore"):
+with np.errstate(divide='ignore'):
     hm = np.log10(np.abs(A_elem_diff) + 1e-20)
-im = ax.imshow(hm, cmap="viridis", aspect="auto", vmin=-10, vmax=0)
-ax.set_xlabel("consuming sector (col)")
-ax.set_ylabel("producing sector (row)")
-ax.set_title("log10 |Adom_new − Adom_old| element-wise")
-fig.colorbar(im, ax=ax, label="log10 |diff|")
+im = ax.imshow(hm, cmap='viridis', aspect='auto', vmin=-10, vmax=0)
+ax.set_xlabel('consuming sector (col)')
+ax.set_ylabel('producing sector (row)')
+ax.set_title('log10 |Adom_new − Adom_old| element-wise')
+fig.colorbar(im, ax=ax, label='log10 |diff|')
 fig.tight_layout()
-fig.savefig(os.path.join(OUT, "Adom_diff_heatmap.png"), dpi=120)
+fig.savefig(os.path.join(OUT, 'Adom_diff_heatmap.png'), dpi=120)
 plt.close(fig)
 
-print(f"\nOutputs written to: {OUT}")
+print(f'\nOutputs written to: {OUT}')

--- a/bedrock/analysis/baseline_snapshot_comparison/compare_y.py
+++ b/bedrock/analysis/baseline_snapshot_comparison/compare_y.py
@@ -1,0 +1,185 @@
+"""Compare y_new (live) vs y_old (v0 snapshot) under 2025_usa_cornerstone_full_model."""
+from __future__ import annotations
+
+import logging
+import os
+import time
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(message)s")
+log = logging.getLogger("compare_y")
+
+OUT = os.path.join(os.path.dirname(__file__), "output")
+os.makedirs(OUT, exist_ok=True)
+
+from bedrock.utils.config.usa_config import set_global_usa_config
+
+set_global_usa_config("2025_usa_cornerstone_full_model")
+
+from bedrock.transform.eeio.derived import derive_y_for_national_accounting_balance_usa
+from bedrock.utils.snapshots.loader import load_snapshot, resolve_snapshot_key
+
+snap_key = resolve_snapshot_key()
+log.info("snapshot key resolved: %s", snap_key)
+
+log.info("computing y_new (live)...")
+t0 = time.time()
+y_new = derive_y_for_national_accounting_balance_usa().astype(float)
+log.info("y_new computed in %.1fs, shape=%s", time.time() - t0, y_new.shape)
+
+log.info("loading y_old from snapshot...")
+y_old_obj = load_snapshot("y_nab_USA", snap_key)
+y_old = (
+    y_old_obj.iloc[:, 0].astype(float)
+    if isinstance(y_old_obj, pd.DataFrame)
+    else y_old_obj.astype(float)
+)
+log.info("y_old shape=%s", y_old.shape)
+
+idx = y_new.index.union(y_old.index).sort_values()
+a = y_new.reindex(idx)
+b = y_old.reindex(idx)
+diff = a.fillna(0) - b.fillna(0)
+with np.errstate(divide="ignore", invalid="ignore"):
+    pct_arr = np.where((b.notna()) & (b != 0), (a - b) / b, np.nan)
+pct_ser = pd.Series(pct_arr, index=idx, name="pct")
+
+df = pd.DataFrame(
+    {"y_new": a, "y_old": b, "diff": diff, "abs_diff": diff.abs(), "pct": pct_ser},
+    index=idx,
+)
+df.index.name = "sector"
+
+tot_new = float(a.sum(skipna=True))
+tot_old = float(b.sum(skipna=True))
+both_idx = a.dropna().index.intersection(b.dropna().index)
+summary = pd.DataFrame(
+    {
+        "metric": [
+            "|sectors|",
+            "both sides",
+            "only y_new",
+            "only y_old",
+            "sum(y_new)",
+            "sum(y_old)",
+            "sum diff",
+            "sum diff (%)",
+            "max |diff|",
+            "sector at max |diff|",
+            "mean pct (where defined)",
+            "median pct (where defined)",
+        ],
+        "value": [
+            len(idx),
+            len(both_idx),
+            len(set(a.dropna().index) - set(b.dropna().index)),
+            len(set(b.dropna().index) - set(a.dropna().index)),
+            f"{tot_new:.3e}",
+            f"{tot_old:.3e}",
+            f"{tot_new - tot_old:.3e}",
+            f"{(tot_new - tot_old) / tot_old * 100:.3f}%" if tot_old else "n/a",
+            f"{df['abs_diff'].max():.3e}",
+            str(df["abs_diff"].idxmax()),
+            f"{np.nanmean(pct_arr) * 100:.3f}%",
+            f"{np.nanmedian(pct_arr) * 100:.3f}%",
+        ],
+    }
+)
+print("\n=== SUMMARY ===")
+print(summary.to_string(index=False))
+
+df.to_csv(os.path.join(OUT, "y_per_sector.csv"))
+
+plt.rcParams["figure.dpi"] = 120
+plt.rcParams["savefig.dpi"] = 120
+
+fig, ax = plt.subplots(figsize=(7, 7))
+mask = a.notna() & b.notna()
+ax.scatter(b[mask], a[mask], s=10, alpha=0.5)
+lim_lo = min(b[mask].min(), a[mask].min())
+lim_hi = max(b[mask].max(), a[mask].max())
+ax.plot([lim_lo, lim_hi], [lim_lo, lim_hi], "r--", lw=1, label="y=x")
+ax.set_xscale("symlog")
+ax.set_yscale("symlog")
+ax.set_xlabel("y_old (v0 snapshot)")
+ax.set_ylabel("y_new (live)")
+ax.set_title("y_new vs y_old — per sector (symlog)")
+ax.legend()
+ax.grid(True, which="both", ls=":", alpha=0.3)
+fig.tight_layout()
+fig.savefig(os.path.join(OUT, "y_scatter.png"))
+plt.close(fig)
+
+top = df.dropna(subset=["diff"]).nlargest(20, "abs_diff")
+fig, ax = plt.subplots(figsize=(10, 7))
+y_pos = np.arange(len(top))
+ax.barh(y_pos, top["y_old"], color="gray", alpha=0.6, label="y_old")
+ax.barh(y_pos, top["y_new"], height=0.4, color="tab:blue", alpha=0.9, label="y_new")
+ax.set_yticks(y_pos)
+ax.set_yticklabels([str(s)[:50] for s in top.index], fontsize=8)
+ax.invert_yaxis()
+ax.set_xlabel("y value")
+ax.set_title("Top 20 sectors by |y_new − y_old|")
+ax.legend()
+ax.grid(True, axis="x", ls=":", alpha=0.3)
+fig.tight_layout()
+fig.savefig(os.path.join(OUT, "y_top20_levels.png"))
+plt.close(fig)
+
+fig, ax = plt.subplots(figsize=(10, 7))
+ax.barh(
+    y_pos,
+    top["diff"],
+    color=["tab:red" if v < 0 else "tab:green" for v in top["diff"]],
+)
+ax.set_yticks(y_pos)
+ax.set_yticklabels([str(s)[:50] for s in top.index], fontsize=8)
+ax.invert_yaxis()
+ax.set_xlabel("y_new − y_old")
+ax.set_title("Top 20 sectors by |y_new − y_old| (signed diff)")
+ax.axvline(0, color="k", lw=0.5)
+ax.grid(True, axis="x", ls=":", alpha=0.3)
+fig.tight_layout()
+fig.savefig(os.path.join(OUT, "y_top20_diffs.png"))
+plt.close(fig)
+
+finite_pct = pct_arr[np.isfinite(pct_arr)]
+fig, ax = plt.subplots(figsize=(9, 5))
+ax.hist(np.clip(finite_pct * 100, -100, 100), bins=60, color="tab:blue", alpha=0.8)
+ax.axvline(0, color="k", lw=0.5)
+ax.set_xlabel("% diff = (y_new − y_old) / y_old × 100 (clipped to ±100%)")
+ax.set_ylabel("sector count")
+ax.set_title(f"Distribution of per-sector % diffs (n={len(finite_pct)})")
+ax.grid(True, ls=":", alpha=0.3)
+fig.tight_layout()
+fig.savefig(os.path.join(OUT, "y_pct_hist.png"))
+plt.close(fig)
+
+q_med = df["y_old"].abs().quantile(0.5)
+meaningful: pd.DataFrame = df.loc[
+    (df["y_old"].abs() > q_med) & df["pct"].notna()
+].copy()
+meaningful["abs_pct_val"] = meaningful["pct"].astype(float).abs()  # type: ignore[union-attr]
+top_pct = meaningful.nlargest(20, "abs_pct_val")  # type: ignore[call-overload]
+fig, ax = plt.subplots(figsize=(10, 7))
+y_pos = np.arange(len(top_pct))
+ax.barh(
+    y_pos,
+    top_pct["pct"] * 100,
+    color=["tab:red" if v < 0 else "tab:green" for v in top_pct["pct"]],
+)
+ax.set_yticks(y_pos)
+ax.set_yticklabels([str(s)[:50] for s in top_pct.index], fontsize=8)
+ax.invert_yaxis()
+ax.set_xlabel("% diff (restricted to y_old above median |y_old|)")
+ax.set_title("Top 20 sectors by |% diff| (meaningful denominators only)")
+ax.axvline(0, color="k", lw=0.5)
+ax.grid(True, axis="x", ls=":", alpha=0.3)
+fig.tight_layout()
+fig.savefig(os.path.join(OUT, "y_top20_pct.png"))
+plt.close(fig)
+
+print(f"\nOutputs written to: {OUT}")

--- a/bedrock/analysis/baseline_snapshot_comparison/compare_y.py
+++ b/bedrock/analysis/baseline_snapshot_comparison/compare_y.py
@@ -1,4 +1,5 @@
 """Compare y_new (live) vs y_old (v0 snapshot) under 2025_usa_cornerstone_full_model."""
+
 from __future__ import annotations
 
 import logging
@@ -9,177 +10,182 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(message)s")
-log = logging.getLogger("compare_y")
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(name)s %(message)s')
+log = logging.getLogger('compare_y')
 
-OUT = os.path.join(os.path.dirname(__file__), "output")
+OUT = os.path.join(os.path.dirname(__file__), 'output')
 os.makedirs(OUT, exist_ok=True)
 
-from bedrock.utils.config.usa_config import set_global_usa_config
+from bedrock.utils.config.usa_config import set_global_usa_config  # noqa: E402
 
-set_global_usa_config("2025_usa_cornerstone_full_model")
+set_global_usa_config('2025_usa_cornerstone_full_model')
 
-from bedrock.transform.eeio.derived import derive_y_for_national_accounting_balance_usa
-from bedrock.utils.snapshots.loader import load_snapshot, resolve_snapshot_key
+from bedrock.transform.eeio.derived import (  # noqa: E402
+    derive_y_for_national_accounting_balance_usa,
+)
+from bedrock.utils.snapshots.loader import (  # noqa: E402
+    load_snapshot,
+    resolve_snapshot_key,
+)
 
 snap_key = resolve_snapshot_key()
-log.info("snapshot key resolved: %s", snap_key)
+log.info('snapshot key resolved: %s', snap_key)
 
-log.info("computing y_new (live)...")
+log.info('computing y_new (live)...')
 t0 = time.time()
 y_new = derive_y_for_national_accounting_balance_usa().astype(float)
-log.info("y_new computed in %.1fs, shape=%s", time.time() - t0, y_new.shape)
+log.info('y_new computed in %.1fs, shape=%s', time.time() - t0, y_new.shape)
 
-log.info("loading y_old from snapshot...")
-y_old_obj = load_snapshot("y_nab_USA", snap_key)
+log.info('loading y_old from snapshot...')
+y_old_obj = load_snapshot('y_nab_USA', snap_key)
 y_old = (
     y_old_obj.iloc[:, 0].astype(float)
     if isinstance(y_old_obj, pd.DataFrame)
     else y_old_obj.astype(float)
 )
-log.info("y_old shape=%s", y_old.shape)
+log.info('y_old shape=%s', y_old.shape)
 
 idx = y_new.index.union(y_old.index).sort_values()
 a = y_new.reindex(idx)
 b = y_old.reindex(idx)
 diff = a.fillna(0) - b.fillna(0)
-with np.errstate(divide="ignore", invalid="ignore"):
+with np.errstate(divide='ignore', invalid='ignore'):
     pct_arr = np.where((b.notna()) & (b != 0), (a - b) / b, np.nan)
-pct_ser = pd.Series(pct_arr, index=idx, name="pct")
+pct_ser = pd.Series(pct_arr, index=idx, name='pct')
 
 df = pd.DataFrame(
-    {"y_new": a, "y_old": b, "diff": diff, "abs_diff": diff.abs(), "pct": pct_ser},
+    {'y_new': a, 'y_old': b, 'diff': diff, 'abs_diff': diff.abs(), 'pct': pct_ser},
     index=idx,
 )
-df.index.name = "sector"
+df.index.name = 'sector'
 
 tot_new = float(a.sum(skipna=True))
 tot_old = float(b.sum(skipna=True))
 both_idx = a.dropna().index.intersection(b.dropna().index)
 summary = pd.DataFrame(
     {
-        "metric": [
-            "|sectors|",
-            "both sides",
-            "only y_new",
-            "only y_old",
-            "sum(y_new)",
-            "sum(y_old)",
-            "sum diff",
-            "sum diff (%)",
-            "max |diff|",
-            "sector at max |diff|",
-            "mean pct (where defined)",
-            "median pct (where defined)",
+        'metric': [
+            '|sectors|',
+            'both sides',
+            'only y_new',
+            'only y_old',
+            'sum(y_new)',
+            'sum(y_old)',
+            'sum diff',
+            'sum diff (%)',
+            'max |diff|',
+            'sector at max |diff|',
+            'mean pct (where defined)',
+            'median pct (where defined)',
         ],
-        "value": [
+        'value': [
             len(idx),
             len(both_idx),
             len(set(a.dropna().index) - set(b.dropna().index)),
             len(set(b.dropna().index) - set(a.dropna().index)),
-            f"{tot_new:.3e}",
-            f"{tot_old:.3e}",
-            f"{tot_new - tot_old:.3e}",
-            f"{(tot_new - tot_old) / tot_old * 100:.3f}%" if tot_old else "n/a",
-            f"{df['abs_diff'].max():.3e}",
-            str(df["abs_diff"].idxmax()),
-            f"{np.nanmean(pct_arr) * 100:.3f}%",
-            f"{np.nanmedian(pct_arr) * 100:.3f}%",
+            f'{tot_new:.3e}',
+            f'{tot_old:.3e}',
+            f'{tot_new - tot_old:.3e}',
+            f'{(tot_new - tot_old) / tot_old * 100:.3f}%' if tot_old else 'n/a',
+            f'{df["abs_diff"].max():.3e}',
+            str(df['abs_diff'].idxmax()),
+            f'{np.nanmean(pct_arr) * 100:.3f}%',
+            f'{np.nanmedian(pct_arr) * 100:.3f}%',
         ],
     }
 )
-print("\n=== SUMMARY ===")
+print('\n=== SUMMARY ===')
 print(summary.to_string(index=False))
 
-df.to_csv(os.path.join(OUT, "y_per_sector.csv"))
+df.to_csv(os.path.join(OUT, 'y_per_sector.csv'))
 
-plt.rcParams["figure.dpi"] = 120
-plt.rcParams["savefig.dpi"] = 120
+plt.rcParams['figure.dpi'] = 120
+plt.rcParams['savefig.dpi'] = 120
 
 fig, ax = plt.subplots(figsize=(7, 7))
 mask = a.notna() & b.notna()
 ax.scatter(b[mask], a[mask], s=10, alpha=0.5)
 lim_lo = min(b[mask].min(), a[mask].min())
 lim_hi = max(b[mask].max(), a[mask].max())
-ax.plot([lim_lo, lim_hi], [lim_lo, lim_hi], "r--", lw=1, label="y=x")
-ax.set_xscale("symlog")
-ax.set_yscale("symlog")
-ax.set_xlabel("y_old (v0 snapshot)")
-ax.set_ylabel("y_new (live)")
-ax.set_title("y_new vs y_old — per sector (symlog)")
+ax.plot([lim_lo, lim_hi], [lim_lo, lim_hi], 'r--', lw=1, label='y=x')
+ax.set_xscale('symlog')
+ax.set_yscale('symlog')
+ax.set_xlabel('y_old (v0 snapshot)')
+ax.set_ylabel('y_new (live)')
+ax.set_title('y_new vs y_old — per sector (symlog)')
 ax.legend()
-ax.grid(True, which="both", ls=":", alpha=0.3)
+ax.grid(True, which='both', ls=':', alpha=0.3)
 fig.tight_layout()
-fig.savefig(os.path.join(OUT, "y_scatter.png"))
+fig.savefig(os.path.join(OUT, 'y_scatter.png'))
 plt.close(fig)
 
-top = df.dropna(subset=["diff"]).nlargest(20, "abs_diff")
+top = df.dropna(subset=['diff']).nlargest(20, 'abs_diff')
 fig, ax = plt.subplots(figsize=(10, 7))
 y_pos = np.arange(len(top))
-ax.barh(y_pos, top["y_old"], color="gray", alpha=0.6, label="y_old")
-ax.barh(y_pos, top["y_new"], height=0.4, color="tab:blue", alpha=0.9, label="y_new")
+ax.barh(y_pos, top['y_old'], color='gray', alpha=0.6, label='y_old')
+ax.barh(y_pos, top['y_new'], height=0.4, color='tab:blue', alpha=0.9, label='y_new')
 ax.set_yticks(y_pos)
 ax.set_yticklabels([str(s)[:50] for s in top.index], fontsize=8)
 ax.invert_yaxis()
-ax.set_xlabel("y value")
-ax.set_title("Top 20 sectors by |y_new − y_old|")
+ax.set_xlabel('y value')
+ax.set_title('Top 20 sectors by |y_new − y_old|')
 ax.legend()
-ax.grid(True, axis="x", ls=":", alpha=0.3)
+ax.grid(True, axis='x', ls=':', alpha=0.3)
 fig.tight_layout()
-fig.savefig(os.path.join(OUT, "y_top20_levels.png"))
+fig.savefig(os.path.join(OUT, 'y_top20_levels.png'))
 plt.close(fig)
 
 fig, ax = plt.subplots(figsize=(10, 7))
 ax.barh(
     y_pos,
-    top["diff"],
-    color=["tab:red" if v < 0 else "tab:green" for v in top["diff"]],
+    top['diff'],
+    color=['tab:red' if v < 0 else 'tab:green' for v in top['diff']],
 )
 ax.set_yticks(y_pos)
 ax.set_yticklabels([str(s)[:50] for s in top.index], fontsize=8)
 ax.invert_yaxis()
-ax.set_xlabel("y_new − y_old")
-ax.set_title("Top 20 sectors by |y_new − y_old| (signed diff)")
-ax.axvline(0, color="k", lw=0.5)
-ax.grid(True, axis="x", ls=":", alpha=0.3)
+ax.set_xlabel('y_new − y_old')
+ax.set_title('Top 20 sectors by |y_new − y_old| (signed diff)')
+ax.axvline(0, color='k', lw=0.5)
+ax.grid(True, axis='x', ls=':', alpha=0.3)
 fig.tight_layout()
-fig.savefig(os.path.join(OUT, "y_top20_diffs.png"))
+fig.savefig(os.path.join(OUT, 'y_top20_diffs.png'))
 plt.close(fig)
 
 finite_pct = pct_arr[np.isfinite(pct_arr)]
 fig, ax = plt.subplots(figsize=(9, 5))
-ax.hist(np.clip(finite_pct * 100, -100, 100), bins=60, color="tab:blue", alpha=0.8)
-ax.axvline(0, color="k", lw=0.5)
-ax.set_xlabel("% diff = (y_new − y_old) / y_old × 100 (clipped to ±100%)")
-ax.set_ylabel("sector count")
-ax.set_title(f"Distribution of per-sector % diffs (n={len(finite_pct)})")
-ax.grid(True, ls=":", alpha=0.3)
+ax.hist(np.clip(finite_pct * 100, -100, 100), bins=60, color='tab:blue', alpha=0.8)
+ax.axvline(0, color='k', lw=0.5)
+ax.set_xlabel('% diff = (y_new − y_old) / y_old × 100 (clipped to ±100%)')
+ax.set_ylabel('sector count')
+ax.set_title(f'Distribution of per-sector % diffs (n={len(finite_pct)})')
+ax.grid(True, ls=':', alpha=0.3)
 fig.tight_layout()
-fig.savefig(os.path.join(OUT, "y_pct_hist.png"))
+fig.savefig(os.path.join(OUT, 'y_pct_hist.png'))
 plt.close(fig)
 
-q_med = df["y_old"].abs().quantile(0.5)
+q_med = df['y_old'].abs().quantile(0.5)
 meaningful: pd.DataFrame = df.loc[
-    (df["y_old"].abs() > q_med) & df["pct"].notna()
+    (df['y_old'].abs() > q_med) & df['pct'].notna()
 ].copy()
-meaningful["abs_pct_val"] = meaningful["pct"].astype(float).abs()  # type: ignore[union-attr]
-top_pct = meaningful.nlargest(20, "abs_pct_val")  # type: ignore[call-overload]
+meaningful['abs_pct_val'] = meaningful['pct'].astype(float).abs()
+top_pct = meaningful.nlargest(20, 'abs_pct_val')
 fig, ax = plt.subplots(figsize=(10, 7))
 y_pos = np.arange(len(top_pct))
 ax.barh(
     y_pos,
-    top_pct["pct"] * 100,
-    color=["tab:red" if v < 0 else "tab:green" for v in top_pct["pct"]],
+    top_pct['pct'] * 100,
+    color=['tab:red' if v < 0 else 'tab:green' for v in top_pct['pct']],
 )
 ax.set_yticks(y_pos)
 ax.set_yticklabels([str(s)[:50] for s in top_pct.index], fontsize=8)
 ax.invert_yaxis()
-ax.set_xlabel("% diff (restricted to y_old above median |y_old|)")
-ax.set_title("Top 20 sectors by |% diff| (meaningful denominators only)")
-ax.axvline(0, color="k", lw=0.5)
-ax.grid(True, axis="x", ls=":", alpha=0.3)
+ax.set_xlabel('% diff (restricted to y_old above median |y_old|)')
+ax.set_title('Top 20 sectors by |% diff| (meaningful denominators only)')
+ax.axvline(0, color='k', lw=0.5)
+ax.grid(True, axis='x', ls=':', alpha=0.3)
 fig.tight_layout()
-fig.savefig(os.path.join(OUT, "y_top20_pct.png"))
+fig.savefig(os.path.join(OUT, 'y_top20_pct.png'))
 plt.close(fig)
 
-print(f"\nOutputs written to: {OUT}")
+print(f'\nOutputs written to: {OUT}')

--- a/bedrock/analysis/baseline_snapshot_comparison/compare_y.py
+++ b/bedrock/analysis/baseline_snapshot_comparison/compare_y.py
@@ -164,28 +164,37 @@ fig.tight_layout()
 fig.savefig(os.path.join(OUT, 'y_pct_hist.png'))
 plt.close(fig)
 
+# Top 20 |% diff| among sectors with meaningful denominators. Emitted as a
+# text table rather than a bar chart: in practice every value lands at
+# ~1e-14 % (float noise), so any plot axis is either misleading or empty.
+# The table preserves the ranking and shows the actual magnitudes.
 q_med = df['y_old'].abs().quantile(0.5)
 meaningful: pd.DataFrame = df.loc[
     (df['y_old'].abs() > q_med) & df['pct'].notna()
 ].copy()
 meaningful['abs_pct_val'] = meaningful['pct'].astype(float).abs()
 top_pct = meaningful.nlargest(20, 'abs_pct_val')
-fig, ax = plt.subplots(figsize=(10, 7))
-y_pos = np.arange(len(top_pct))
-ax.barh(
-    y_pos,
-    top_pct['pct'] * 100,
-    color=['tab:red' if v < 0 else 'tab:green' for v in top_pct['pct']],
-)
-ax.set_yticks(y_pos)
-ax.set_yticklabels([str(s)[:50] for s in top_pct.index], fontsize=8)
-ax.invert_yaxis()
-ax.set_xlabel('% diff (restricted to y_old above median |y_old|)')
-ax.set_title('Top 20 sectors by |% diff| (meaningful denominators only)')
-ax.axvline(0, color='k', lw=0.5)
-ax.grid(True, axis='x', ls=':', alpha=0.3)
-fig.tight_layout()
-fig.savefig(os.path.join(OUT, 'y_top20_pct.png'))
-plt.close(fig)
+
+max_abs_pct = float(top_pct['abs_pct_val'].max()) if len(top_pct) else 0.0
+report_tbl = top_pct[['y_new', 'y_old', 'pct']].copy()
+report_tbl['pct'] = [f'{float(v) * 100:+.3e} %' for v in report_tbl['pct']]
+report_tbl['y_new'] = [f'{float(v):.6e}' for v in report_tbl['y_new']]
+report_tbl['y_old'] = [f'{float(v):.6e}' for v in report_tbl['y_old']]
+
+report_path = os.path.join(OUT, 'y_top20_pct.txt')
+with open(report_path, 'w') as fh:
+    fh.write('Top 20 sectors by |% diff| (y_old > median |y_old|)\n')
+    fh.write(f'max |% diff| in this top-20: {max_abs_pct * 100:.3e} %\n')
+    if max_abs_pct < 1e-6:
+        fh.write(
+            'All values are below 1e-4 % — i.e. float-precision noise. '
+            'For both-sided sectors above the denominator floor, y_new and '
+            'y_old match within machine precision.\n'
+        )
+    fh.write('\n')
+    fh.write(report_tbl.to_string())
+    fh.write('\n')
+
+log.info('wrote y_top20_pct.txt (max |%%diff| = %.3e %%)', max_abs_pct * 100)
 
 print(f'\nOutputs written to: {OUT}')

--- a/bedrock/analysis/baseline_snapshot_comparison/decompose_d_E_x.py
+++ b/bedrock/analysis/baseline_snapshot_comparison/decompose_d_E_x.py
@@ -13,6 +13,7 @@ We compare:
 Additive log decomposition:
     ln(Bi_col_new / Bi_col_old) = ln(E_col_new / E_col_old) − ln(x_new / x_old)
 """
+
 from __future__ import annotations
 
 import logging
@@ -22,32 +23,32 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(message)s")
-log = logging.getLogger("decompose_d_E_x")
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(name)s %(message)s')
+log = logging.getLogger('decompose_d_E_x')
 
-OUT = os.path.join(os.path.dirname(__file__), "output")
+OUT = os.path.join(os.path.dirname(__file__), 'output')
 os.makedirs(OUT, exist_ok=True)
 
-from bedrock.utils.config.usa_config import set_global_usa_config
+from bedrock.utils.config.usa_config import set_global_usa_config  # noqa: E402
 
-set_global_usa_config("2025_usa_cornerstone_full_model")
+set_global_usa_config('2025_usa_cornerstone_full_model')
 
-from bedrock.transform.allocation.derived import derive_E_usa
-from bedrock.transform.eeio.derived_cornerstone import (
+from bedrock.transform.allocation.derived import derive_E_usa  # noqa: E402
+from bedrock.transform.eeio.derived_cornerstone import (  # noqa: E402
     derive_cornerstone_x,
     derive_cornerstone_x_after_redefinition,
 )
-from bedrock.utils.snapshots.loader import load_configured_snapshot
+from bedrock.utils.snapshots.loader import load_configured_snapshot  # noqa: E402
 
 log.info("computing live E, both x's...")
 E_new = derive_E_usa()
 x_new = derive_cornerstone_x_after_redefinition()  # flag ON (live convention)
 x_old = derive_cornerstone_x()  # flag OFF (v0 convention approximation)
-log.info("E_new=%s  x_new=%s  x_old=%s", E_new.shape, x_new.shape, x_old.shape)
+log.info('E_new=%s  x_new=%s  x_old=%s', E_new.shape, x_new.shape, x_old.shape)
 
-log.info("loading v0 E_USA_ES snapshot...")
-E_old = load_configured_snapshot("E_USA_ES")
-log.info("E_old=%s", E_old.shape)
+log.info('loading v0 E_USA_ES snapshot...')
+E_old = load_configured_snapshot('E_USA_ES')
+log.info('E_old=%s', E_old.shape)
 
 # Reduce E to per-industry (sum over ghg rows)
 E_new_col = E_new.sum(axis=0).astype(float)
@@ -62,7 +63,7 @@ E_o = E_old_col.reindex(idx)
 x_n = x_new.reindex(idx).astype(float)
 x_o = x_old.reindex(idx).astype(float)
 
-with np.errstate(divide="ignore", invalid="ignore"):
+with np.errstate(divide='ignore', invalid='ignore'):
     Bi_n = E_n / x_n
     Bi_o = E_o / x_o
     ln_Bi = np.log(Bi_n / Bi_o)
@@ -72,112 +73,120 @@ with np.errstate(divide="ignore", invalid="ignore"):
 
 tbl = pd.DataFrame(
     {
-        "E_old": E_o,
-        "E_new": E_n,
-        "E_pct": (E_n / E_o - 1) * 100,
-        "x_old": x_o,
-        "x_new": x_n,
-        "x_pct": (x_n / x_o - 1) * 100,
-        "Bi_old": Bi_o,
-        "Bi_new": Bi_n,
-        "Bi_pct": (Bi_n / Bi_o - 1) * 100,
-        "dln_Bi": ln_Bi,
-        "dln_E": ln_E,
-        "minus_dln_x": -ln_x,
-        "residual_ln": residual,
+        'E_old': E_o,
+        'E_new': E_n,
+        'E_pct': (E_n / E_o - 1) * 100,
+        'x_old': x_o,
+        'x_new': x_n,
+        'x_pct': (x_n / x_o - 1) * 100,
+        'Bi_old': Bi_o,
+        'Bi_new': Bi_n,
+        'Bi_pct': (Bi_n / Bi_o - 1) * 100,
+        'dln_Bi': ln_Bi,
+        'dln_E': ln_E,
+        'minus_dln_x': -ln_x,
+        'residual_ln': residual,
     },
     index=idx,
 )
-tbl.index.name = "sector"
-tbl.to_csv(os.path.join(OUT, "d_E_x_decomposition.csv"))
+tbl.index.name = 'sector'
+tbl.to_csv(os.path.join(OUT, 'd_E_x_decomposition.csv'))
 
 # Focus: 221100
-print("\n=== Sector 221100 (Electricity) — industry-space E / x decomposition ===")
-if "221100" in tbl.index:
-    r = tbl.loc["221100"]
-    print(f"  E_old             = {r['E_old']:.4e}")
-    print(f"  E_new             = {r['E_new']:.4e}   ({r['E_pct']:+.2f}%)")
-    print(f"  x_old             = {r['x_old']:.4e}")
-    print(f"  x_new             = {r['x_new']:.4e}   ({r['x_pct']:+.2f}%)")
-    print(f"  Bi_old = E/x old  = {r['Bi_old']:.4e}")
-    print(f"  Bi_new = E/x new  = {r['Bi_new']:.4e}   ({r['Bi_pct']:+.2f}%)")
+print('\n=== Sector 221100 (Electricity) — industry-space E / x decomposition ===')
+if '221100' in tbl.index:
+    r = tbl.loc['221100']
+    print(f'  E_old             = {r["E_old"]:.4e}')
+    print(f'  E_new             = {r["E_new"]:.4e}   ({r["E_pct"]:+.2f}%)')
+    print(f'  x_old             = {r["x_old"]:.4e}')
+    print(f'  x_new             = {r["x_new"]:.4e}   ({r["x_pct"]:+.2f}%)')
+    print(f'  Bi_old = E/x old  = {r["Bi_old"]:.4e}')
+    print(f'  Bi_new = E/x new  = {r["Bi_new"]:.4e}   ({r["Bi_pct"]:+.2f}%)')
     print()
-    print(f"  Δln(Bi)     = {r['dln_Bi']:+.4f}   (= target)")
-    print(f"  Δln(E)      = {r['dln_E']:+.4f}   (E-contribution)")
-    print(f"  −Δln(x)     = {r['minus_dln_x']:+.4f}   (x-contribution)")
-    print(f"  residual    = {r['residual_ln']:+.4e}   (should be ~0)")
-    if abs(r["dln_Bi"]) > 1e-12:
-        share_E = r["dln_E"] / r["dln_Bi"] * 100
-        share_x = r["minus_dln_x"] / r["dln_Bi"] * 100
-        print(f"\n  => E drives  {share_E:+.1f}% of the Bi change")
-        print(f"  => x drives  {share_x:+.1f}% of the Bi change")
+    print(f'  Δln(Bi)     = {r["dln_Bi"]:+.4f}   (= target)')
+    print(f'  Δln(E)      = {r["dln_E"]:+.4f}   (E-contribution)')
+    print(f'  −Δln(x)     = {r["minus_dln_x"]:+.4f}   (x-contribution)')
+    print(f'  residual    = {r["residual_ln"]:+.4e}   (should be ~0)')
+    if abs(r['dln_Bi']) > 1e-12:
+        share_E = r['dln_E'] / r['dln_Bi'] * 100
+        share_x = r['minus_dln_x'] / r['dln_Bi'] * 100
+        print(f'\n  => E drives  {share_E:+.1f}% of the Bi change')
+        print(f'  => x drives  {share_x:+.1f}% of the Bi change')
 
 # Top sectors by |Δln(Bi)|
-print("\n=== Top 15 sectors by |Δln(Bi)| (both sides present, finite) ===")
-finite: pd.DataFrame = tbl.dropna(subset=["dln_Bi", "dln_E", "minus_dln_x"]).copy()
-finite = finite.loc[np.isfinite(finite["dln_Bi"])]
-finite["abs_dln_Bi"] = finite["dln_Bi"].astype(float).abs()  # type: ignore[union-attr]
-top = finite.nlargest(15, "abs_dln_Bi")  # type: ignore[call-overload]
-print(top[["Bi_old", "Bi_new", "dln_Bi", "dln_E", "minus_dln_x", "residual_ln"]].to_string())  # type: ignore[call-overload]
+print('\n=== Top 15 sectors by |Δln(Bi)| (both sides present, finite) ===')
+finite: pd.DataFrame = tbl.dropna(subset=['dln_Bi', 'dln_E', 'minus_dln_x']).copy()
+finite = finite.loc[np.isfinite(finite['dln_Bi'])]
+finite['abs_dln_Bi'] = finite['dln_Bi'].astype(float).abs()
+top = finite.nlargest(15, 'abs_dln_Bi')
+print(
+    top[
+        ['Bi_old', 'Bi_new', 'dln_Bi', 'dln_E', 'minus_dln_x', 'residual_ln']
+    ].to_string()
+)
 
 # Visual: per-sector stacked bar — Δln(Bi) decomposed into E and -x for top 20
-top20 = finite.nlargest(20, "abs_dln_Bi").copy()  # type: ignore[call-overload]
+top20 = finite.nlargest(20, 'abs_dln_Bi').copy()
 fig, ax = plt.subplots(figsize=(11, 8))
 y_pos = np.arange(len(top20))
-ax.barh(y_pos, top20["dln_E"], color="tab:orange", alpha=0.85, label="Δln(E)")
+ax.barh(y_pos, top20['dln_E'], color='tab:orange', alpha=0.85, label='Δln(E)')
 ax.barh(
     y_pos,
-    top20["minus_dln_x"],
-    left=top20["dln_E"],
-    color="tab:purple",
+    top20['minus_dln_x'],
+    left=top20['dln_E'],
+    color='tab:purple',
     alpha=0.85,
-    label="−Δln(x)",
+    label='−Δln(x)',
 )
 ax.plot(
-    top20["dln_Bi"],
+    top20['dln_Bi'],
     y_pos,
-    "k|",
+    'k|',
     markersize=14,
     markeredgewidth=2,
-    label="Δln(Bi) (target)",
+    label='Δln(Bi) (target)',
 )
 ax.set_yticks(y_pos)
 ax.set_yticklabels([str(s) for s in top20.index], fontsize=9)
 ax.invert_yaxis()
-ax.axvline(0, color="k", lw=0.5)
-ax.set_xlabel("log ratio (new/old)")
-ax.set_title("Decomposition of Δln(Bi) = Δln(E) − Δln(x)  — top 20 sectors by |Δln(Bi)|")
-ax.legend(loc="best")
-ax.grid(True, axis="x", ls=":", alpha=0.3)
+ax.axvline(0, color='k', lw=0.5)
+ax.set_xlabel('log ratio (new/old)')
+ax.set_title(
+    'Decomposition of Δln(Bi) = Δln(E) − Δln(x)  — top 20 sectors by |Δln(Bi)|'
+)
+ax.legend(loc='best')
+ax.grid(True, axis='x', ls=':', alpha=0.3)
 fig.tight_layout()
-fig.savefig(os.path.join(OUT, "d_E_x_decomposition_top20.png"), dpi=120)
+fig.savefig(os.path.join(OUT, 'd_E_x_decomposition_top20.png'), dpi=120)
 plt.close(fig)
 
 # E vs x %-change scatter
 fig, ax = plt.subplots(figsize=(7, 7))
-mask = np.isfinite(tbl["E_pct"]) & np.isfinite(tbl["x_pct"])
-ax.scatter(tbl.loc[mask, "x_pct"], tbl.loc[mask, "E_pct"], s=10, alpha=0.5)
-if "221100" in tbl.index:
-    r = tbl.loc["221100"]
-    ax.scatter([r["x_pct"]], [r["E_pct"]], s=80, color="tab:red", zorder=5, label="221100")
-    ax.annotate(
-        "221100",
-        (r["x_pct"], r["E_pct"]),
-        textcoords="offset points",
-        xytext=(8, 6),
-        color="tab:red",
+mask = np.isfinite(tbl['E_pct']) & np.isfinite(tbl['x_pct'])
+ax.scatter(tbl.loc[mask, 'x_pct'], tbl.loc[mask, 'E_pct'], s=10, alpha=0.5)
+if '221100' in tbl.index:
+    r = tbl.loc['221100']
+    ax.scatter(
+        [r['x_pct']], [r['E_pct']], s=80, color='tab:red', zorder=5, label='221100'
     )
-ax.axhline(0, color="k", lw=0.5)
-ax.axvline(0, color="k", lw=0.5)
-ax.set_xlabel("x % change (new/old − 1)")
-ax.set_ylabel("E % change (new/old − 1)")
-ax.set_title("Per-industry: E change vs x change (clipped)")
+    ax.annotate(
+        '221100',
+        (float(r['x_pct']), float(r['E_pct'])),
+        textcoords='offset points',
+        xytext=(8, 6),
+        color='tab:red',
+    )
+ax.axhline(0, color='k', lw=0.5)
+ax.axvline(0, color='k', lw=0.5)
+ax.set_xlabel('x % change (new/old − 1)')
+ax.set_ylabel('E % change (new/old − 1)')
+ax.set_title('Per-industry: E change vs x change (clipped)')
 ax.set_xlim(-100, 200)
 ax.set_ylim(-100, 200)
 ax.legend()
-ax.grid(True, ls=":", alpha=0.3)
+ax.grid(True, ls=':', alpha=0.3)
 fig.tight_layout()
-fig.savefig(os.path.join(OUT, "d_E_x_scatter.png"), dpi=120)
+fig.savefig(os.path.join(OUT, 'd_E_x_scatter.png'), dpi=120)
 plt.close(fig)
 
-print(f"\nOutputs written to: {OUT}")
+print(f'\nOutputs written to: {OUT}')

--- a/bedrock/analysis/baseline_snapshot_comparison/decompose_d_E_x.py
+++ b/bedrock/analysis/baseline_snapshot_comparison/decompose_d_E_x.py
@@ -1,0 +1,183 @@
+"""Decompose d = colsum(B) into E and x contributions (industry space).
+
+B is computed as `Bi = E / x` in industry space, then `B = Bi @ Vnorm` in
+commodity space. For sectors where industry ≈ commodity (e.g. electricity
+221100), industry-space d ≈ commodity-space d.
+
+We compare:
+- E: live derive_E_usa() vs v0 E_USA_ES snapshot
+- x: live x (flag ON, derive_cornerstone_x_after_redefinition) vs live x
+  (flag OFF, derive_cornerstone_x()). v0 predates the flag, so flag-off x
+  computed today is the closest approximation to the x v0 used.
+
+Additive log decomposition:
+    ln(Bi_col_new / Bi_col_old) = ln(E_col_new / E_col_old) − ln(x_new / x_old)
+"""
+from __future__ import annotations
+
+import logging
+import os
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(message)s")
+log = logging.getLogger("decompose_d_E_x")
+
+OUT = os.path.join(os.path.dirname(__file__), "output")
+os.makedirs(OUT, exist_ok=True)
+
+from bedrock.utils.config.usa_config import set_global_usa_config
+
+set_global_usa_config("2025_usa_cornerstone_full_model")
+
+from bedrock.transform.allocation.derived import derive_E_usa
+from bedrock.transform.eeio.derived_cornerstone import (
+    derive_cornerstone_x,
+    derive_cornerstone_x_after_redefinition,
+)
+from bedrock.utils.snapshots.loader import load_configured_snapshot
+
+log.info("computing live E, both x's...")
+E_new = derive_E_usa()
+x_new = derive_cornerstone_x_after_redefinition()  # flag ON (live convention)
+x_old = derive_cornerstone_x()  # flag OFF (v0 convention approximation)
+log.info("E_new=%s  x_new=%s  x_old=%s", E_new.shape, x_new.shape, x_old.shape)
+
+log.info("loading v0 E_USA_ES snapshot...")
+E_old = load_configured_snapshot("E_USA_ES")
+log.info("E_old=%s", E_old.shape)
+
+# Reduce E to per-industry (sum over ghg rows)
+E_new_col = E_new.sum(axis=0).astype(float)
+E_old_col = E_old.sum(axis=0).astype(float)
+
+# Industry-space direct-intensity d_i = E_col_i / x_i
+idx = (
+    E_new_col.index.union(E_old_col.index).union(x_new.index).union(x_old.index)
+).sort_values()
+E_n = E_new_col.reindex(idx)
+E_o = E_old_col.reindex(idx)
+x_n = x_new.reindex(idx).astype(float)
+x_o = x_old.reindex(idx).astype(float)
+
+with np.errstate(divide="ignore", invalid="ignore"):
+    Bi_n = E_n / x_n
+    Bi_o = E_o / x_o
+    ln_Bi = np.log(Bi_n / Bi_o)
+    ln_E = np.log(E_n / E_o)
+    ln_x = np.log(x_n / x_o)
+    residual = ln_Bi - (ln_E - ln_x)
+
+tbl = pd.DataFrame(
+    {
+        "E_old": E_o,
+        "E_new": E_n,
+        "E_pct": (E_n / E_o - 1) * 100,
+        "x_old": x_o,
+        "x_new": x_n,
+        "x_pct": (x_n / x_o - 1) * 100,
+        "Bi_old": Bi_o,
+        "Bi_new": Bi_n,
+        "Bi_pct": (Bi_n / Bi_o - 1) * 100,
+        "dln_Bi": ln_Bi,
+        "dln_E": ln_E,
+        "minus_dln_x": -ln_x,
+        "residual_ln": residual,
+    },
+    index=idx,
+)
+tbl.index.name = "sector"
+tbl.to_csv(os.path.join(OUT, "d_E_x_decomposition.csv"))
+
+# Focus: 221100
+print("\n=== Sector 221100 (Electricity) — industry-space E / x decomposition ===")
+if "221100" in tbl.index:
+    r = tbl.loc["221100"]
+    print(f"  E_old             = {r['E_old']:.4e}")
+    print(f"  E_new             = {r['E_new']:.4e}   ({r['E_pct']:+.2f}%)")
+    print(f"  x_old             = {r['x_old']:.4e}")
+    print(f"  x_new             = {r['x_new']:.4e}   ({r['x_pct']:+.2f}%)")
+    print(f"  Bi_old = E/x old  = {r['Bi_old']:.4e}")
+    print(f"  Bi_new = E/x new  = {r['Bi_new']:.4e}   ({r['Bi_pct']:+.2f}%)")
+    print()
+    print(f"  Δln(Bi)     = {r['dln_Bi']:+.4f}   (= target)")
+    print(f"  Δln(E)      = {r['dln_E']:+.4f}   (E-contribution)")
+    print(f"  −Δln(x)     = {r['minus_dln_x']:+.4f}   (x-contribution)")
+    print(f"  residual    = {r['residual_ln']:+.4e}   (should be ~0)")
+    if abs(r["dln_Bi"]) > 1e-12:
+        share_E = r["dln_E"] / r["dln_Bi"] * 100
+        share_x = r["minus_dln_x"] / r["dln_Bi"] * 100
+        print(f"\n  => E drives  {share_E:+.1f}% of the Bi change")
+        print(f"  => x drives  {share_x:+.1f}% of the Bi change")
+
+# Top sectors by |Δln(Bi)|
+print("\n=== Top 15 sectors by |Δln(Bi)| (both sides present, finite) ===")
+finite: pd.DataFrame = tbl.dropna(subset=["dln_Bi", "dln_E", "minus_dln_x"]).copy()
+finite = finite.loc[np.isfinite(finite["dln_Bi"])]
+finite["abs_dln_Bi"] = finite["dln_Bi"].astype(float).abs()  # type: ignore[union-attr]
+top = finite.nlargest(15, "abs_dln_Bi")  # type: ignore[call-overload]
+print(top[["Bi_old", "Bi_new", "dln_Bi", "dln_E", "minus_dln_x", "residual_ln"]].to_string())  # type: ignore[call-overload]
+
+# Visual: per-sector stacked bar — Δln(Bi) decomposed into E and -x for top 20
+top20 = finite.nlargest(20, "abs_dln_Bi").copy()  # type: ignore[call-overload]
+fig, ax = plt.subplots(figsize=(11, 8))
+y_pos = np.arange(len(top20))
+ax.barh(y_pos, top20["dln_E"], color="tab:orange", alpha=0.85, label="Δln(E)")
+ax.barh(
+    y_pos,
+    top20["minus_dln_x"],
+    left=top20["dln_E"],
+    color="tab:purple",
+    alpha=0.85,
+    label="−Δln(x)",
+)
+ax.plot(
+    top20["dln_Bi"],
+    y_pos,
+    "k|",
+    markersize=14,
+    markeredgewidth=2,
+    label="Δln(Bi) (target)",
+)
+ax.set_yticks(y_pos)
+ax.set_yticklabels([str(s) for s in top20.index], fontsize=9)
+ax.invert_yaxis()
+ax.axvline(0, color="k", lw=0.5)
+ax.set_xlabel("log ratio (new/old)")
+ax.set_title("Decomposition of Δln(Bi) = Δln(E) − Δln(x)  — top 20 sectors by |Δln(Bi)|")
+ax.legend(loc="best")
+ax.grid(True, axis="x", ls=":", alpha=0.3)
+fig.tight_layout()
+fig.savefig(os.path.join(OUT, "d_E_x_decomposition_top20.png"), dpi=120)
+plt.close(fig)
+
+# E vs x %-change scatter
+fig, ax = plt.subplots(figsize=(7, 7))
+mask = np.isfinite(tbl["E_pct"]) & np.isfinite(tbl["x_pct"])
+ax.scatter(tbl.loc[mask, "x_pct"], tbl.loc[mask, "E_pct"], s=10, alpha=0.5)
+if "221100" in tbl.index:
+    r = tbl.loc["221100"]
+    ax.scatter([r["x_pct"]], [r["E_pct"]], s=80, color="tab:red", zorder=5, label="221100")
+    ax.annotate(
+        "221100",
+        (r["x_pct"], r["E_pct"]),
+        textcoords="offset points",
+        xytext=(8, 6),
+        color="tab:red",
+    )
+ax.axhline(0, color="k", lw=0.5)
+ax.axvline(0, color="k", lw=0.5)
+ax.set_xlabel("x % change (new/old − 1)")
+ax.set_ylabel("E % change (new/old − 1)")
+ax.set_title("Per-industry: E change vs x change (clipped)")
+ax.set_xlim(-100, 200)
+ax.set_ylim(-100, 200)
+ax.legend()
+ax.grid(True, ls=":", alpha=0.3)
+fig.tight_layout()
+fig.savefig(os.path.join(OUT, "d_E_x_scatter.png"), dpi=120)
+plt.close(fig)
+
+print(f"\nOutputs written to: {OUT}")

--- a/bedrock/analysis/baseline_snapshot_comparison/decompose_sector.py
+++ b/bedrock/analysis/baseline_snapshot_comparison/decompose_sector.py
@@ -1,0 +1,121 @@
+"""Decompose BLy drift for a single sector into d, L·y, and residual contributions."""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(message)s")
+log = logging.getLogger("decompose")
+
+SECTOR = sys.argv[1] if len(sys.argv) > 1 else "221100"
+
+from bedrock.utils.config.usa_config import set_global_usa_config
+
+set_global_usa_config("2025_usa_cornerstone_full_model")
+
+from bedrock.transform.eeio.derived import (
+    derive_Aq_usa,
+    derive_B_usa_non_finetuned,
+    derive_y_for_national_accounting_balance_usa,
+)
+from bedrock.utils.math.formulas import compute_d, compute_L_matrix
+from bedrock.utils.snapshots.loader import load_snapshot, resolve_snapshot_key
+
+snap_key = resolve_snapshot_key()
+
+log.info("computing live B, Adom, y...")
+B_new = derive_B_usa_non_finetuned()
+Adom_new = derive_Aq_usa().Adom
+y_new = derive_y_for_national_accounting_balance_usa().astype(float)
+
+log.info("loading v0 snapshot B, Adom, y...")
+B_old = load_snapshot("B_USA_non_finetuned", snap_key)
+Adom_old = load_snapshot("Adom_USA", snap_key)
+y_old_obj = load_snapshot("y_nab_USA", snap_key)
+y_old = (
+    y_old_obj.iloc[:, 0].astype(float)
+    if isinstance(y_old_obj, pd.DataFrame)
+    else y_old_obj.astype(float)
+)
+
+log.info("computing d, L, Ly, BLy for both sides...")
+d_new = compute_d(B=B_new)
+d_old = compute_d(B=B_old)
+L_new = compute_L_matrix(A=Adom_new)
+L_old = compute_L_matrix(A=Adom_old)
+Ly_new = L_new @ y_new
+Ly_old = L_old @ y_old
+BLy_new = d_new * Ly_new
+BLy_old = d_old * Ly_old
+
+
+def at(s: pd.Series, sec: str) -> float:
+    if sec in s.index:
+        return float(s.loc[sec])
+    return float("nan")
+
+
+print(f"\n=== Decomposition for sector {SECTOR} ===")
+print(f"{'metric':<22} {'old':>15} {'new':>15} {'diff':>15} {'pct':>10}")
+
+
+def row(label: str, new_v: float, old_v: float) -> None:
+    diff = new_v - old_v
+    p = (diff / old_v * 100) if old_v not in (0, float("nan")) and not np.isnan(old_v) else float("nan")
+    print(f"{label:<22} {old_v:>15.4e} {new_v:>15.4e} {diff:>15.4e} {p:>9.2f}%")
+
+
+row("y_j", at(y_new, SECTOR), at(y_old, SECTOR))
+row("d_j (direct int.)", at(d_new, SECTOR), at(d_old, SECTOR))
+row("(Ly)_j (total out.)", at(Ly_new, SECTOR), at(Ly_old, SECTOR))
+row("BLy_j = d_j·(Ly)_j", at(BLy_new, SECTOR), at(BLy_old, SECTOR))
+
+# Counterfactuals: hold one side fixed at old, move only the other
+try:
+    d_o = at(d_old, SECTOR)
+    d_n = at(d_new, SECTOR)
+    ly_o = at(Ly_old, SECTOR)
+    ly_n = at(Ly_new, SECTOR)
+    bly_o = d_o * ly_o
+    bly_n = d_n * ly_n
+    only_d = d_n * ly_o
+    only_ly = d_o * ly_n
+    delta_total = bly_n - bly_o
+    delta_from_d = only_d - bly_o
+    delta_from_ly = only_ly - bly_o
+    interaction = delta_total - delta_from_d - delta_from_ly
+    print("\n=== Contribution decomposition (BLy_new - BLy_old) ===")
+    print(f"  from d change alone:       {delta_from_d:>15.4e}  ({delta_from_d / delta_total * 100 if delta_total else 0:>6.1f}%)")
+    print(f"  from (Ly) change alone:    {delta_from_ly:>15.4e}  ({delta_from_ly / delta_total * 100 if delta_total else 0:>6.1f}%)")
+    print(f"  interaction term:          {interaction:>15.4e}  ({interaction / delta_total * 100 if delta_total else 0:>6.1f}%)")
+    print(f"  total:                     {delta_total:>15.4e}")
+except Exception as e:
+    log.warning("decomposition failed: %s", e)
+
+# What drives (Ly)_j? It's row j of L times y. Break into L contribution vs y contribution.
+# (Ly_new - Ly_old)_j = sum_k (L_new[j,k] * y_new[k] - L_old[j,k] * y_old[k])
+if SECTOR in L_new.index and SECTOR in L_old.index:
+    common_k = y_new.index.intersection(y_old.index).intersection(L_new.columns).intersection(L_old.columns)
+    ly_diff_per_k = pd.Series(
+        L_new.loc[SECTOR, common_k].astype(float).to_numpy() * y_new.loc[common_k].to_numpy()
+        - L_old.loc[SECTOR, common_k].astype(float).to_numpy() * y_old.loc[common_k].to_numpy(),
+        index=common_k,
+        name="Ly_diff_contribution",
+    )
+    print(f"\n=== Top 10 upstream sectors k driving Δ(Ly)_{SECTOR} ===")
+    top_k = ly_diff_per_k.reindex(ly_diff_per_k.abs().sort_values(ascending=False).index).head(10)
+    print(top_k.to_string())
+
+OUT = os.path.join(os.path.dirname(__file__), "output")
+os.makedirs(OUT, exist_ok=True)
+with open(os.path.join(OUT, f"decompose_{SECTOR}.txt"), "w") as f:
+    f.write(f"Decomposition for {SECTOR}\n")
+    f.write(f"y:  old={at(y_old, SECTOR):.6e}  new={at(y_new, SECTOR):.6e}\n")
+    f.write(f"d:  old={at(d_old, SECTOR):.6e}  new={at(d_new, SECTOR):.6e}\n")
+    f.write(f"Ly: old={at(Ly_old, SECTOR):.6e}  new={at(Ly_new, SECTOR):.6e}\n")
+    f.write(f"BLy: old={at(BLy_old, SECTOR):.6e}  new={at(BLy_new, SECTOR):.6e}\n")
+print(f"\nSummary text written to {OUT}/decompose_{SECTOR}.txt")

--- a/bedrock/analysis/baseline_snapshot_comparison/decompose_sector.py
+++ b/bedrock/analysis/baseline_snapshot_comparison/decompose_sector.py
@@ -1,4 +1,5 @@
 """Decompose BLy drift for a single sector into d, L·y, and residual contributions."""
+
 from __future__ import annotations
 
 import logging
@@ -8,41 +9,44 @@ import sys
 import numpy as np
 import pandas as pd
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(message)s")
-log = logging.getLogger("decompose")
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(name)s %(message)s')
+log = logging.getLogger('decompose')
 
-SECTOR = sys.argv[1] if len(sys.argv) > 1 else "221100"
+SECTOR = sys.argv[1] if len(sys.argv) > 1 else '221100'
 
-from bedrock.utils.config.usa_config import set_global_usa_config
+from bedrock.utils.config.usa_config import set_global_usa_config  # noqa: E402
 
-set_global_usa_config("2025_usa_cornerstone_full_model")
+set_global_usa_config('2025_usa_cornerstone_full_model')
 
-from bedrock.transform.eeio.derived import (
+from bedrock.transform.eeio.derived import (  # noqa: E402
     derive_Aq_usa,
     derive_B_usa_non_finetuned,
     derive_y_for_national_accounting_balance_usa,
 )
-from bedrock.utils.math.formulas import compute_d, compute_L_matrix
-from bedrock.utils.snapshots.loader import load_snapshot, resolve_snapshot_key
+from bedrock.utils.math.formulas import compute_d, compute_L_matrix  # noqa: E402
+from bedrock.utils.snapshots.loader import (  # noqa: E402
+    load_snapshot,
+    resolve_snapshot_key,
+)
 
 snap_key = resolve_snapshot_key()
 
-log.info("computing live B, Adom, y...")
+log.info('computing live B, Adom, y...')
 B_new = derive_B_usa_non_finetuned()
 Adom_new = derive_Aq_usa().Adom
 y_new = derive_y_for_national_accounting_balance_usa().astype(float)
 
-log.info("loading v0 snapshot B, Adom, y...")
-B_old = load_snapshot("B_USA_non_finetuned", snap_key)
-Adom_old = load_snapshot("Adom_USA", snap_key)
-y_old_obj = load_snapshot("y_nab_USA", snap_key)
+log.info('loading v0 snapshot B, Adom, y...')
+B_old = load_snapshot('B_USA_non_finetuned', snap_key)
+Adom_old = load_snapshot('Adom_USA', snap_key)
+y_old_obj = load_snapshot('y_nab_USA', snap_key)
 y_old = (
     y_old_obj.iloc[:, 0].astype(float)
     if isinstance(y_old_obj, pd.DataFrame)
     else y_old_obj.astype(float)
 )
 
-log.info("computing d, L, Ly, BLy for both sides...")
+log.info('computing d, L, Ly, BLy for both sides...')
 d_new = compute_d(B=B_new)
 d_old = compute_d(B=B_old)
 L_new = compute_L_matrix(A=Adom_new)
@@ -56,23 +60,27 @@ BLy_old = d_old * Ly_old
 def at(s: pd.Series, sec: str) -> float:
     if sec in s.index:
         return float(s.loc[sec])
-    return float("nan")
+    return float('nan')
 
 
-print(f"\n=== Decomposition for sector {SECTOR} ===")
-print(f"{'metric':<22} {'old':>15} {'new':>15} {'diff':>15} {'pct':>10}")
+print(f'\n=== Decomposition for sector {SECTOR} ===')
+print(f'{"metric":<22} {"old":>15} {"new":>15} {"diff":>15} {"pct":>10}')
 
 
 def row(label: str, new_v: float, old_v: float) -> None:
     diff = new_v - old_v
-    p = (diff / old_v * 100) if old_v not in (0, float("nan")) and not np.isnan(old_v) else float("nan")
-    print(f"{label:<22} {old_v:>15.4e} {new_v:>15.4e} {diff:>15.4e} {p:>9.2f}%")
+    p = (
+        (diff / old_v * 100)
+        if old_v not in (0, float('nan')) and not np.isnan(old_v)
+        else float('nan')
+    )
+    print(f'{label:<22} {old_v:>15.4e} {new_v:>15.4e} {diff:>15.4e} {p:>9.2f}%')
 
 
-row("y_j", at(y_new, SECTOR), at(y_old, SECTOR))
-row("d_j (direct int.)", at(d_new, SECTOR), at(d_old, SECTOR))
-row("(Ly)_j (total out.)", at(Ly_new, SECTOR), at(Ly_old, SECTOR))
-row("BLy_j = d_j·(Ly)_j", at(BLy_new, SECTOR), at(BLy_old, SECTOR))
+row('y_j', at(y_new, SECTOR), at(y_old, SECTOR))
+row('d_j (direct int.)', at(d_new, SECTOR), at(d_old, SECTOR))
+row('(Ly)_j (total out.)', at(Ly_new, SECTOR), at(Ly_old, SECTOR))
+row('BLy_j = d_j·(Ly)_j', at(BLy_new, SECTOR), at(BLy_old, SECTOR))
 
 # Counterfactuals: hold one side fixed at old, move only the other
 try:
@@ -88,34 +96,49 @@ try:
     delta_from_d = only_d - bly_o
     delta_from_ly = only_ly - bly_o
     interaction = delta_total - delta_from_d - delta_from_ly
-    print("\n=== Contribution decomposition (BLy_new - BLy_old) ===")
-    print(f"  from d change alone:       {delta_from_d:>15.4e}  ({delta_from_d / delta_total * 100 if delta_total else 0:>6.1f}%)")
-    print(f"  from (Ly) change alone:    {delta_from_ly:>15.4e}  ({delta_from_ly / delta_total * 100 if delta_total else 0:>6.1f}%)")
-    print(f"  interaction term:          {interaction:>15.4e}  ({interaction / delta_total * 100 if delta_total else 0:>6.1f}%)")
-    print(f"  total:                     {delta_total:>15.4e}")
+    print('\n=== Contribution decomposition (BLy_new - BLy_old) ===')
+    print(
+        f'  from d change alone:       {delta_from_d:>15.4e}  ({delta_from_d / delta_total * 100 if delta_total else 0:>6.1f}%)'
+    )
+    print(
+        f'  from (Ly) change alone:    {delta_from_ly:>15.4e}  ({delta_from_ly / delta_total * 100 if delta_total else 0:>6.1f}%)'
+    )
+    print(
+        f'  interaction term:          {interaction:>15.4e}  ({interaction / delta_total * 100 if delta_total else 0:>6.1f}%)'
+    )
+    print(f'  total:                     {delta_total:>15.4e}')
 except Exception as e:
-    log.warning("decomposition failed: %s", e)
+    log.warning('decomposition failed: %s', e)
 
 # What drives (Ly)_j? It's row j of L times y. Break into L contribution vs y contribution.
 # (Ly_new - Ly_old)_j = sum_k (L_new[j,k] * y_new[k] - L_old[j,k] * y_old[k])
 if SECTOR in L_new.index and SECTOR in L_old.index:
-    common_k = y_new.index.intersection(y_old.index).intersection(L_new.columns).intersection(L_old.columns)
-    ly_diff_per_k = pd.Series(
-        L_new.loc[SECTOR, common_k].astype(float).to_numpy() * y_new.loc[common_k].to_numpy()
-        - L_old.loc[SECTOR, common_k].astype(float).to_numpy() * y_old.loc[common_k].to_numpy(),
-        index=common_k,
-        name="Ly_diff_contribution",
+    common_k = (
+        y_new.index.intersection(y_old.index)
+        .intersection(L_new.columns)
+        .intersection(L_old.columns)
     )
-    print(f"\n=== Top 10 upstream sectors k driving Δ(Ly)_{SECTOR} ===")
-    top_k = ly_diff_per_k.reindex(ly_diff_per_k.abs().sort_values(ascending=False).index).head(10)
+    L_new_row = L_new.loc[SECTOR].reindex(common_k).astype(float).to_numpy()
+    L_old_row = L_old.loc[SECTOR].reindex(common_k).astype(float).to_numpy()
+    y_new_k = y_new.reindex(common_k).to_numpy()
+    y_old_k = y_old.reindex(common_k).to_numpy()
+    ly_diff_per_k = pd.Series(
+        L_new_row * y_new_k - L_old_row * y_old_k,
+        index=common_k,
+        name='Ly_diff_contribution',
+    )
+    print(f'\n=== Top 10 upstream sectors k driving Δ(Ly)_{SECTOR} ===')
+    top_k = ly_diff_per_k.reindex(
+        ly_diff_per_k.abs().sort_values(ascending=False).index
+    ).head(10)
     print(top_k.to_string())
 
-OUT = os.path.join(os.path.dirname(__file__), "output")
+OUT = os.path.join(os.path.dirname(__file__), 'output')
 os.makedirs(OUT, exist_ok=True)
-with open(os.path.join(OUT, f"decompose_{SECTOR}.txt"), "w") as f:
-    f.write(f"Decomposition for {SECTOR}\n")
-    f.write(f"y:  old={at(y_old, SECTOR):.6e}  new={at(y_new, SECTOR):.6e}\n")
-    f.write(f"d:  old={at(d_old, SECTOR):.6e}  new={at(d_new, SECTOR):.6e}\n")
-    f.write(f"Ly: old={at(Ly_old, SECTOR):.6e}  new={at(Ly_new, SECTOR):.6e}\n")
-    f.write(f"BLy: old={at(BLy_old, SECTOR):.6e}  new={at(BLy_new, SECTOR):.6e}\n")
-print(f"\nSummary text written to {OUT}/decompose_{SECTOR}.txt")
+with open(os.path.join(OUT, f'decompose_{SECTOR}.txt'), 'w') as f:
+    f.write(f'Decomposition for {SECTOR}\n')
+    f.write(f'y:  old={at(y_old, SECTOR):.6e}  new={at(y_new, SECTOR):.6e}\n')
+    f.write(f'd:  old={at(d_old, SECTOR):.6e}  new={at(d_new, SECTOR):.6e}\n')
+    f.write(f'Ly: old={at(Ly_old, SECTOR):.6e}  new={at(Ly_new, SECTOR):.6e}\n')
+    f.write(f'BLy: old={at(BLy_old, SECTOR):.6e}  new={at(BLy_new, SECTOR):.6e}\n')
+print(f'\nSummary text written to {OUT}/decompose_{SECTOR}.txt')


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

Added four ad-hoc analysis scripts under `bedrock/analysis/baseline_snapshot_comparison/` for diagnosing drift between live-derived matrices and the v0 baseline snapshot under `2025_usa_cornerstone_full_model`:

- `compare_B_Adom.py` — live vs snapshot `B` and `Adom` (column-sum scatter, heatmap, top-20 diffs).
- `compare_y.py` — live vs snapshot `y` (`derive_y_for_national_accounting_balance_usa`): scatter, top-20 levels/diffs/%.
- `decompose_d_E_x.py` — additive log decomposition of `ln(Bi_col_new / Bi_col_old)` into `E` and `x` contributions (flag-on vs flag-off `x`).
- `decompose_sector.py` — per-sector `BLy` drift decomposition into `d`, `L·y`, and residual contributions (defaults to sector `221100`).

Outputs (`output/*.png`, `*.csv`, `*.txt`) are gitignored.

## Testing

scripts are standalone diagnostics; verified by running each and inspecting outputs