### PR TITLE
USEEIO Baseline 2 - wire GHG FBS m2

### DIFF
--- a/bedrock/analysis/time_series_B_matrix/derive_B_time_series.py
+++ b/bedrock/analysis/time_series_B_matrix/derive_B_time_series.py
@@ -245,7 +245,8 @@ def _map_fbs_to_cornerstone(fbs: pd.DataFrame) -> pd.DataFrame:
     regardless of the global usa_config flag, ensuring the canonical
     schema is always Cornerstone (405 sectors).
 
-    Logic mirrors ``map_to_CEDA()`` in transform/allocation/derived.py
+    Logic mirrors ``map_fbs_sectors_to_model_schema()`` in
+    transform/allocation/derived.py
     but hardcodes the Cornerstone mapping.
     """
     from bedrock.transform.flowbysector import FlowBySector  # noqa: PLC0415

--- a/bedrock/transform/allocation/derived.py
+++ b/bedrock/transform/allocation/derived.py
@@ -8,6 +8,9 @@ import pandas as pd
 from bedrock.transform.allocation.constants import EmissionsSource
 from bedrock.transform.allocation.registry import ALLOCATED_EMISSIONS_REGISTRY
 from bedrock.transform.flowbysector import FlowBySector, getFlowBySector
+from bedrock.transform.iot.derived_gross_industry_output import (
+    derive_gross_output_after_redefinition,
+)
 from bedrock.utils.config.common import load_crosswalk
 from bedrock.utils.config.usa_config import get_usa_config
 from bedrock.utils.emissions.ghg import GHG_MAPPING
@@ -23,6 +26,116 @@ from bedrock.utils.taxonomy.mappings.bea_v2017_industry__bea_v2017_commodity imp
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _select_flowsa_ghg_method() -> str:
+    """Select FBS methodname from USA config (first match wins)."""
+    usa = get_usa_config()
+    if usa.new_ghg_method:
+        return 'GHG_national_Cornerstone_2023'
+    if usa.use_ghg_national_2023_m2:
+        return 'GHG_national_2023_m2'
+    if usa.update_ghg_coa_allocation:
+        return 'GHG_national_Cornerstone_2023_coa_allocation'
+    if usa.update_electricity_ghg_method:
+        return 'GHG_national_Cornerstone_2023_electricity'
+    if usa.update_other_gases_ghg_method:
+        return 'GHG_national_Cornerstone_2023_other_gases'
+    if usa.update_ghg_attribution_method_for_ng_and_petrol_systems:
+        return 'GHG_national_Cornerstone_2023_petroleum_natgas'
+    if usa.update_flowsa_refrigerant_method:
+        return "GHG_national_Cornerstone_2023_refrigerants_foams"
+    if usa.update_transportation_ghg_method:
+        return 'GHG_national_Cornerstone_2023_mobile_combustion'
+    if usa.add_new_ghg_activities:
+        return 'GHG_national_Cornerstone_2023_new_activities'
+    if usa.update_enteric_fermentation_and_manure_management_ghg_method:
+        return 'GHG_national_Cornerstone_2023_ag_livestock'
+    if usa.update_liming_and_fertilizer_ghg_method:
+        return 'GHG_national_Cornerstone_2023_ag_soils'
+    return 'GHG_national_CEDA_2023'
+
+
+def _build_mapping_with_allocations(
+    mapping: pd.DataFrame, *, use_output_weights: bool
+) -> pd.DataFrame:
+    """Return Sector->Activity mapping with an Allocation column.
+
+    When ``use_output_weights`` is True, one-to-many Sector mappings are split
+    using gross industry output shares for ``usa_ghg_data_year``.
+    """
+    mapping2 = mapping[['Activity', 'Sector']].dropna().copy()
+    if not use_output_weights:
+        return (
+            mapping2.drop_duplicates(subset='Sector', keep='first')
+            .assign(Allocation=1.0)
+            .reset_index(drop=True)
+        )
+
+    go = derive_gross_output_after_redefinition(
+        target_year=get_usa_config().usa_ghg_data_year
+    )
+    mapping2['Output'] = mapping2['Activity'].map(go)
+    mapping2['Output'] = mapping2['Output'].fillna(0.0)
+
+    group_sum = mapping2.groupby('Sector')['Output'].transform('sum')
+    group_size = mapping2.groupby('Sector')['Sector'].transform('size')
+    bad_one_to_many = (group_size > 1) & (group_sum <= 0)
+    if bad_one_to_many.any():
+        bad_sectors = sorted(mapping2.loc[bad_one_to_many, 'Sector'].dropna().unique())
+        raise ValueError(
+            'Missing/zero gross output for one-to-many weighted mapping sectors: '
+            f'{bad_sectors[:20]}'
+        )
+
+    mapping2['Allocation'] = 0.0
+    valid_weight = group_sum > 0
+    mapping2.loc[valid_weight, 'Allocation'] = (
+        mapping2.loc[valid_weight, 'Output'] / group_sum.loc[valid_weight]
+    )
+    mapping2.loc[~valid_weight, 'Allocation'] = 1.0 / group_size.loc[~valid_weight]
+
+    return mapping2[['Activity', 'Sector', 'Allocation']].reset_index(drop=True)
+
+
+def _should_use_output_weighted_mapping() -> bool:
+    return bool(get_usa_config().use_ghg_national_2023_m2)
+
+
+def _build_naics_to_bea_weighted_mapping() -> pd.DataFrame:
+    """Build NAICS->BEA mapping weighted by gross output for GHG year."""
+    cw = load_crosswalk('NAICS_to_BEA_Crosswalk_2017')
+    mapping = cw.rename(
+        columns={
+            'NAICS_2017_Code': 'Sector',
+            'BEA_2017_Detail_Code': 'Activity',
+        }
+    )[['Sector', 'Activity']]
+    mapping = mapping.dropna().drop_duplicates().astype('string')
+
+    go = derive_gross_output_after_redefinition(
+        target_year=get_usa_config().usa_ghg_data_year
+    )
+    mapping['Output'] = mapping['Activity'].map(go).fillna(0.0)
+
+    group_sum = mapping.groupby('Sector')['Output'].transform('sum')
+    group_size = mapping.groupby('Sector')['Sector'].transform('size')
+    bad_one_to_many = (group_size > 1) & (group_sum <= 0)
+    if bad_one_to_many.any():
+        bad_sectors = sorted(mapping.loc[bad_one_to_many, 'Sector'].dropna().unique())
+        raise ValueError(
+            'Missing/zero gross output for one-to-many weighted NAICS->BEA sectors: '
+            f'{bad_sectors[:20]}'
+        )
+
+    mapping['Allocation'] = 0.0
+    valid_weight = group_sum > 0
+    mapping.loc[valid_weight, 'Allocation'] = (
+        mapping.loc[valid_weight, 'Output'] / group_sum.loc[valid_weight]
+    )
+    mapping.loc[~valid_weight, 'Allocation'] = 1.0 / group_size.loc[~valid_weight]
+
+    return mapping[['Sector', 'Activity', 'Allocation']].reset_index(drop=True)
 
 
 def derive_E_usa() -> pd.DataFrame:
@@ -69,8 +182,8 @@ def derive_E_usa_emissions_sources() -> pd.DataFrame:
     return E_usa
 
 
-def map_to_CEDA(fbs: pd.DataFrame) -> pd.DataFrame:
-    """Map FBS sectors from NAICS to CEDA v7 sectors."""
+def map_fbs_sectors_to_model_schema(fbs: pd.DataFrame) -> pd.DataFrame:
+    """Map FBS sectors from NAICS into the active model schema."""
     # Because the schema for the FBS is mixed digit, first need to expand the schema all the way
     # to 6 digits prior to mapping back to the CEDA schema. In doing this mapping we only need
     # to assign a 1:1 mapping (hence drop duplicates, keep = first). When the mapping is reversed
@@ -100,34 +213,46 @@ def map_to_CEDA(fbs: pd.DataFrame) -> pd.DataFrame:
     )
     fbs2['NAICS_6'] = fbs2['NAICS_6'].fillna(fbs2['SectorProducedBy'])
 
-    if get_usa_config().use_cornerstone_2026_model_schema:
-        mapping = get_activitytosector_mapping('Cornerstone_2025').drop_duplicates(
-            subset='Sector', keep='first'
+    use_output_weights = _should_use_output_weighted_mapping()
+    if use_output_weights:
+        mapping = _build_naics_to_bea_weighted_mapping()
+    elif get_usa_config().use_cornerstone_2026_model_schema:
+        mapping = _build_mapping_with_allocations(
+            get_activitytosector_mapping('Cornerstone_2025'),
+            use_output_weights=False,
         )
     else:
-        mapping = (
-            get_activitytosector_mapping('CEDA_2025')
-            # we don't want to map back to the sectors that are aggregated so keep only first
-            # this assumes that the first listed mapping is the priority.
-            # TODO: update to rely on the reported CEDA schema.
-            .drop_duplicates(subset='Sector', keep='first')
+        mapping = _build_mapping_with_allocations(
+            get_activitytosector_mapping('CEDA_2025'),
+            use_output_weights=False,
         )
+
+    pre_total = float(fbs2['FlowAmount'].sum())
     fbs2 = (
         fbs2.merge(
-            mapping[['Activity', 'Sector']],
+            mapping[['Activity', 'Sector', 'Allocation']],
             how='left',
             left_on='NAICS_6',
             right_on=['Sector'],
-            validate="m:1",
+            validate="m:m",
         )
+        .assign(Allocation=lambda x: x['Allocation'].fillna(1.0))
+        .assign(FlowAmount=lambda x: x['FlowAmount'] * x['Allocation'])
         .assign(SectorProducedBy=lambda x: x['Activity'].fillna(x['NAICS_6']))
-        .drop(columns=['Activity', 'NAICS', 'NAICS_6', 'Sector'])
+        .drop(columns=['Activity', 'NAICS', 'NAICS_6', 'Sector', 'Allocation'])
     )
 
     ## re assign SPB and aggregate using exisiting functions
     fbs3 = pd.DataFrame(FlowBySector(fbs2).aggregate_flowby())
 
-    # TODO: add test to confirm no data loss
+    if use_output_weights:
+        post_total = float(fbs3['FlowAmount'].sum())
+        rel_diff = abs(post_total - pre_total) / abs(pre_total) if pre_total else 0.0
+        if rel_diff > 0.005:
+            raise ValueError(
+                'FlowAmount conservation failed in weighted NAICS->BEA mapping '
+                f'(pre={pre_total}, post={post_total}, rel_diff={rel_diff:.6f})'
+            )
 
     return fbs3
 
@@ -138,6 +263,7 @@ def load_E_from_flowsa() -> pd.DataFrame:
     FBS method is chosen by USA config (first match wins):
     - GHG_national_Cornerstone_2023 when
       new_ghg_method is True
+    - GHG_national_2023_m2 when use_ghg_national_2023_m2 is True
     - GHG_national_Cornerstone_2023_coa_allocation when update_ghg_coa_allocation is True
     - GHG_national_Cornerstone_2023_electricity when
       update_electricity_ghg_method is True
@@ -158,32 +284,10 @@ def load_E_from_flowsa() -> pd.DataFrame:
 
     Only used when load_E_from_flowsa is True in USA config.
     """
-    usa = get_usa_config()
-    if usa.new_ghg_method:
-        methodname = 'GHG_national_Cornerstone_2023'
-    elif usa.update_ghg_coa_allocation:
-        methodname = 'GHG_national_Cornerstone_2023_coa_allocation'
-    elif usa.update_electricity_ghg_method:
-        methodname = 'GHG_national_Cornerstone_2023_electricity'
-    elif usa.update_other_gases_ghg_method:
-        methodname = 'GHG_national_Cornerstone_2023_other_gases'
-    elif usa.update_ghg_attribution_method_for_ng_and_petrol_systems:
-        methodname = 'GHG_national_Cornerstone_2023_petroleum_natgas'
-    elif usa.update_flowsa_refrigerant_method:
-        methodname = "GHG_national_Cornerstone_2023_refrigerants_foams"
-    elif usa.update_transportation_ghg_method:
-        methodname = 'GHG_national_Cornerstone_2023_mobile_combustion'
-    elif usa.add_new_ghg_activities:
-        methodname = 'GHG_national_Cornerstone_2023_new_activities'
-    elif usa.update_enteric_fermentation_and_manure_management_ghg_method:
-        methodname = 'GHG_national_Cornerstone_2023_ag_livestock'
-    elif usa.update_liming_and_fertilizer_ghg_method:
-        methodname = 'GHG_national_Cornerstone_2023_ag_soils'
-    else:
-        methodname = 'GHG_national_CEDA_2023'
+    methodname = _select_flowsa_ghg_method()
     fbs = getFlowBySector(methodname=methodname)
 
-    fbs = map_to_CEDA(fbs)
+    fbs = map_fbs_sectors_to_model_schema(fbs)
 
     # Align flow names with temporary mapping
     gas_map = {

--- a/bedrock/transform/allocation/derived.py
+++ b/bedrock/transform/allocation/derived.py
@@ -19,7 +19,10 @@ from bedrock.utils.mapping.sectormapping import (
     get_activitytosector_mapping,
 )
 from bedrock.utils.taxonomy.bea.ceda_v7 import CEDA_V7_SECTORS
-from bedrock.utils.taxonomy.cornerstone.industries import INDUSTRIES
+from bedrock.utils.taxonomy.cornerstone.industries import (
+    INDUSTRIES,
+    WASTE_DISAGG_INDUSTRIES,
+)
 from bedrock.utils.taxonomy.correspondence import create_correspondence_matrix
 from bedrock.utils.taxonomy.mappings.bea_v2017_industry__bea_v2017_commodity import (
     load_bea_v2017_industry_to_bea_v2017_commodity,
@@ -102,8 +105,30 @@ def _should_use_output_weighted_mapping() -> bool:
     return bool(get_usa_config().use_ghg_national_2023_m2)
 
 
+def _apply_cornerstone_waste_overrides(mapping: pd.DataFrame) -> pd.DataFrame:
+    """Override waste NAICS mappings with Cornerstone waste-disaggregated targets."""
+    waste_targets = set(WASTE_DISAGG_INDUSTRIES['562000'])
+    cs_mapping = _build_mapping_with_allocations(
+        get_activitytosector_mapping('Cornerstone_2025'),
+        use_output_weights=False,
+    )[['Sector', 'Activity']].dropna()
+    waste_override = cs_mapping[
+        cs_mapping['Sector'].str.startswith('562')
+        & cs_mapping['Activity'].isin(waste_targets)
+    ].drop_duplicates()
+    waste_naics = set(waste_override['Sector'])
+    return pd.concat(
+        [mapping[~mapping['Sector'].isin(waste_naics)], waste_override],
+        ignore_index=True,
+    ).drop_duplicates()
+
+
 def _build_naics_to_bea_weighted_mapping() -> pd.DataFrame:
-    """Build NAICS->BEA mapping weighted by gross output for GHG year."""
+    """Build NAICS->BEA mapping weighted by gross output for GHG year.
+
+    When waste disaggregation is enabled, start from the NAICS->BEA crosswalk and
+    override waste NAICS rows with the Cornerstone waste disaggregation.
+    """
     cw = load_crosswalk('NAICS_to_BEA_Crosswalk_2017')
     mapping = cw.rename(
         columns={
@@ -112,6 +137,8 @@ def _build_naics_to_bea_weighted_mapping() -> pd.DataFrame:
         }
     )[['Sector', 'Activity']]
     mapping = mapping.dropna().drop_duplicates().astype('string')
+    if get_usa_config().implement_waste_disaggregation:
+        mapping = _apply_cornerstone_waste_overrides(mapping)
 
     go = derive_gross_output_after_redefinition(
         target_year=get_usa_config().usa_ghg_data_year

--- a/bedrock/utils/config/__tests__/test_usa_config.py
+++ b/bedrock/utils/config/__tests__/test_usa_config.py
@@ -163,10 +163,25 @@ def test_disallow_new_ghg_method_with_m2_flag() -> None:
 
 def test_allow_m2_flag_when_new_ghg_method_is_false() -> None:
     cfg = USAConfig.model_validate(
-        {'new_ghg_method': False, 'use_ghg_national_2023_m2': True},
+        {
+            'new_ghg_method': False,
+            'use_ghg_national_2023_m2': True,
+            'use_useeio_schema': True,
+        },
         strict=True,
     )
     assert cfg.use_ghg_national_2023_m2 is True
+
+
+def test_disallow_m2_without_useeio_schema() -> None:
+    with pytest.raises(
+        ValueError,
+        match='use_ghg_national_2023_m2 requires use_useeio_schema to be true',
+    ):
+        USAConfig.model_validate(
+            {'use_ghg_national_2023_m2': True, 'use_useeio_schema': False},
+            strict=True,
+        )
 
 
 def test_disallow_useeio_b_with_e_data_year_x_flag() -> None:

--- a/bedrock/utils/config/configs/useeio_phoebe_23_restore_schema_and_ghg.yaml
+++ b/bedrock/utils/config/configs/useeio_phoebe_23_restore_schema_and_ghg.yaml
@@ -1,5 +1,6 @@
 # Sensitivity from useeio_phoebe_23.
 # Turns off using USEEIO schema
+# Since m2 requires useeio schema, this config also restores GHG to Cornerstone.
 
 model_base_year: 2017
 iot_before_or_after_redefinition: before
@@ -14,6 +15,6 @@ implement_waste_disaggregation: true
 
 use_useeio_schema: false # False means use Cornerstone schema
 use_useeio_B: true
-use_ghg_national_2023_m2: true
+use_ghg_national_2023_m2: false # Restore Cornerstone GHG method
 skip_scrap_adjustment_in_vnorm: true
-new_ghg_method: false
+new_ghg_method: true

--- a/bedrock/utils/config/usa_config.py
+++ b/bedrock/utils/config/usa_config.py
@@ -141,6 +141,10 @@ class USAConfig(BaseModel):
             raise ValueError(
                 'new_ghg_method and use_ghg_national_2023_m2 cannot both be true'
             )
+        if self.use_ghg_national_2023_m2 and not self.use_useeio_schema:
+            raise ValueError(
+                'use_ghg_national_2023_m2 requires use_useeio_schema to be true'
+            )
         if self.use_useeio_B and self.use_E_data_year_for_x_in_B:
             raise ValueError(
                 'use_useeio_B and use_E_data_year_for_x_in_B cannot both be true'


### PR DESCRIPTION
cc:
Closes:
## What changed? Why?

This PR implements the GHG m2 path wiring for the USEEIO baseline comparison. Adds an output allocation for attributing NAICS to BEA sectors where the mappings are many:many (e.g. gov't, construction).

Staged scope in this PR:

- `load_E_from_flowsa` now supports explicit m2 method selection:
  - Adds `GHG_national_2023_m2` selection in `bedrock/transform/allocation/derived.py`
  - Refactors method selection into `_select_flowsa_ghg_method()`
- Replaces the old sector mapping helper name with a schema-neutral one:
  - `map_fbs_sectors_to_model_schema(...)`
  - Updated internal call site and related analysis doc reference
- Adds weighted NAICS->BEA mapping path for m2:
  - Uses `NAICS_to_BEA_Crosswalk_2017` as mapping basis
  - For waste NAICS (562*), applies a targeted override from `Cornerstone_2025` waste sector definitions (via helper)
  - Uses `derive_gross_output_after_redefinition(target_year=usa_ghg_data_year)` for weights
  - Enforces fail-fast behavior for one-to-many sectors with missing/zero output weights
  - Adds mass-conservation check on mapped `FlowAmount` totals (raises when tolerance exceeded)
- Tightens config invariants in `USAConfig`:
  - disallow `new_ghg_method=true` with `use_ghg_national_2023_m2=true` (existing)
  - add invariant: `use_ghg_national_2023_m2` requires `use_useeio_schema=true`
- Updates sensitivity config naming/semantics to match new invariant:
  - Renames `useeio_phoebe_23_restore_schema.yaml` to `useeio_phoebe_23_restore_schema_and_ghg.yaml`
  - Adjusts contents so schema restore no longer represents an invalid m2+non-USEEIO combination
- Extends config test coverage:
  - m2 requires USEEIO schema
  - m2/new_ghg mutual exclusion

Why this step:

- Ensures m2 is selected intentionally and mapped using an explicit NAICS->BEA crosswalk with output-based weighting.
- Protects existing paths by constraining new weighted logic to the m2 branch and enforcing invariant combinations at config validation time.
- Adds conservation/error checks to prevent silent mapping drift.

## Testing

Test script confirm succesful mapping of m2 to target schema.
