### PR TITLE
Add EF diagnostics analysis plots package

### DIFF
--- a/bedrock/utils/io/gcp.py
+++ b/bedrock/utils/io/gcp.py
@@ -176,6 +176,33 @@ def __sheets_client() -> googleapiclient.discovery.Resource:
     return googleapiclient.discovery.build('sheets', 'v4', credentials=credentials)
 
 
+def read_sheet_tab(sheet_id: str, tab: str) -> pd.DataFrame:
+    """
+    Read a Google Sheets tab into a DataFrame.
+
+    The first row is used as column headers. All cells come back as strings —
+    callers that need numeric types should coerce column-wise.
+
+    Args:
+        sheet_id: The Google Sheets document ID
+        tab: The name of the tab to read
+    """
+    client = __sheets_client()
+    result = (
+        client.spreadsheets()
+        .values()
+        .get(spreadsheetId=sheet_id, range=f"'{tab}'")
+        .execute()
+    )
+    values = result.get("values", [])
+    if not values:
+        return pd.DataFrame()
+    header, *rows = values
+    width = len(header)
+    normalized = [row + [""] * (width - len(row)) for row in rows]
+    return pd.DataFrame(normalized, columns=header)
+
+
 def update_sheet_tab(
     sheet_id: str,
     tab: str,

--- a/bedrock/utils/validation/analysis/.gitignore
+++ b/bedrock/utils/validation/analysis/.gitignore
@@ -1,0 +1,4 @@
+output/
+.cache/
+.DS_Store
+__pycache__/

--- a/bedrock/utils/validation/analysis/README.md
+++ b/bedrock/utils/validation/analysis/README.md
@@ -1,0 +1,44 @@
+# validation/analysis
+
+Post-run analysis and plotting for diagnostics produced by
+`bedrock/utils/validation/generate_diagnostics.py`.
+
+The producer side writes results (N, D, significant sectors, etc.) to a
+Google Sheet. This package is the consumer side: it loads those tabs
+back, caches them locally as parquet, and renders analysis figures.
+
+## Layout
+
+- `plotting.py` — shared matplotlib primitives (percent histogram, absolute-change
+  histogram, reference lines, styled text boxes).
+- `fetch.py` — `load_tab` / `load_tabs` read Sheet tabs via
+  `bedrock.utils.io.gcp.read_sheet_tab`, coerce numerics, and cache as parquet
+  under `.cache/<sheet_id>/<tab>.parquet`.
+- `_cli.py` — shared click options (`--sheet-id`, `--refresh`, `--tag`,
+  `--out-dir`) and output-dir resolution.
+- `ef_plots.py` — produces four PNGs in one run:
+  - `ef_perc_diff_histogram.png` — 2×2 N/D percent-diff distributions
+    (all sectors + significant sectors)
+  - `ef_n_perc_diff_histogram.png` — standalone N percent-diff distribution
+    (all sectors)
+  - `ef_pct_change_vs_abs_change.png` — |% change| vs |absolute change|
+  - `ef_pct_change_vs_ef_size.png` — |% change| vs old EF size
+  - `ef_abs_change_histogram.png` — distribution of absolute EF changes
+
+## Running
+
+```bash
+uv run python -m bedrock.utils.validation.analysis.ef_plots \
+    --sheet-id <google_sheet_id> [--refresh] [--tag <label>] [--out-dir <path>]
+```
+
+`--sheet-id` falls back to the `BEDROCK_DIAGNOSTICS_SHEET_ID` environment
+variable, so you can set it once and omit the flag on subsequent runs:
+
+```bash
+export BEDROCK_DIAGNOSTICS_SHEET_ID=1Qa...
+uv run python -m bedrock.utils.validation.analysis.ef_plots --tag my-run
+```
+
+Outputs default to `analysis/output/<tag>/`; the parquet cache lives at
+`analysis/.cache/<sheet_id>/`. Pass `--refresh` to bypass the cache.

--- a/bedrock/utils/validation/analysis/_cli.py
+++ b/bedrock/utils/validation/analysis/_cli.py
@@ -1,0 +1,97 @@
+"""Shared CLI options + path helpers for analysis plot commands.
+
+Every script exposes the same flags (``--baseline``, ``--sheet-id``,
+``--refresh``, ``--tag``, ``--out-dir``) via ``common_options``. The
+sheet-id resolver picks from (in order): ``--sheet-id``, ``--baseline``
+lookup in ``baselines.BASELINES``, then ``$BEDROCK_DIAGNOSTICS_SHEET_ID``.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, TypeVar
+
+import click
+
+from .baselines import BASELINES
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+_OUTPUT_ROOT = Path(__file__).resolve().parent / "output"
+_SHEET_ID_ENV = "BEDROCK_DIAGNOSTICS_SHEET_ID"
+
+
+def common_options(func: F) -> F:
+    """Apply the shared click options to ``func``."""
+    func = click.option(
+        "--out-dir",
+        type=click.Path(file_okay=False, path_type=Path),
+        default=None,
+        help="Override output directory. Defaults to analysis/output/<tag>/",
+    )(func)
+    func = click.option(
+        "--tag",
+        type=str,
+        default=None,
+        help=(
+            "Label for output dir + figure titles. Defaults to --baseline "
+            "name, else first 12 chars of --sheet-id."
+        ),
+    )(func)
+    func = click.option(
+        "--refresh",
+        is_flag=True,
+        default=False,
+        help="Force re-fetch from Google Sheets, overwriting the parquet cache.",
+    )(func)
+    func = click.option(
+        "--sheet-id",
+        required=False,
+        default=None,
+        type=str,
+        help=(
+            "Google Sheet ID (string between /d/ and /edit in the sheet URL). "
+            "Takes precedence over --baseline."
+        ),
+    )(func)
+    func = click.option(
+        "--baseline",
+        required=False,
+        default=None,
+        type=click.Choice(list(BASELINES)),
+        help=(
+            "Registered baseline name — looked up in baselines.BASELINES. "
+            f"Falls back to ${_SHEET_ID_ENV} when neither --baseline nor "
+            "--sheet-id is given."
+        ),
+    )(func)
+    return func
+
+
+def resolve_sheet_id(sheet_id: str | None, baseline: str | None) -> str:
+    """Resolve a sheet id from (priority order) ``--sheet-id``, ``--baseline``, env var."""
+    if sheet_id:
+        return sheet_id
+    if baseline:
+        return BASELINES[baseline]
+    from_env = os.environ.get(_SHEET_ID_ENV)
+    if from_env:
+        return from_env
+    raise click.UsageError(
+        f"One of --sheet-id, --baseline, or ${_SHEET_ID_ENV} is required."
+    )
+
+
+def resolve_output_dir(
+    sheet_id: str,
+    tag: str | None,
+    out_dir: Path | None,
+    baseline: str | None = None,
+) -> tuple[str, Path]:
+    """Return a (tag, output_dir) pair, creating the directory if needed."""
+    resolved_tag = tag or baseline or sheet_id[:12]
+    resolved_dir = out_dir if out_dir else _OUTPUT_ROOT / resolved_tag
+    resolved_dir.mkdir(parents=True, exist_ok=True)
+    return resolved_tag, resolved_dir

--- a/bedrock/utils/validation/analysis/baselines.py
+++ b/bedrock/utils/validation/analysis/baselines.py
@@ -1,0 +1,16 @@
+"""Registered diagnostics baselines: friendly name → Google Sheet ID.
+
+Shared, long-lived comparison sheets. Each entry points at a diagnostics
+sheet comparing current Cornerstone outputs against a named baseline
+(CEDA-US, USEEIO, etc.). Extend as new reference runs are produced.
+
+For ad-hoc or per-PR sheets, pass ``--sheet-id`` directly or set the
+``BEDROCK_DIAGNOSTICS_SHEET_ID`` environment variable instead.
+"""
+
+from __future__ import annotations
+
+BASELINES: dict[str, str] = {
+    "ceda": "1pCSgLD14lmrQg3OtfHvnK4lQrFtqiavrjCt-C3R_bSw",
+    "useeio": "1WjEMhfJw_Z62sGffoLFSJoZtC112IDtjA9Ak7H8PUVQ",
+}

--- a/bedrock/utils/validation/analysis/ef_plots.py
+++ b/bedrock/utils/validation/analysis/ef_plots.py
@@ -1,0 +1,540 @@
+"""EF analysis plots from diagnostics Google Sheets.
+
+Reads the ``N_and_diffs``, ``D_and_diffs``, and ``D_and_N_significant_sectors``
+tabs and renders:
+
+- ``ef_perc_diff_histogram.png``     — 2×2 N/D percent-diff distributions
+                                       (all sectors + significant sectors)
+- ``ef_pct_change_vs_abs_change.png`` — |% change| vs |absolute change|
+- ``ef_pct_change_vs_ef_size.png``    — |% change| vs old EF size
+- ``ef_abs_change_histogram.png``     — distribution of absolute EF changes
+
+Usage:
+    uv run python -m bedrock.utils.validation.analysis.ef_plots \\
+        --sheet-id <google_sheet_id> [--refresh] [--tag <label>] [--out-dir <path>]
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Hashable
+
+import click
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from matplotlib.figure import Figure
+
+from ._cli import common_options, resolve_output_dir, resolve_sheet_id
+from .fetch import load_tab, load_tabs_optional
+from .plotting import (
+    DEFAULT_XLIM,
+    abs_change_histogram,
+    dodge_annotations,
+    percent_histogram,
+    save_and_close,
+    setup_mpl,
+)
+
+TAB_N = "N_and_diffs"
+TAB_D = "D_and_diffs"
+TAB_SIG = "D_and_N_significant_sectors"
+
+OUTLIER_COLOR = "#d32f2f"
+POINT_COLOR = "#546e7a"
+TITLE_FONTSIZE = 20
+AXIS_LABEL_FONTSIZE = 16
+TICK_FONTSIZE = 13
+TEXT_BOX_FONTSIZE = 11
+LEGEND_FONTSIZE = 13
+SINGLE_PANEL_FIGSIZE = (14, 10)
+
+
+def _apply_axis_fonts(ax: Any) -> None:
+    """Apply the shared axis-label and tick font sizes."""
+    ax.xaxis.label.set_fontsize(AXIS_LABEL_FONTSIZE)
+    ax.yaxis.label.set_fontsize(AXIS_LABEL_FONTSIZE)
+    ax.tick_params(axis="both", labelsize=TICK_FONTSIZE)
+
+
+def _add_outlier_box(ax: Any, text: str) -> Any:
+    """Anchor a left-aligned, translucent outlier box in the upper-right corner.
+
+    Matches the abs-change histogram's outlier-box styling so all plots share
+    a consistent look — wheat background at low opacity, monospaced,
+    left-multialigned lines. Returns the artist so callers can pass it as an
+    ``avoid`` region to ``dodge_annotations``.
+    """
+    return ax.text(
+        0.98,
+        0.98,
+        text,
+        transform=ax.transAxes,
+        fontsize=TEXT_BOX_FONTSIZE,
+        verticalalignment="top",
+        horizontalalignment="right",
+        multialignment="left",
+        fontfamily="monospace",
+        bbox=dict(boxstyle="round,pad=0.4", facecolor="wheat", alpha=0.35),
+    )
+
+
+def _sector_label(sector: Any, sector_name: str, width: int = 20) -> str:
+    name = (
+        sector_name if len(sector_name) <= width else sector_name[: width - 3] + "..."
+    )
+    return f"{sector} ({name})"
+
+
+def _drop_old_only(df: pd.DataFrame) -> pd.DataFrame:
+    if "comparison_type" in df.columns:
+        return df[~df["comparison_type"].astype(str).str.startswith("old-only")]
+    return df
+
+
+def _normalize_schema(df: pd.DataFrame) -> pd.DataFrame:
+    """Canonicalize the sector-code column name across sheet variants.
+
+    Some tabs (e.g. USEEIO) use ``index`` as the sector-code column instead
+    of ``sector``. Rename so downstream code can assume ``sector`` exists.
+    """
+    if "sector" not in df.columns and "index" in df.columns:
+        df = df.rename(columns={"index": "sector"})
+    return df
+
+
+def _normalize_perc_diff(df: pd.DataFrame, prefix: str) -> pd.DataFrame:
+    """Normalize a ``<prefix>_perc_diff`` column to numeric fractions.
+
+    Tolerates the legacy ``<prefix>_no_manual_adj_perc_diff`` column
+    (percent-string) by routing it to the canonical ``<prefix>_perc_diff``.
+    """
+    target = f"{prefix}_perc_diff"
+    source = (
+        f"{prefix}_no_manual_adj_perc_diff"
+        if f"{prefix}_no_manual_adj_perc_diff" in df.columns
+        else target
+    )
+    out = df.copy()
+    out[target] = out[source].map(_parse_pct)
+    return out
+
+
+# ---------- N/D percent-diff histogram ----------
+
+
+def _format_sector_line(row: "pd.Series[Any]", val_col: str) -> str:
+    name = str(row.get("sector_name", "") or "")
+    sector = str(row.get("sector", "") or "")
+    return f"{_sector_label(sector, name)}: {float(row[val_col]) * 100:+.1f}%"
+
+
+_BEYOND_20_MAX_SHOWN = 30
+
+
+def _beyond_20_text(
+    df: pd.DataFrame,
+    filter_col: str,
+    *,
+    show_col: str | None = None,
+    label: str = "Beyond ±20%",
+) -> str:
+    """Render a ``Beyond ±20%`` summary, capped at ``_BEYOND_20_MAX_SHOWN`` rows.
+
+    Filters by ``|df[filter_col]| > 0.20``, sorts by ``|filter_col|``
+    descending, and shows ``show_col`` (defaults to ``filter_col``) for each
+    row. The header reports the true total when the list is truncated.
+    """
+    show = show_col or filter_col
+    beyond = df[df[filter_col].abs() > 0.20].copy()
+    if beyond.empty:
+        return f"{label}: None"
+    beyond = beyond.sort_values(filter_col, key=lambda s: s.abs(), ascending=False)
+    shown = beyond.head(_BEYOND_20_MAX_SHOWN)
+    lines = [_format_sector_line(row, show) for _, row in shown.iterrows()]
+    total = len(beyond)
+    header = (
+        f"{label} ({total}):"
+        if total <= _BEYOND_20_MAX_SHOWN
+        else f"{label} ({total} total; top {_BEYOND_20_MAX_SHOWN} by |%| shown):"
+    )
+    return header + "\n" + "\n".join(lines)
+
+
+def plot_ef_perc_diff_histogram(
+    df_n: pd.DataFrame,
+    df_d: pd.DataFrame,
+    df_sig: pd.DataFrame | None = None,
+) -> Figure:
+    """N/D percent-diff histograms. 2×2 when ``df_sig`` is given, else 1×2."""
+    n_y = "N_perc_diff"
+    d_y = "D_perc_diff"
+
+    df_n = _normalize_perc_diff(df_n, "N")
+    df_d = _normalize_perc_diff(df_d, "D")
+    if df_sig is not None:
+        df_sig = _normalize_perc_diff(_normalize_perc_diff(df_sig, "N"), "D")
+
+    df_merged = df_n[["sector", "sector_name", n_y]].merge(
+        df_d[["sector", d_y]], on="sector", how="inner"
+    )
+    d_text_all = _beyond_20_text(
+        df_merged, n_y, show_col=d_y, label="N beyond ±20% — D"
+    )
+
+    panels: list[tuple[int, int, pd.DataFrame, str, str, str | None]] = [
+        (0, 0, df_n, n_y, "N distribution: all sectors", None),
+        (0, 1, df_d, d_y, "D distribution: all sectors", d_text_all),
+    ]
+    n_rows = 1
+    if df_sig is not None:
+        d_text_sig = _beyond_20_text(
+            df_sig, n_y, show_col=d_y, label="N beyond ±20% — D"
+        )
+        panels.extend(
+            [
+                (1, 0, df_sig, n_y, "N distribution: significant sectors", None),
+                (1, 1, df_sig, d_y, "D distribution: significant sectors", d_text_sig),
+            ]
+        )
+        n_rows = 2
+
+    fig, axes_raw = plt.subplots(n_rows, 2, figsize=(18, 7 * n_rows), squeeze=False)
+    axes = axes_raw
+    for r, c, df, y_col, title, text_override in panels:
+        text = (
+            text_override if text_override is not None else _beyond_20_text(df, y_col)
+        )
+        percent_histogram(
+            axes[r, c],
+            df[y_col].dropna() * 100,
+            xlim=DEFAULT_XLIM,
+            xlabel="Percentage Diff (%)",
+            ylabel="Count",
+            title=title,
+            text_box=text,
+            text_box_fontsize=TEXT_BOX_FONTSIZE,
+            legend_fontsize=LEGEND_FONTSIZE,
+        )
+        axes[r, c].title.set_fontsize(TITLE_FONTSIZE)
+        _apply_axis_fonts(axes[r, c])
+    ylim_max = max(axes[r, c].get_ylim()[1] for r in range(n_rows) for c in range(2))
+    for r in range(n_rows):
+        for c in range(2):
+            axes[r, c].set_ylim(0, ylim_max)
+    fig.tight_layout()
+    return fig
+
+
+def plot_n_perc_diff_histogram(df_n: pd.DataFrame) -> Figure:
+    """Standalone histogram of N percent-diff across all sectors."""
+    df_n = _normalize_perc_diff(df_n, "N")
+    y_col = "N_perc_diff"
+    text = _beyond_20_text(df_n, y_col)
+
+    fig, ax = plt.subplots(figsize=SINGLE_PANEL_FIGSIZE)
+    percent_histogram(
+        ax,
+        df_n[y_col].dropna() * 100,
+        xlim=DEFAULT_XLIM,
+        xlabel="Percentage Diff (%)",
+        ylabel="Count",
+        title="Distribution of Percentage (%) EF Changes",
+        text_box=text,
+        text_box_fontsize=11,
+        legend_fontsize=13,
+    )
+    ax.title.set_fontsize(TITLE_FONTSIZE)
+    _apply_axis_fonts(ax)
+    fig.tight_layout()
+    return fig
+
+
+# ---------- EF comparison table + scatter/abs-change plots ----------
+
+
+def _parse_pct(v: Any) -> float:
+    """Parse a percent cell that may be a float fraction or a ``"X%"`` string."""
+    if pd.isna(v):
+        return float("nan")
+    if isinstance(v, str):
+        s = v.strip().rstrip("%")
+        try:
+            return float(s) / 100.0
+        except ValueError:
+            return float("nan")
+    return float(v)
+
+
+def build_ef_comparison(df_n: pd.DataFrame) -> pd.DataFrame:
+    """Reshape ``N_and_diffs`` into a sector-indexed EF comparison table.
+
+    Tolerates the legacy ``N_no_manual_adj_*`` column variant. Returns
+    columns: ``ef_new``, ``ef_old``, ``ef_change``, ``ef_pct_change``,
+    ``sector_name``. ``df_n`` should already have old-only rows dropped.
+    """
+    if "N_no_manual_adj_perc_diff" in df_n.columns:
+        old_col = "N_no_manual_adj_old_inflated"
+        pct_col = "N_no_manual_adj_perc_diff"
+    else:
+        old_col = "N_old_inflated"
+        pct_col = "N_perc_diff"
+
+    sector_key = df_n["sector"].astype("string").fillna(df_n["sector_name"].astype(str))
+    out = pd.DataFrame(
+        {
+            "ef_new": df_n["N_new"].astype(float).to_numpy(),
+            "ef_old": df_n[old_col].astype(float).to_numpy(),
+            "ef_pct_change": df_n[pct_col].map(_parse_pct).to_numpy(),
+            "sector_name": df_n.get("sector_name", sector_key).astype(str).to_numpy(),
+        },
+        index=pd.Index(sector_key.astype(str), name="sector"),
+    )
+    out["ef_change"] = out["ef_new"] - out["ef_old"]
+    out["ef_pct_change"] = out["ef_pct_change"].replace([np.inf, -np.inf], np.nan)
+    return out
+
+
+def plot_ef_pct_change_vs_abs_change(
+    ef_comparison: pd.DataFrame,
+    *,
+    top_n_labels: int = 8,
+    xlim_cap: float = 1.0,
+    ylim_cap: float = 100.0,
+) -> Figure:
+    """Scatter: |absolute EF change| vs |% EF change|.
+
+    Answers: do big % changes correspond to big or small absolute changes?
+    """
+    sd = ef_comparison.dropna(subset=["ef_pct_change"]).copy()
+    sd["_abs_change"] = sd["ef_change"].abs()
+    sd["_abs_pct"] = sd["ef_pct_change"].abs()
+
+    fig, ax = plt.subplots(figsize=SINGLE_PANEL_FIGSIZE)
+    ax.scatter(
+        sd["_abs_change"],
+        sd["_abs_pct"] * 100,
+        s=40,
+        c=POINT_COLOR,
+        alpha=0.6,
+        edgecolors="k",
+        linewidths=0.4,
+    )
+
+    on_chart = sd[(sd["_abs_change"] <= xlim_cap) & (sd["_abs_pct"] * 100 <= ylim_cap)]
+    outliers = sd[(sd["_abs_change"] > xlim_cap) | (sd["_abs_pct"] * 100 > ylim_cap)]
+
+    to_label_idx = set(on_chart.nlargest(top_n_labels, "_abs_pct").index) | set(
+        on_chart.nlargest(top_n_labels, "_abs_change").index
+    )
+    label_items = [
+        (
+            float(row["_abs_change"]),
+            float(row["_abs_pct"]) * 100,
+            _sector_label(sector, str(row["sector_name"])),
+        )
+        for sector, row in on_chart.loc[list(to_label_idx)].iterrows()
+    ]
+
+    outlier_artist = None
+    if not outliers.empty:
+        lines = [f"Outliers ({len(outliers)} off-chart):"]
+        for sector, row in outliers.sort_values("_abs_pct", ascending=False).iterrows():
+            lines.append(
+                f"  {_sector_label(sector, str(row['sector_name']), width=25)}:"
+                f" |Δ|={row['_abs_change']:.2f}, |%|={row['_abs_pct'] * 100:.0f}%"
+            )
+        outlier_artist = _add_outlier_box(ax, "\n".join(lines))
+
+    ax.set_xlim(0, xlim_cap)
+    ax.set_ylim(0, ylim_cap * 1.08)
+    ax.set_xlabel("|EF Absolute Change| (kgCO2e/$)")
+    ax.set_ylabel("|EF % Change|")
+    ax.set_title("EF % Change vs EF Absolute Change", fontsize=TITLE_FONTSIZE, pad=12)
+    _apply_axis_fonts(ax)
+    ax.grid(alpha=0.2)
+    fig.tight_layout()
+    dodge_annotations(
+        ax, label_items, avoid=[outlier_artist] if outlier_artist else None
+    )
+    return fig
+
+
+def plot_ef_pct_change_vs_ef_size(
+    ef_comparison: pd.DataFrame,
+    *,
+    top_n_labels: int = 8,
+    ylim_cap: float = 100.0,
+    pct_threshold: float = 10.0,
+) -> Figure:
+    """Scatter: old EF size vs |% EF change|.
+
+    Answers: do big % changes happen on large or small EFs?
+    """
+    sd = ef_comparison.dropna(subset=["ef_pct_change"]).copy()
+    sd["_abs_change"] = sd["ef_change"].abs()
+    sd["_abs_pct"] = sd["ef_pct_change"].abs()
+
+    fig, ax = plt.subplots(figsize=SINGLE_PANEL_FIGSIZE)
+    ax.scatter(
+        sd["ef_old"],
+        sd["_abs_pct"] * 100,
+        s=40,
+        c=POINT_COLOR,
+        alpha=0.6,
+        edgecolors="k",
+        linewidths=0.4,
+    )
+
+    on_chart = sd[sd["_abs_pct"] * 100 <= ylim_cap]
+    outliers = sd[sd["_abs_pct"] * 100 > ylim_cap]
+
+    to_label_idx = set(on_chart.nlargest(top_n_labels, "_abs_pct").index) | set(
+        on_chart.nlargest(top_n_labels, "_abs_change").index
+    )
+    label_items = [
+        (
+            float(row["ef_old"]),
+            float(row["_abs_pct"]) * 100,
+            _sector_label(sector, str(row["sector_name"])),
+        )
+        for sector, row in on_chart.loc[list(to_label_idx)].iterrows()
+    ]
+
+    outlier_artist = None
+    if not outliers.empty:
+        lines = [f"Outliers ({len(outliers)} off-chart):"]
+        for sector, row in outliers.sort_values("_abs_pct", ascending=False).iterrows():
+            lines.append(
+                f"  {_sector_label(sector, str(row['sector_name']), width=25)}:"
+                f" EF={row['ef_old']:.2f}, |%|={row['_abs_pct'] * 100:.0f}%"
+            )
+        outlier_artist = _add_outlier_box(ax, "\n".join(lines))
+
+    median_ef = float(sd["ef_old"].median())
+    ax.axvline(median_ef, color=OUTLIER_COLOR, linestyle="--", linewidth=1.5, alpha=0.7)
+    ax.axhline(
+        pct_threshold, color=OUTLIER_COLOR, linestyle="--", linewidth=1.5, alpha=0.7
+    )
+    label_bbox = dict(
+        boxstyle="round,pad=0.3",
+        facecolor="white",
+        edgecolor=OUTLIER_COLOR,
+        alpha=0.9,
+    )
+    ax.text(
+        median_ef,
+        -0.04,
+        f"median EF: {median_ef:.2f}",
+        transform=ax.get_xaxis_transform(),
+        color=OUTLIER_COLOR,
+        fontsize=14,
+        fontweight="bold",
+        ha="center",
+        va="top",
+        bbox=label_bbox,
+    )
+    ax.text(
+        -0.01,
+        pct_threshold,
+        f"{pct_threshold:g}%",
+        transform=ax.get_yaxis_transform(),
+        color=OUTLIER_COLOR,
+        fontsize=14,
+        fontweight="bold",
+        ha="right",
+        va="center",
+        bbox=label_bbox,
+    )
+
+    ax.set_ylim(0, ylim_cap * 1.08)
+    ax.set_xlabel("EF Size (old EF, kgCO2e/$)")
+    ax.set_ylabel("|EF % Change|")
+    ax.set_title("EF % Change vs EF Size", fontsize=TITLE_FONTSIZE, pad=12)
+    _apply_axis_fonts(ax)
+    ax.grid(alpha=0.2)
+    fig.tight_layout()
+    dodge_annotations(
+        ax, label_items, avoid=[outlier_artist] if outlier_artist else None
+    )
+    return fig
+
+
+def plot_ef_abs_change_histogram(
+    ef_comparison: pd.DataFrame,
+    *,
+    n_bins: int = 50,
+    clip_range: tuple[float, float] = (-0.1, 0.1),
+) -> Figure:
+    """Histogram of absolute EF changes (kgCO2e/$) across all sectors."""
+    sd = ef_comparison.dropna(subset=["ef_change"])
+    changes = sd["ef_change"]
+    sector_name = sd["sector_name"]
+
+    def outlier_label(idx: Hashable, v: float) -> str:
+        desc = str(sector_name.get(idx, idx))[:30]
+        return f"  {idx} ({desc}): {v:+.4f}"
+
+    fig, ax = plt.subplots(figsize=SINGLE_PANEL_FIGSIZE)
+    abs_change_histogram(
+        ax,
+        changes,
+        clip_range=clip_range,
+        n_bins=n_bins,
+        outlier_label_fn=outlier_label,
+        xlabel="EF Absolute Change (kgCO2e/$)",
+        ylabel="Number of Sectors",
+        title="Distribution of Absolute EF Changes",
+        legend_fontsize=LEGEND_FONTSIZE,
+        outlier_fontsize=TEXT_BOX_FONTSIZE,
+    )
+    ax.set_title("Distribution of Absolute EF Changes", fontsize=TITLE_FONTSIZE)
+    _apply_axis_fonts(ax)
+    fig.tight_layout()
+    return fig
+
+
+# ---------- entry point ----------
+
+
+def plot(sheet_id: str, out_dir: Path, *, refresh: bool) -> None:
+    df_n = _drop_old_only(_normalize_schema(load_tab(sheet_id, TAB_N, refresh=refresh)))
+    df_d = _drop_old_only(_normalize_schema(load_tab(sheet_id, TAB_D, refresh=refresh)))
+    sig_raw = load_tabs_optional(sheet_id, [TAB_SIG], refresh=refresh)[TAB_SIG]
+    df_sig = _drop_old_only(_normalize_schema(sig_raw)) if sig_raw is not None else None
+
+    fig_h = plot_ef_perc_diff_histogram(df_n, df_d, df_sig)
+    save_and_close(fig_h, out_dir / "ef_perc_diff_histogram.png")
+
+    fig_n = plot_n_perc_diff_histogram(df_n)
+    save_and_close(fig_n, out_dir / "ef_n_perc_diff_histogram.png")
+
+    ef_comparison = build_ef_comparison(df_n)
+
+    fig_abs = plot_ef_pct_change_vs_abs_change(ef_comparison)
+    save_and_close(fig_abs, out_dir / "ef_pct_change_vs_abs_change.png")
+
+    fig_size = plot_ef_pct_change_vs_ef_size(ef_comparison)
+    save_and_close(fig_size, out_dir / "ef_pct_change_vs_ef_size.png")
+
+    fig_hist = plot_ef_abs_change_histogram(ef_comparison)
+    save_and_close(fig_hist, out_dir / "ef_abs_change_histogram.png")
+
+
+@click.command()
+@common_options
+def main(
+    baseline: str | None,
+    sheet_id: str | None,
+    refresh: bool,
+    tag: str | None,
+    out_dir: Path | None,
+) -> None:
+    resolved_sheet_id = resolve_sheet_id(sheet_id, baseline)
+    setup_mpl(font_size=14)
+    _, out = resolve_output_dir(resolved_sheet_id, tag, out_dir, baseline=baseline)
+    plot(resolved_sheet_id, out, refresh=refresh)
+
+
+if __name__ == "__main__":
+    main()

--- a/bedrock/utils/validation/analysis/fetch.py
+++ b/bedrock/utils/validation/analysis/fetch.py
@@ -1,0 +1,95 @@
+"""Fetch + cache Google Sheet diagnostics tabs as typed DataFrames.
+
+Each tab is fetched once via ``read_sheet_tab``, numeric columns are
+coerced (Sheets returns all-string cells), and the result is cached as
+parquet next to this package. Subsequent calls skip the network unless
+``refresh=True``.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pandas as pd
+
+from bedrock.utils.io.gcp import read_sheet_tab
+
+logger = logging.getLogger(__name__)
+
+CACHE_ROOT = Path(__file__).resolve().parent / ".cache"
+
+
+def _cache_path(sheet_id: str, tab: str) -> Path:
+    safe_tab = tab.replace("/", "_")
+    return CACHE_ROOT / sheet_id / f"{safe_tab}.parquet"
+
+
+def _coerce_numeric(df: pd.DataFrame) -> pd.DataFrame:
+    """Convert columns that parse cleanly as numeric; leave the rest as strings.
+
+    Sheets returns every cell as a string. Coerce column-wise so EF values
+    and counts become numeric, but preserve identifier columns (sector
+    codes, country codes, sector_name) as strings.
+
+    A column is coerced only when *every* non-null value parses as numeric.
+    This is deliberate: NAICS sectors are often mixed (``111200`` alongside
+    ``33131B``), and a permissive threshold would silently convert the
+    majority-digit codes to floats and drop the alphanumeric ones.
+    """
+    out = df.copy()
+    for col in out.columns:
+        non_null = out[col].notna() & (out[col].astype(str).str.len() > 0)
+        if not non_null.any():
+            continue
+        coerced = pd.to_numeric(out[col][non_null], errors="coerce")
+        if coerced.notna().all():
+            out[col] = pd.to_numeric(out[col], errors="coerce")
+    return out
+
+
+def load_tab(
+    sheet_id: str,
+    tab: str,
+    *,
+    refresh: bool = False,
+) -> pd.DataFrame:
+    """Return a tab as a typed DataFrame, using the parquet cache when present."""
+    path = _cache_path(sheet_id, tab)
+    if path.exists() and not refresh:
+        logger.info(f"Cache hit: {path}")
+        return pd.read_parquet(path)
+
+    logger.info(f"Fetching sheet {sheet_id!r} tab {tab!r}")
+    df = _coerce_numeric(read_sheet_tab(sheet_id, tab))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_parquet(path)
+    logger.info(f"Cached: {path}")
+    return df
+
+
+def load_tabs(
+    sheet_id: str,
+    tabs: list[str],
+    *,
+    refresh: bool = False,
+) -> dict[str, pd.DataFrame]:
+    """Load a set of tabs; any missing or unreadable tab raises."""
+    return {tab: load_tab(sheet_id, tab, refresh=refresh) for tab in tabs}
+
+
+def load_tabs_optional(
+    sheet_id: str,
+    tabs: list[str],
+    *,
+    refresh: bool = False,
+) -> dict[str, pd.DataFrame | None]:
+    """Like ``load_tabs`` but tolerates missing tabs, returning None for each."""
+    result: dict[str, pd.DataFrame | None] = {}
+    for tab in tabs:
+        try:
+            result[tab] = load_tab(sheet_id, tab, refresh=refresh)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"Sheet tab {tab!r} not loaded: {e}")
+            result[tab] = None
+    return result

--- a/bedrock/utils/validation/analysis/plotting.py
+++ b/bedrock/utils/validation/analysis/plotting.py
@@ -1,0 +1,351 @@
+"""Shared plotting primitives for the diagnostics analysis package.
+
+Centralizes styling (colors, reference lines, text boxes, axis formatters)
+and the label-dodge helper so the plot scripts in this package share a
+consistent look. Stays close to matplotlib: callers build the figure/axes,
+pass in data, and get styled panels back.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Hashable, Sequence
+from pathlib import Path
+from typing import Any
+
+import matplotlib
+import matplotlib.pyplot as plt
+import matplotlib.ticker as mticker
+import numpy as np
+import pandas as pd
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+
+DEFAULT_XLIM: tuple[float, float] = (-115.0, 115.0)
+PERCENT_TICKS: tuple[float, ...] = (-100, -50, -20, 0, 20, 50, 100)
+DEFAULT_BIN_WIDTH: float = 2.0
+
+HIST_COLOR = "steelblue"
+HIST_ALPHA = 0.6
+MEDIAN_COLOR = "red"
+ZERO_COLOR = "black"
+THRESHOLD_COLORS: tuple[str, str] = ("green", "purple")
+
+
+def setup_mpl(font_size: int = 17, agg: bool = True) -> None:
+    """Configure matplotlib for non-interactive PNG output."""
+    if agg:
+        matplotlib.use("Agg")
+    matplotlib.rcParams.update({"font.size": font_size})
+
+
+def add_reference_lines(
+    ax: Axes,
+    *,
+    median: float,
+    median_label: str = "median",
+    median_fmt: str = ".1f",
+    thresholds: Sequence[float] = (10, 20),
+    threshold_colors: Sequence[str] = THRESHOLD_COLORS,
+    zero_label: str = "0%",
+) -> None:
+    """Draw median (red dashed), 0 (solid black), and symmetric threshold lines.
+
+    Thresholds are in the same units as the x-axis (e.g. percent points).
+    Pairs each threshold with a color from ``threshold_colors``; symmetric
+    ±threshold lines share a legend entry.
+    """
+    ax.axvline(
+        x=median,
+        color=MEDIAN_COLOR,
+        linestyle="--",
+        linewidth=1.5,
+        label=f"{median_label} = {median:{median_fmt}}%",
+    )
+    ax.axvline(x=0, color=ZERO_COLOR, linestyle="-", linewidth=2, label=zero_label)
+    for t, color in zip(thresholds, threshold_colors):
+        ax.axvline(
+            x=-t,
+            color=color,
+            linestyle="--",
+            linewidth=1.5,
+            alpha=0.8,
+            label=f"±{t:g}%",
+        )
+        ax.axvline(x=t, color=color, linestyle="--", linewidth=1.5, alpha=0.8)
+
+
+def format_percent_axis(ax: Axes, ticks: Sequence[float] = PERCENT_TICKS) -> None:
+    """Apply fixed tick locations and percent formatting to the x-axis."""
+    ax.xaxis.set_major_locator(mticker.FixedLocator(list(ticks)))
+    ax.xaxis.set_major_formatter(mticker.PercentFormatter(xmax=100, decimals=0))
+
+
+def add_text_box(
+    ax: Axes,
+    text: str,
+    *,
+    loc: str = "upper left",
+    fontsize: int = 13,
+    multialignment: str | None = None,
+    bg_alpha: float = 0.35,
+) -> None:
+    """Anchor a wheat-backed monospace text box to a corner of the axes.
+
+    ``multialignment`` controls how lines line up within the box (independent
+    of the box anchor); defaults to match the corner's horizontal alignment.
+    ``bg_alpha`` controls the background opacity — lower values let the
+    underlying plot show through.
+    """
+    positions = {
+        "upper left": (0.02, 0.95, "top", "left"),
+        "upper right": (0.98, 0.95, "top", "right"),
+        "lower left": (0.02, 0.05, "bottom", "left"),
+        "lower right": (0.98, 0.05, "bottom", "right"),
+    }
+    x, y, va, ha = positions[loc]
+    ax.text(
+        x,
+        y,
+        text,
+        transform=ax.transAxes,
+        fontsize=fontsize,
+        verticalalignment=va,
+        horizontalalignment=ha,
+        multialignment=multialignment if multialignment is not None else ha,
+        fontfamily="monospace",
+        bbox=dict(boxstyle="round,pad=0.3", facecolor="wheat", alpha=bg_alpha),
+    )
+
+
+def percent_histogram(
+    ax: Axes,
+    vals_pct: "pd.Series[float]",
+    *,
+    xlim: tuple[float, float] = DEFAULT_XLIM,
+    bin_width: float = DEFAULT_BIN_WIDTH,
+    ticks: Sequence[float] = PERCENT_TICKS,
+    xlabel: str = "Percentage Diff (%)",
+    ylabel: str = "Count",
+    title: str | None = None,
+    text_box: str | None = None,
+    text_box_loc: str = "upper left",
+    text_box_fontsize: int = 13,
+    legend_loc: str = "upper right",
+    legend_fontsize: int = 14,
+    thresholds: Sequence[float] = (10, 20),
+) -> None:
+    """Render a percent-diff histogram panel with reference lines + text box."""
+    vals = vals_pct.dropna()
+    bin_edges = np.arange(xlim[0], xlim[1] + bin_width, bin_width).tolist()
+    ax.hist(vals, bins=bin_edges, alpha=HIST_ALPHA, color=HIST_COLOR)
+
+    add_reference_lines(ax, median=float(vals.median()), thresholds=thresholds)
+    ax.set_xlim(xlim)
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel(ylabel)
+    if title is not None:
+        ax.set_title(title)
+    format_percent_axis(ax, ticks)
+    ax.legend(fontsize=legend_fontsize, loc=legend_loc)
+
+    if text_box:
+        add_text_box(
+            ax,
+            text_box,
+            loc=text_box_loc,
+            fontsize=text_box_fontsize,
+            multialignment="left",
+        )
+
+
+def abs_change_histogram(
+    ax: Axes,
+    values: "pd.Series[float]",
+    *,
+    clip_range: tuple[float, float],
+    n_bins: int = 100,
+    outlier_label_fn: Callable[[Hashable, float], str] | None = None,
+    value_fmt: str = "+.4f",
+    xlabel: str = "Absolute change",
+    ylabel: str = "Count",
+    title: str | None = None,
+    increase_label: str = "Increases",
+    decrease_label: str = "Decreases",
+    legend_loc: str = "upper center",
+    legend_fontsize: int = 14,
+    outlier_fontsize: int = 11,
+    outlier_bg_alpha: float = 0.35,
+    outlier_text_align: str = "left",
+) -> None:
+    """Histogram of absolute changes, clipped to ``clip_range``.
+
+    Outliers outside ``clip_range`` are listed in two wheat boxes at
+    top-left (decreases) and top-right (increases). Callers pass
+    ``outlier_label_fn(index, value) -> str`` to customize each row; by
+    default shows just the index and value. ``outlier_bg_alpha`` lowers
+    the box opacity so bars stay visible; ``outlier_text_align`` sets
+    line-alignment inside the boxes.
+    """
+    vals = values.dropna()
+    clipped_below = int((vals < clip_range[0]).sum())
+    clipped_above = int((vals > clip_range[1]).sum())
+    visible = vals.clip(lower=clip_range[0], upper=clip_range[1])
+
+    bin_edges = np.linspace(clip_range[0], clip_range[1], n_bins + 1).tolist()
+    ax.hist(visible, bins=bin_edges, alpha=HIST_ALPHA, color=HIST_COLOR)
+
+    median_val = float(vals.median())
+    std_val = float(vals.std())
+    ax.axvline(
+        median_val,
+        color=MEDIAN_COLOR,
+        linestyle="--",
+        linewidth=1.5,
+        label=f"median = {median_val:{value_fmt}}  (std: {std_val:{value_fmt.lstrip('+')}})",
+    )
+    ax.axvline(x=0, color=ZERO_COLOR, linestyle="-", linewidth=2, label="0")
+
+    ax.set_xlim(clip_range)
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel(ylabel)
+    if title is not None:
+        ax.set_title(title)
+    ax.legend(fontsize=legend_fontsize, loc=legend_loc)
+
+    above = vals[vals > clip_range[1]].sort_values(ascending=False)
+    below = vals[vals < clip_range[0]].sort_values()
+
+    def _format(idx: Hashable, v: float) -> str:
+        if outlier_label_fn is not None:
+            return outlier_label_fn(idx, v)
+        return f"  {idx}: {v:{value_fmt}}"
+
+    dec_lines = [
+        f"Clipped: {clipped_below} below {clip_range[0]:g}",
+        "",
+        f"{decrease_label} below {clip_range[0]:g}:",
+        *[_format(idx, v) for idx, v in below.items()],
+    ]
+    inc_lines = [
+        f"Clipped: {clipped_above} above {clip_range[1]:g}",
+        "",
+        f"{increase_label} above {clip_range[1]:g}:",
+        *[_format(idx, v) for idx, v in above.items()],
+    ]
+    add_text_box(
+        ax,
+        "\n".join(dec_lines),
+        loc="upper left",
+        fontsize=outlier_fontsize,
+        multialignment=outlier_text_align,
+        bg_alpha=outlier_bg_alpha,
+    )
+    add_text_box(
+        ax,
+        "\n".join(inc_lines),
+        loc="upper right",
+        fontsize=outlier_fontsize,
+        multialignment=outlier_text_align,
+        bg_alpha=outlier_bg_alpha,
+    )
+
+
+def dodge_annotations(
+    ax: Axes,
+    items: Sequence[tuple[float, float, str]],
+    *,
+    fontsize: int = 12,
+    offset_px: tuple[float, float] = (6, 6),
+    max_iters: int = 60,
+    step_px: float = 3.0,
+    max_push_px: float = 40.0,
+    leader_threshold_px: float = 16.0,
+    avoid: Sequence[Any] | None = None,
+) -> None:
+    """Place text annotations at each ``(x, y)`` and nudge overlaps apart vertically.
+
+    Greedy: give every label the initial offset, then for each overlapping pair
+    push the upper one up. If that label has already been pushed past
+    ``max_push_px`` above its starting offset, push the lower one down instead
+    (capped symmetrically). Stops when no pair overlaps or ``max_iters`` is
+    hit. A thin leader line is kept on labels that drift noticeably from their
+    point so the reader can match label to data. ``avoid`` is a sequence of
+    artists (e.g. existing text boxes or legends) whose bboxes are treated as
+    immovable obstacles — labels that collide with them are pushed downward.
+    """
+    if not items:
+        return
+    fig = ax.figure
+    if fig is None:
+        return
+
+    arrow_style = dict(arrowstyle="-", color="0.6", lw=0.5, shrinkA=0, shrinkB=2)
+    annotations = [
+        ax.annotate(
+            text,
+            xy=(x, y),
+            xytext=offset_px,
+            textcoords="offset points",
+            fontsize=fontsize,
+            ha="left",
+            va="bottom",
+            arrowprops=arrow_style,
+        )
+        for x, y, text in items
+    ]
+    base_dy = offset_px[1]
+    fig.canvas.draw()
+    renderer = fig.canvas.get_renderer()
+    axes_bbox = ax.get_window_extent(renderer=renderer)
+    avoid_bboxes = (
+        [a.get_window_extent(renderer=renderer) for a in avoid] if avoid else []
+    )
+
+    for _ in range(max_iters):
+        bboxes = [t.get_window_extent(renderer=renderer) for t in annotations]
+        moved = False
+        # Push any annotation colliding with an avoid-region downward.
+        for k in range(len(annotations)):
+            if any(bboxes[k].overlaps(ab) for ab in avoid_bboxes):
+                dx, dy = annotations[k].xyann
+                if base_dy - dy < max_push_px:
+                    annotations[k].xyann = (dx, dy - step_px)
+                    moved = True
+        for i in range(len(annotations)):
+            for j in range(i + 1, len(annotations)):
+                if not bboxes[i].overlaps(bboxes[j]):
+                    continue
+                upper = i if bboxes[i].y0 >= bboxes[j].y0 else j
+                lower = j if upper == i else i
+                dx_u, dy_u = annotations[upper].xyann
+                dx_l, dy_l = annotations[lower].xyann
+                upper_top = bboxes[upper].y1
+                upper_collides_avoid = any(
+                    bboxes[upper].overlaps(ab) for ab in avoid_bboxes
+                )
+                can_push_up = (
+                    dy_u - base_dy < max_push_px
+                    and upper_top + step_px < axes_bbox.y1
+                    and not upper_collides_avoid
+                )
+                if can_push_up:
+                    annotations[upper].xyann = (dx_u, dy_u + step_px)
+                    moved = True
+                elif base_dy - dy_l < max_push_px:
+                    annotations[lower].xyann = (dx_l, dy_l - step_px)
+                    moved = True
+        if not moved:
+            break
+        fig.canvas.draw()
+
+    for t in annotations:
+        dx, dy = t.xyann
+        if (dx**2 + dy**2) ** 0.5 <= leader_threshold_px and t.arrow_patch is not None:
+            t.arrow_patch.set_visible(False)
+
+
+def save_and_close(fig: Figure, out: Path) -> None:
+    """Write ``fig`` to ``out`` at dpi=150, close the figure, and log the path."""
+    fig.savefig(out, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Saved: {out}")


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

Adds `bedrock/utils/validation/analysis/`, a CLI package that loads diagnostics tabs from Google Sheets (parquet-cached) and renders five PNGs from `N_and_diffs` / `D_and_diffs`: a 2×2 N/D percent-diff histogram (all + significant sectors), a standalone N percent-diff histogram, two scatters (`|% change|` vs `|absolute change|` and vs EF size) with outlier boxes and a label-dodge helper, and an absolute-change histogram. The `ceda` and `useeio` baseline sheets are registered in `baselines.py`; ad-hoc runs use `--sheet-id` or `$BEDROCK_DIAGNOSTICS_SHEET_ID`. Also adds `read_sheet_tab` to `bedrock/utils/io/gcp.py` so the fetcher can pull tabs. README covers GCP auth, sheet sharing, and usage.

## Testing

Ran `uv run python -m bedrock.utils.validation.analysis.ef_plots --baseline ceda` and `--baseline useeio`; all five PNGs render correctly for both baselines.
### Sample plots
<img width="2070" height="1469" alt="ef_abs_change_histogram" src="https://github.com/user-attachments/assets/6fc96188-2291-458a-ba9f-9e80a19544d7" />
<img width="2070" height="1469" alt="ef_n_perc_diff_histogram" src="https://github.com/user-attachments/assets/0e899b64-d14d-4d41-b74e-7b851a877884" />
<img width="2069" height="1467" alt="ef_pct_change_vs_abs_change" src="https://github.com/user-attachments/assets/8f4c85b8-f5ef-488b-9601-2e575fb40260" />
<img width="2069" height="1469" alt="ef_pct_change_vs_ef_size" src="https://github.com/user-attachments/assets/9b8f2ffd-4bb2-4f86-8653-4223fd392aed" />
<img width="2670" height="2069" alt="ef_perc_diff_histogram" src="https://github.com/user-attachments/assets/ed85dcd3-3fd4-4114-951b-55a982149c35" />

