### PR TITLE
Edit files to use DISAGG_SECTORS instead of WASTE_DISAGG

### DIFF
--- a/bedrock/extract/allocation/bea.py
+++ b/bedrock/extract/allocation/bea.py
@@ -16,11 +16,13 @@ from bedrock.utils.config.usa_config import get_usa_config
 from bedrock.utils.io.gcp import load_from_gcs
 from bedrock.utils.io.gcp_paths import GCS_CEDA_INPUT_DIR
 from bedrock.utils.taxonomy.bea.ceda_v7 import CEDA_V7_SECTORS
-from bedrock.utils.taxonomy.cornerstone.commodities import WASTE_DISAGG_COMMODITIES
+from bedrock.utils.taxonomy.cornerstone.disagg_sectors import DISAGG_SECTORS
 
 # Schema alignment: CEDA allocator sectors → Cornerstone use table.
-_WASTE_AGGREGATE = "562000"
-_WASTE_SUBS = list(WASTE_DISAGG_COMMODITIES[_WASTE_AGGREGATE])
+# TODO: Generalize when a second sector is added to `DISAGG_SECTORS`.
+_waste_disagg = DISAGG_SECTORS["waste"]
+_WASTE_AGGREGATE = _waste_disagg.commodity_aggregate_code
+_WASTE_SUBS = list(_waste_disagg.commodity_new_codes)
 _APPLIANCE_AGGREGATE = "335220"
 _APPLIANCE_SUBS = ["335221", "335222", "335224", "335228"]
 # CEDA 331313 = primary + secondary aluminum; Cornerstone has 331313 + 33131B.

--- a/bedrock/transform/eeio/cornerstone_expansion.py
+++ b/bedrock/transform/eeio/cornerstone_expansion.py
@@ -56,7 +56,8 @@ def _col_normalize(df: pd.DataFrame) -> pd.DataFrame:
 def commodity_corresp() -> pd.DataFrame:
     """Column-normalized commodity correspondence.
 
-    Ensures one-to-many BEA→cornerstone splits (e.g. waste 562000 → 7 subsectors)
+    Ensures one-to-many BEA→cornerstone splits (e.g. registered disaggregations such as
+    waste 562000 → seven subsectors)
     distribute values proportionally rather than duplicating.
     """
     return _col_normalize(commodity_corresp_raw())
@@ -113,7 +114,8 @@ def ceda_commodity_corresp_raw() -> pd.DataFrame:
 def ceda_commodity_corresp() -> pd.DataFrame:
     """Column-normalized CEDA v7 → Cornerstone commodity correspondence.
 
-    Ensures one-to-many CEDA→Cornerstone splits (e.g. waste 562000 → 7 subsectors)
+    Ensures one-to-many CEDA→Cornerstone splits (e.g. registered disaggregations such as
+    waste 562000 → seven subsectors)
     distribute values proportionally rather than duplicating.
     """
     return _col_normalize(ceda_commodity_corresp_raw())
@@ -144,18 +146,19 @@ def _valid_pairs(
     return [c for c, _ in pairs], [b for _, b in pairs]
 
 
-def _apply_waste_intragroup_treatment(expanded: pd.DataFrame) -> None:
-    """Zero cross-terms and divide non-group entries for waste subsectors in-place.
+def _apply_disagg_intragroup_treatment(expanded: pd.DataFrame) -> None:
+    """Zero cross-terms and divide non-group entries for registered disagg subsectors in-place.
 
-    Only applies to waste — these have no real disaggregated data, so the BEA
-    parent value is duplicated.  Other disaggregations (e.g. aluminum) have
-    real correspondence-informed splits and are left as-is.
+    Applies to sectors in ``DISAGG_SECTORS`` whose children have no real
+    disaggregated data in the source matrix (the BEA parent value is duplicated).
+    Other correspondence splits (e.g. aluminum) have real weights and are left as-is.
     """
-    from bedrock.utils.taxonomy.cornerstone.commodities import (  # noqa: PLC0415
-        WASTE_DISAGG_COMMODITIES,
+    from bedrock.utils.taxonomy.cornerstone.disagg_sectors import (  # noqa: PLC0415
+        DISAGG_SECTORS,
     )
 
-    for _old_code, new_codes in WASTE_DISAGG_COMMODITIES.items():
+    for sector in DISAGG_SECTORS.values():
+        new_codes = [*sector.commodity_new_codes]
         siblings = [c for c in new_codes if c in expanded.index]
         n = len(siblings)
         if n <= 1:
@@ -171,6 +174,9 @@ def _apply_waste_intragroup_treatment(expanded: pd.DataFrame) -> None:
             expanded.loc[s, non_siblings] /= n  # type: ignore[index]
 
 
+_apply_waste_intragroup_treatment = _apply_disagg_intragroup_treatment
+
+
 def expand_square_matrix(
     M: pd.DataFrame,
     target_codes: list[str],
@@ -181,20 +187,21 @@ def expand_square_matrix(
     """Expand a BEA square matrix to Cornerstone space.
 
     Rows and columns for disaggregated sectors are **duplicated** (not split).
-    When *zero_intragroup_cross_terms* is True, waste subsector cross-terms
-    are zeroed and non-group entries divided by n to prevent L inflation.
+    When *zero_intragroup_cross_terms* is True, disaggregation subsector cross-terms
+    (see ``DISAGG_SECTORS``) are zeroed and non-group entries divided by *n* to
+    prevent Leontief-inverse inflation.
     """
     cs_valid, bea_valid = _valid_pairs(target_codes, code_map, M.index)
 
     expanded = M.loc[bea_valid, bea_valid].copy()
-    expanded.index = cs_valid
-    expanded.columns = cs_valid
+    expanded.index = pd.Index(cs_valid)
+    expanded.columns = pd.Index(cs_valid)
     expanded = expanded.reindex(
         index=target_codes, columns=target_codes, fill_value=0.0
     )
 
     if zero_intragroup_cross_terms:
-        _apply_waste_intragroup_treatment(expanded)
+        _apply_disagg_intragroup_treatment(expanded)
 
     expanded.index.name = 'sector'
     expanded.columns.name = 'sector'
@@ -210,7 +217,7 @@ def expand_vector(
     cs_valid, bea_valid = _valid_pairs(target_codes, code_map, v.index)
 
     expanded = v.loc[bea_valid].copy()
-    expanded.index = cs_valid
+    expanded.index = pd.Index(cs_valid)
     return expanded.reindex(target_codes, fill_value=0.0)
 
 
@@ -223,7 +230,7 @@ def expand_ghg_matrix_from_bea_to_cornerstone(
     cs_valid, bea_valid = _valid_pairs(target_col_codes, col_map, M.columns)
 
     expanded = M.loc[:, bea_valid].copy()
-    expanded.columns = cs_valid
+    expanded.columns = pd.Index(cs_valid)
     expanded = expanded.reindex(columns=target_col_codes, fill_value=0.0)
     expanded.index.name = 'ghg'
     expanded.columns.name = 'sector'

--- a/bedrock/transform/eeio/derived_cornerstone.py
+++ b/bedrock/transform/eeio/derived_cornerstone.py
@@ -125,13 +125,16 @@ from bedrock.utils.taxonomy.bea.v2017_industry_summary import (
 from bedrock.utils.taxonomy.bea_v2017_to_ceda_v7_helpers import (
     get_bea_v2017_summary_to_cornerstone_corresp_df,
 )
-from bedrock.utils.taxonomy.cornerstone.commodities import WASTE_DISAGG_COMMODITIES
+from bedrock.utils.taxonomy.cornerstone.disagg_sectors import (
+    DISAGG_SECTORS,
+    DisaggSectorTaxonomy,
+)
 from bedrock.utils.taxonomy.cornerstone.value_added import VALUE_ADDEDS
 
 _BEDROCK_PKG_ROOT = pathlib.Path(__file__).resolve().parents[2]
 
-_WASTE_ORIGINAL_CODE = "562000"
-_WASTE_NEW_CODES: list[str] = list(WASTE_DISAGG_COMMODITIES[_WASTE_ORIGINAL_CODE])
+_WASTE_ORIGINAL_CODE = DISAGG_SECTORS["waste"].commodity_aggregate_code
+_WASTE_NEW_CODES: list[str] = list(DISAGG_SECTORS["waste"].commodity_new_codes)
 
 # ---------------------------------------------------------------------------
 # Waste disaggregation weight provider (4a)
@@ -211,8 +214,10 @@ def derive_cornerstone_x() -> pd.Series[float]:
 
 def _distribute_waste_parent_x_using_v_row_shares(
     x_cs: pd.Series[float],
+    *,
+    taxonomy: DisaggSectorTaxonomy = DISAGG_SECTORS["waste"],
 ) -> pd.Series[float]:
-    """Split duplicated BEA parent gross output across waste children using ``V`` row-sum shares.
+    """Split duplicated BEA parent gross output across disagg children using ``V`` row-sum shares.
 
     After ``expand_vector``, one-to-many BEA→Cornerstone splits (e.g. 562000)
     assign the **full** parent total to **each** child. When waste
@@ -227,7 +232,7 @@ def _distribute_waste_parent_x_using_v_row_shares(
     x_v = derive_cornerstone_x()
     present = [
         c
-        for c in _WASTE_NEW_CODES
+        for c in taxonomy.commodity_new_codes
         if c in x.index and c in x_v.index and pd.notna(x_v.loc[c])
     ]
     if not present:
@@ -598,14 +603,19 @@ def derive_cornerstone_E() -> pd.DataFrame:
     )
 
 
-def _normalize_E_for_waste(E: pd.DataFrame, V: pd.DataFrame) -> pd.DataFrame:
-    """Distribute E's waste industry columns proportionally by industry output.
+def _normalize_E_for_waste(
+    E: pd.DataFrame,
+    V: pd.DataFrame,
+    *,
+    taxonomy: DisaggSectorTaxonomy = DISAGG_SECTORS["waste"],
+) -> pd.DataFrame:
+    """Distribute E's disaggregated industry columns proportionally by industry output.
 
-    Instead of duplicating E_bea[:, 562000] to every waste subsector, each
-    waste industry i gets E_bea[:, 562000] * share_i, where share_i is i's
-    fraction of total waste industry output (Make table column sums).
+    Instead of duplicating the aggregate column to every child industry, each
+    child *i* gets the aggregate column times *i*'s fraction of total child
+    industry output (Make table column sums).
     """
-    waste_industries = [c for c in _WASTE_NEW_CODES if c in E.columns]
+    waste_industries = [c for c in taxonomy.industry_new_codes if c in E.columns]
     if not waste_industries:
         return E
     g_waste = V.sum(axis=0).loc[waste_industries]

--- a/bedrock/utils/taxonomy/cornerstone/__tests__/test_disagg_sectors.py
+++ b/bedrock/utils/taxonomy/cornerstone/__tests__/test_disagg_sectors.py
@@ -1,0 +1,19 @@
+from bedrock.utils.taxonomy.cornerstone.commodities import WASTE_DISAGG_COMMODITIES
+from bedrock.utils.taxonomy.cornerstone.disagg_sectors import DISAGG_SECTORS
+from bedrock.utils.taxonomy.cornerstone.industries import WASTE_DISAGG_INDUSTRIES
+
+
+def test_disagg_sectors_waste_registry() -> None:
+    waste = DISAGG_SECTORS["waste"]
+    assert waste.name == "waste"
+    assert waste.industry_aggregate_code == "562000"
+    assert waste.commodity_aggregate_code == "562000"
+    assert len(waste.industry_new_codes) == 7
+    assert len(waste.commodity_new_codes) == 7
+    assert waste.industry_new_codes == waste.commodity_new_codes
+
+
+def test_waste_disagg_aliases_match_registry() -> None:
+    waste = DISAGG_SECTORS["waste"]
+    assert WASTE_DISAGG_COMMODITIES["562000"] == list(waste.commodity_new_codes)
+    assert WASTE_DISAGG_INDUSTRIES["562000"] == list(waste.industry_new_codes)

--- a/bedrock/utils/taxonomy/cornerstone/commodities.py
+++ b/bedrock/utils/taxonomy/cornerstone/commodities.py
@@ -1,4 +1,7 @@
 import typing as ta
+from typing import cast
+
+from bedrock.utils.taxonomy.cornerstone.disagg_sectors import DISAGG_SECTORS
 
 # 405 commodities.
 # COMMODITY is the Literal type (for static type checking); COMMODITIES is the runtime list.
@@ -822,13 +825,6 @@ COMMODITY_DESC: ta.Dict[COMMODITY, str] = {
 }
 
 WASTE_DISAGG_COMMODITIES: ta.Dict[str, ta.List[COMMODITY]] = {
-    '562000': [
-        '562111',
-        '562HAZ',
-        '562212',
-        '562213',
-        '562910',
-        '562920',
-        '562OTH',
-    ]
+    s.commodity_aggregate_code: cast(ta.List[COMMODITY], [*s.commodity_new_codes])
+    for s in DISAGG_SECTORS.values()
 }

--- a/bedrock/utils/taxonomy/cornerstone/disagg_sectors.py
+++ b/bedrock/utils/taxonomy/cornerstone/disagg_sectors.py
@@ -1,0 +1,41 @@
+"""Registry of Cornerstone sectors that disaggregate from a single aggregate code."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DisaggSectorTaxonomy:
+    name: str
+    industry_aggregate_code: str
+    commodity_aggregate_code: str
+    industry_new_codes: tuple[str, ...]
+    commodity_new_codes: tuple[str, ...]
+
+
+DISAGG_SECTORS: dict[str, DisaggSectorTaxonomy] = {
+    "waste": DisaggSectorTaxonomy(
+        name="waste",
+        industry_aggregate_code="562000",
+        commodity_aggregate_code="562000",
+        industry_new_codes=(
+            "562111",
+            "562HAZ",
+            "562212",
+            "562213",
+            "562910",
+            "562920",
+            "562OTH",
+        ),
+        commodity_new_codes=(
+            "562111",
+            "562HAZ",
+            "562212",
+            "562213",
+            "562910",
+            "562920",
+            "562OTH",
+        ),
+    ),
+}

--- a/bedrock/utils/taxonomy/cornerstone/industries.py
+++ b/bedrock/utils/taxonomy/cornerstone/industries.py
@@ -1,4 +1,7 @@
 import typing as ta
+from typing import cast
+
+from bedrock.utils.taxonomy.cornerstone.disagg_sectors import DISAGG_SECTORS
 
 # 405 industries.
 # INDUSTRY is the Literal type (for static type checking); INDUSTRIES is the runtime list.
@@ -823,13 +826,6 @@ INDUSTRY_DESC: ta.Dict[INDUSTRY, str] = {
 }
 
 WASTE_DISAGG_INDUSTRIES: ta.Dict[str, ta.List[INDUSTRY]] = {
-    '562000': [
-        '562111',
-        '562HAZ',
-        '562212',
-        '562213',
-        '562910',
-        '562920',
-        '562OTH',
-    ]
+    s.industry_aggregate_code: cast(ta.List[INDUSTRY], [*s.industry_new_codes])
+    for s in DISAGG_SECTORS.values()
 }

--- a/bedrock/utils/taxonomy/mappings/bea_ceda_v7__cornerstone_commodity.py
+++ b/bedrock/utils/taxonomy/mappings/bea_ceda_v7__cornerstone_commodity.py
@@ -1,11 +1,9 @@
 import typing as ta
+from typing import cast
 
 from bedrock.utils.taxonomy.bea.ceda_v7 import CEDA_V7_SECTOR, CEDA_V7_SECTORS
-from bedrock.utils.taxonomy.cornerstone.commodities import (
-    COMMODITIES,
-    COMMODITY,
-    WASTE_DISAGG_COMMODITIES,
-)
+from bedrock.utils.taxonomy.cornerstone.commodities import COMMODITIES, COMMODITY
+from bedrock.utils.taxonomy.cornerstone.disagg_sectors import DISAGG_SECTORS
 from bedrock.utils.taxonomy.utils import validate_mapping
 
 
@@ -21,9 +19,9 @@ def load_ceda_v7_commodity_to_cornerstone_commodity() -> (
         # Appliances: CEDA v7 splits 335220 into 4; Cornerstone keeps 335220
         if ceda in {'335221', '335222', '335224', '335228'}:
             return ['335220']
-        # Waste: CEDA v7 keeps 562000; Cornerstone disaggregates into 7
-        if ceda == '562000':
-            return WASTE_DISAGG_COMMODITIES['562000']
+        for sector in DISAGG_SECTORS.values():
+            if ceda == sector.commodity_aggregate_code:
+                return cast(ta.List[COMMODITY], [*sector.commodity_new_codes])
         # 1:1 codes present in both taxonomies
         if ceda in COMMODITIES:
             return [ceda]  # type: ignore

--- a/bedrock/utils/taxonomy/mappings/bea_v2017_commodity__cornerstone_commodity.py
+++ b/bedrock/utils/taxonomy/mappings/bea_v2017_commodity__cornerstone_commodity.py
@@ -1,14 +1,12 @@
 import typing as ta
+from typing import cast
 
 from bedrock.utils.taxonomy.bea.v2017_commodity import (
     BEA_2017_COMMODITY_CODE,
     BEA_2017_COMMODITY_CODES,
 )
-from bedrock.utils.taxonomy.cornerstone.commodities import (
-    COMMODITIES,
-    COMMODITY,
-    WASTE_DISAGG_COMMODITIES,
-)
+from bedrock.utils.taxonomy.cornerstone.commodities import COMMODITIES, COMMODITY
+from bedrock.utils.taxonomy.cornerstone.disagg_sectors import DISAGG_SECTORS
 from bedrock.utils.taxonomy.utils import validate_mapping
 
 
@@ -18,8 +16,9 @@ def load_bea_v2017_commodity_to_cornerstone_commodity() -> (
     def _map_v2017_commodity_to_cornerstone_commodity(
         bea: BEA_2017_COMMODITY_CODE,
     ) -> ta.List[COMMODITY]:
-        if bea == '562000':  # Waste disaggregation
-            return WASTE_DISAGG_COMMODITIES['562000']
+        for sector in DISAGG_SECTORS.values():
+            if bea == sector.commodity_aggregate_code:
+                return cast(ta.List[COMMODITY], [*sector.commodity_new_codes])
         if bea in {  # Drop these commodities
             'S00401',  # Scrap
             'S00300',  # Noncomparable imports

--- a/bedrock/utils/taxonomy/mappings/bea_v2017_industry__cornerstone_industry.py
+++ b/bedrock/utils/taxonomy/mappings/bea_v2017_industry__cornerstone_industry.py
@@ -1,14 +1,12 @@
 import typing as ta
+from typing import cast
 
 from bedrock.utils.taxonomy.bea.v2017_industry import (
     BEA_2017_INDUSTRY_CODE,
     BEA_2017_INDUSTRY_CODES,
 )
-from bedrock.utils.taxonomy.cornerstone.industries import (
-    INDUSTRIES,
-    INDUSTRY,
-    WASTE_DISAGG_INDUSTRIES,
-)
+from bedrock.utils.taxonomy.cornerstone.disagg_sectors import DISAGG_SECTORS
+from bedrock.utils.taxonomy.cornerstone.industries import INDUSTRIES, INDUSTRY
 from bedrock.utils.taxonomy.utils import validate_mapping
 
 
@@ -22,8 +20,9 @@ def load_bea_v2017_industry_to_cornerstone_industry() -> (
             return ["221100"]
         if bea == "S00201":  # Aggregate passenger transportation
             return ["485000"]
-        if bea == '562000':  # Waste disaggregation
-            return WASTE_DISAGG_INDUSTRIES['562000']
+        for sector in DISAGG_SECTORS.values():
+            if bea == sector.industry_aggregate_code:
+                return cast(ta.List[INDUSTRY], [*sector.industry_new_codes])
         if bea in INDUSTRIES:
             return [bea]  # type: ignore
         raise RuntimeError(f"Unexpected BEA 2017 industry code: {bea}")

--- a/bedrock/utils/validation/diagnostics_helpers.py
+++ b/bedrock/utils/validation/diagnostics_helpers.py
@@ -33,7 +33,8 @@ logger = logging.getLogger(__name__)
 # Sector alignment constants for CEDA v7 (old) ↔ cornerstone (new)
 #
 # Sources of truth:
-#   Waste:     taxonomy/cornerstone/commodities.py  → WASTE_DISAGG_COMMODITIES
+#   Sector disaggregation: taxonomy/cornerstone/disagg_sectors.py → DISAGG_SECTORS
+#     (e.g. waste aggregate 562000 → seven subsectors; see WASTE_DISAGG_COMMODITIES)
 #   Appliance: taxonomy/mappings/bea_v2017_commodity__bea_ceda_v7.py  (335220 → 4 codes)
 #   Aluminum:  taxonomy/mappings/bea_v2017_commodity__bea_ceda_v7.py  (33131B → 331313)
 # ---------------------------------------------------------------------------
@@ -81,14 +82,16 @@ class EfsForDiagnostics(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-def _waste_disagg() -> ta.Tuple[str, ta.List[str]]:
-    """Return (old_code, new_subsector_codes) from the cornerstone taxonomy."""
-    from bedrock.utils.taxonomy.cornerstone.commodities import (  # noqa: PLC0415
-        WASTE_DISAGG_COMMODITIES,
+def _disagg_sectors() -> ta.List[ta.Tuple[str, ta.List[str]]]:
+    """Return ``(aggregate_commodity_code, new_commodity_codes)`` per registered sector."""
+    from bedrock.utils.taxonomy.cornerstone.disagg_sectors import (  # noqa: PLC0415
+        DISAGG_SECTORS,
     )
 
-    ((old_code, new_codes),) = WASTE_DISAGG_COMMODITIES.items()
-    return old_code, list(new_codes)
+    return [
+        (s.commodity_aggregate_code, list(s.commodity_new_codes))
+        for s in DISAGG_SECTORS.values()
+    ]
 
 
 def get_aligned_sector_desc() -> ta.Dict[str, str]:
@@ -118,24 +121,23 @@ def compute_active_mapped_sectors(
     (both old-only and new-only codes) so that the ``comparison_type`` column
     in the output sheet clearly labels each row.
 
-    Mapping labels:
+    Mapping labels (waste is one example of a registered disaggregation):
       - ``old-only (waste aggregate)``  – old aggregate that was disaggregated
       - ``new-only (waste subsector)``   – new subsectors of the above
       - ``old-only (appliance detail)``  – old detail codes that were aggregated
       - ``new-only (appliance aggregate)`` – new aggregate of the above
       - ``old-only (aluminum)`` / ``new-only (aluminum)`` – aluminum split
     """
-    waste_old, waste_new = _waste_disagg()
     old_idx = set(old_ef.index)
     new_idx = set(new_ef.index)
     active: ta.Dict[str, str] = {}
 
-    # Waste: old has aggregate 562000, new has subsectors
-    if waste_old in old_idx and waste_old not in new_idx:
-        if all(c in new_idx for c in waste_new):
-            active[waste_old] = 'old-only (waste aggregate)'
-            for c in waste_new:
-                active[c] = 'new-only (waste subsector)'
+    for disagg_old, disagg_new in _disagg_sectors():
+        if disagg_old in old_idx and disagg_old not in new_idx:
+            if all(c in new_idx for c in disagg_new):
+                active[disagg_old] = 'old-only (waste aggregate)'
+                for c in disagg_new:
+                    active[c] = 'new-only (waste subsector)'
 
     # Appliances: old has 4 detail codes, new aggregates to 335220
     if _APPLIANCE_NEW_CODE in new_idx and _APPLIANCE_NEW_CODE not in old_idx:
@@ -172,23 +174,22 @@ def _build_fill_maps(
     to the source code(s) in the *same* EF vector whose value should be used.
 
     Old-side fills (codes missing from old EF):
-      - Waste subsectors (562111 …) ← old aggregate 562000
+      - Disaggregated subsectors (e.g. waste 562111 …) ← their old aggregate (e.g. 562000)
       - Appliance aggregate (335220) ← sum of old detail codes
       - Aluminum new code (33131B) ← old 331313
 
     New-side fills (codes missing from new EF):
-      - Waste aggregate (562000) ← sum of new subsectors
+      - Old aggregate codes (e.g. waste 562000) ← sum of their new subsectors
       - Appliance detail codes (335221 …) ← new aggregate 335220
     """
-    waste_old, waste_new = _waste_disagg()
     old_fill: FillMap = {}
     new_fill: FillMap = {}
 
-    # Waste: disaggregated in new schema
-    if waste_old in active_mappings:
-        for c in waste_new:
-            old_fill[c] = waste_old
-        new_fill[waste_old] = waste_new
+    for disagg_old, disagg_new in _disagg_sectors():
+        if disagg_old in active_mappings:
+            for c in disagg_new:
+                old_fill[c] = disagg_old
+            new_fill[disagg_old] = disagg_new
 
     # Appliances: aggregated in new schema
     if _APPLIANCE_NEW_CODE in active_mappings:


### PR DESCRIPTION
cc: cornerstone-data/bedrock#367 
Closes:

## What changed? Why?

Introduces a `DisaggSectorTaxonomy` dataclass and a `DISAGG_SECTORS` registry in a new `disagg_sectors.py` module. Previously, the waste sector disaggregation (BEA code `562000` → seven subsectors) was hardcoded in multiple places across `commodities.py`, `industries.py`, and various mapping and transformation files. This change centralizes all disaggregation metadata — aggregate codes, child industry codes, and child commodity codes — into a single source of truth.

`WASTE_DISAGG_COMMODITIES` and `WASTE_DISAGG_INDUSTRIES` are now derived from `DISAGG_SECTORS` rather than maintaining their own hardcoded lists, preserving backward compatibility while eliminating duplication. All call sites that previously referenced waste-specific logic now iterate over `DISAGG_SECTORS.values()`, making it straightforward to register additional disaggregated sectors in the future without touching transformation or mapping logic.

A backward-compatible alias `_apply_waste_intragroup_treatment = _apply_disagg_intragroup_treatment` is retained to avoid breaking any external references.

## Plan

Corresponds to PR 1 in [plan](https://github.com/cornerstone-data/bedrock/issues/367#issuecomment-4309284863)

## Testing

Added `test_disagg_sectors.py` with two tests:
- `test_disagg_sectors_waste_registry` — verifies the waste entry in `DISAGG_SECTORS` has the correct aggregate code, name, and exactly seven child industry and commodity codes.
- `test_waste_disagg_aliases_match_registry` — confirms that `WASTE_DISAGG_COMMODITIES` and `WASTE_DISAGG_INDUSTRIES` remain consistent with the registry values.