### PR TITLE
USEEIO Baseline 3 - Add access to before redefinition use tables

### DIFF
--- a/bedrock/extract/iot/io_2017.py
+++ b/bedrock/extract/iot/io_2017.py
@@ -5,7 +5,11 @@ import functools
 import pandas as pd
 from typing_extensions import deprecated
 
-from bedrock.extract.iot.constants import GCS_USA_MAKE_USE_DIR, GCS_USA_SUP_DIR
+from bedrock.extract.iot.constants import (
+    GCS_USA_MAKE_USE_DIR,
+    GCS_USA_SUP_DIR,
+)
+from bedrock.utils.config.usa_config import get_usa_config
 from bedrock.utils.economic.units import MILLION_CURRENCY_TO_CURRENCY
 from bedrock.utils.io.gcp import load_from_gcs
 from bedrock.utils.io.local_extract_input_data import local_dir_for_gcs_sub_bucket
@@ -186,8 +190,8 @@ def load_2017_Utot_before_redef_usa() -> pd.DataFrame:
             name=USA_2017_DETAIL_IO_BEFORE_REDEF_MATRIX_MAPPING[
                 "Use_detail_before_redef"
             ],
-            sub_bucket=GCS_USA_DIR,
-            local_dir=IN_DIR,
+            sub_bucket=GCS_USA_MAKE_USE_DIR,
+            local_dir=LOCAL_USA_MAKE_USE_DIR,
             loader=lambda pth: pd.read_excel(
                 pth, sheet_name="2017", skiprows=5, dtype={"Code": str}
             ),
@@ -246,8 +250,8 @@ def load_2017_Uimp_before_redef_usa() -> pd.DataFrame:
             name=USA_2017_DETAIL_IO_BEFORE_REDEF_MATRIX_MAPPING[
                 "Import_detail_before_redef"
             ],
-            sub_bucket=GCS_USA_DIR,
-            local_dir=IN_DIR,
+            sub_bucket=GCS_USA_MAKE_USE_DIR,
+            local_dir=LOCAL_USA_MAKE_USE_DIR,
             loader=lambda pth: pd.read_excel(
                 pth, sheet_name="2017", skiprows=5, dtype={"Code": str}
             ),

--- a/bedrock/extract/iot/io_2017.py
+++ b/bedrock/extract/iot/io_2017.py
@@ -69,13 +69,18 @@ LOCAL_USA_SUP_DIR = local_dir_for_gcs_sub_bucket(GCS_USA_SUP_DIR)
 #     > Requirements Tables
 #       > After Redefinitions
 #         > Import Matrices/After Redefinitions
+#
+# ``load_2017_V_usa``, ``load_2017_Utot_usa``, and ``load_2017_Uimp_usa`` branch on
+# ``USAConfig.iot_before_or_after_redefinition`` and are not cached. Pipelines that
+# must always use after-redefinition BEA detail tables (e.g. CEDA mapping) should
+# call ``load_*_after_redef_usa`` explicitly.
 
 
 @functools.cache
-def load_2017_V_usa() -> pd.DataFrame:
+def load_2017_V_after_redef_usa() -> pd.DataFrame:
     """
-    Make table, industry x commodity, after redefintion, in producer price
-    unit is USD, original unit is million USD
+    Make table, industry x commodity, after redefinition, in producer price.
+    unit is USD, original unit is million USD.
     """
     df = (
         _load_2017_detail_make_use_usa("Make_detail")
@@ -86,6 +91,18 @@ def load_2017_V_usa() -> pd.DataFrame:
     df.index = USA_2017_INDUSTRY_INDEX
     df.columns = USA_2017_COMMODITY_INDEX
     return df
+
+
+def load_2017_V_usa() -> pd.DataFrame:
+    """2017 USA Make (V); before vs after BEA redefinitions from ``USAConfig``."""
+    stage = get_usa_config().iot_before_or_after_redefinition
+    if stage == "before":
+        return load_2017_V_before_redef_usa()
+    if stage == "after":
+        return load_2017_V_after_redef_usa()
+    raise ValueError(
+        "Invalid iot_before_or_after_redefinition; expected 'before' or 'after'."
+    )
 
 
 @functools.cache
@@ -129,10 +146,10 @@ def load_2017_V_before_redef_usa() -> pd.DataFrame:
 
 
 @functools.cache
-def load_2017_Utot_usa() -> pd.DataFrame:
+def load_2017_Utot_after_redef_usa() -> pd.DataFrame:
     """
-    Use table, commodity x industry, after redefintion, in producer price
-    unit is USD, original unit is million USD
+    Use table, commodity x industry, after redefinition, in producer price.
+    unit is USD, original unit is million USD.
     """
     df = (
         _load_2017_detail_make_use_usa("Use_detail")
@@ -146,11 +163,53 @@ def load_2017_Utot_usa() -> pd.DataFrame:
     return df
 
 
+def load_2017_Utot_usa() -> pd.DataFrame:
+    """2017 USA total Use (Utot); before vs after BEA redefinitions from ``USAConfig``."""
+    stage = get_usa_config().iot_before_or_after_redefinition
+    if stage == "before":
+        return load_2017_Utot_before_redef_usa()
+    if stage == "after":
+        return load_2017_Utot_after_redef_usa()
+    raise ValueError(
+        "Invalid iot_before_or_after_redefinition; expected 'before' or 'after'."
+    )
+
+
 @functools.cache
-def load_2017_Uimp_usa() -> pd.DataFrame:
+def load_2017_Utot_before_redef_usa() -> pd.DataFrame:
     """
-    Import table, commodity x industry, after redefintion, in producer price
-    unit is USD, original unit is million USD
+    Use table, commodity x industry, before redefinition, in producer price.
+    unit is USD, original unit is million USD.
+    """
+    df = (
+        load_from_gcs(
+            name=USA_2017_DETAIL_IO_BEFORE_REDEF_MATRIX_MAPPING[
+                "Use_detail_before_redef"
+            ],
+            sub_bucket=GCS_USA_DIR,
+            local_dir=IN_DIR,
+            loader=lambda pth: pd.read_excel(
+                pth, sheet_name="2017", skiprows=5, dtype={"Code": str}
+            ),
+        )
+        .set_index("Code")
+        .fillna(0)
+    )
+    df.columns = df.columns.astype(str)
+    df = (
+        df.loc[USA_2017_COMMODITY_CODES, USA_2017_INDUSTRY_CODES].astype(float)
+        * MILLION_CURRENCY_TO_CURRENCY
+    )
+    df.index = USA_2017_COMMODITY_INDEX
+    df.columns = USA_2017_INDUSTRY_INDEX
+    return df
+
+
+@functools.cache
+def load_2017_Uimp_after_redef_usa() -> pd.DataFrame:
+    """
+    Import table, commodity x industry, after redefinition, in producer price.
+    unit is USD, original unit is million USD.
     """
     df = (
         _load_2017_detail_make_use_usa("Import_detail")
@@ -161,6 +220,48 @@ def load_2017_Uimp_usa() -> pd.DataFrame:
     df.index = USA_2017_COMMODITY_INDEX
     df.columns = USA_2017_INDUSTRY_INDEX
 
+    return df
+
+
+def load_2017_Uimp_usa() -> pd.DataFrame:
+    """2017 USA import Use (Uimp); before vs after BEA redefinitions from ``USAConfig``."""
+    stage = get_usa_config().iot_before_or_after_redefinition
+    if stage == "before":
+        return load_2017_Uimp_before_redef_usa()
+    if stage == "after":
+        return load_2017_Uimp_after_redef_usa()
+    raise ValueError(
+        "Invalid iot_before_or_after_redefinition; expected 'before' or 'after'."
+    )
+
+
+@functools.cache
+def load_2017_Uimp_before_redef_usa() -> pd.DataFrame:
+    """
+    Import table, commodity x industry, before redefinition, in producer price.
+    unit is USD, original unit is million USD.
+    """
+    df = (
+        load_from_gcs(
+            name=USA_2017_DETAIL_IO_BEFORE_REDEF_MATRIX_MAPPING[
+                "Import_detail_before_redef"
+            ],
+            sub_bucket=GCS_USA_DIR,
+            local_dir=IN_DIR,
+            loader=lambda pth: pd.read_excel(
+                pth, sheet_name="2017", skiprows=5, dtype={"Code": str}
+            ),
+        )
+        .set_index("Code")
+        .fillna(0)
+    )
+    df.columns = df.columns.astype(str)
+    df = (
+        df.loc[USA_2017_COMMODITY_CODES, USA_2017_INDUSTRY_CODES].astype(float)
+        * MILLION_CURRENCY_TO_CURRENCY
+    )
+    df.index = USA_2017_COMMODITY_INDEX
+    df.columns = USA_2017_INDUSTRY_INDEX
     return df
 
 

--- a/bedrock/transform/allocation/derived.py
+++ b/bedrock/transform/allocation/derived.py
@@ -74,6 +74,12 @@ def _build_mapping_with_allocations(
             .assign(Allocation=1.0)
             .reset_index(drop=True)
         )
+    # TODO:
+    # m2 NAICS→BEA weights use derive_gross_output_after_redefinition (after-redef-adjusted
+    # BEA detail GO). USEEIO Phoebe sets BasewithRedefinitions: FALSE so getNAICStoBEAAllocation
+    # uses MultiYearIndustryOutput tied to before-redef benchmark IO. Evaluate whether to
+    # branch weight source on model config (e.g. iot_before_or_after_redefinition or a
+    # dedicated flag) for parity vs documenting an intentional difference.
 
     go = derive_gross_output_after_redefinition(
         target_year=get_usa_config().usa_ghg_data_year

--- a/bedrock/transform/allocation/derived.py
+++ b/bedrock/transform/allocation/derived.py
@@ -9,8 +9,7 @@ from bedrock.transform.allocation.constants import EmissionsSource
 from bedrock.transform.allocation.registry import ALLOCATED_EMISSIONS_REGISTRY
 from bedrock.transform.flowbysector import FlowBySector, getFlowBySector
 from bedrock.transform.iot.derived_gross_industry_output import (
-    derive_gross_output_after_redefinition,
-    derive_gross_output_before_redefinition,
+    derive_gross_output,
 )
 from bedrock.utils.config.common import load_crosswalk
 from bedrock.utils.config.usa_config import get_usa_config
@@ -30,16 +29,6 @@ from bedrock.utils.taxonomy.mappings.bea_v2017_industry__bea_v2017_commodity imp
 )
 
 logger = logging.getLogger(__name__)
-
-
-def derive_gross_output() -> pd.Series[float]:
-    """Derive gross output series based on configured redefinition mode."""
-    cfg = get_usa_config()
-    if cfg.iot_before_or_after_redefinition == 'before':
-        return derive_gross_output_before_redefinition(
-            target_year=cfg.usa_ghg_data_year
-        )
-    return derive_gross_output_after_redefinition(target_year=cfg.usa_ghg_data_year)
 
 
 def _select_flowsa_ghg_method() -> str:
@@ -85,7 +74,11 @@ def _build_mapping_with_allocations(
             .assign(Allocation=1.0)
             .reset_index(drop=True)
         )
-    go = derive_gross_output()
+    cfg = get_usa_config()
+    go = derive_gross_output(
+        target_year=cfg.usa_ghg_data_year,
+        iot_before_or_after_redefinition=cfg.iot_before_or_after_redefinition,
+    )
     mapping2['Output'] = mapping2['Activity'].map(go)
     mapping2['Output'] = mapping2['Output'].fillna(0.0)
 
@@ -148,7 +141,11 @@ def _build_naics_to_bea_weighted_mapping() -> pd.DataFrame:
     if get_usa_config().implement_waste_disaggregation:
         mapping = _apply_cornerstone_waste_overrides(mapping)
 
-    go = derive_gross_output()
+    cfg = get_usa_config()
+    go = derive_gross_output(
+        target_year=cfg.usa_ghg_data_year,
+        iot_before_or_after_redefinition=cfg.iot_before_or_after_redefinition,
+    )
     mapping['Output'] = mapping['Activity'].map(go).fillna(0.0)
 
     group_sum = mapping.groupby('Sector')['Output'].transform('sum')

--- a/bedrock/transform/allocation/derived.py
+++ b/bedrock/transform/allocation/derived.py
@@ -10,6 +10,7 @@ from bedrock.transform.allocation.registry import ALLOCATED_EMISSIONS_REGISTRY
 from bedrock.transform.flowbysector import FlowBySector, getFlowBySector
 from bedrock.transform.iot.derived_gross_industry_output import (
     derive_gross_output_after_redefinition,
+    derive_gross_output_before_redefinition,
 )
 from bedrock.utils.config.common import load_crosswalk
 from bedrock.utils.config.usa_config import get_usa_config
@@ -29,6 +30,16 @@ from bedrock.utils.taxonomy.mappings.bea_v2017_industry__bea_v2017_commodity imp
 )
 
 logger = logging.getLogger(__name__)
+
+
+def derive_gross_output() -> pd.Series[float]:
+    """Derive gross output series based on configured redefinition mode."""
+    cfg = get_usa_config()
+    if cfg.iot_before_or_after_redefinition == 'before':
+        return derive_gross_output_before_redefinition(
+            target_year=cfg.usa_ghg_data_year
+        )
+    return derive_gross_output_after_redefinition(target_year=cfg.usa_ghg_data_year)
 
 
 def _select_flowsa_ghg_method() -> str:
@@ -74,16 +85,7 @@ def _build_mapping_with_allocations(
             .assign(Allocation=1.0)
             .reset_index(drop=True)
         )
-    # TODO:
-    # m2 NAICS→BEA weights use derive_gross_output_after_redefinition (after-redef-adjusted
-    # BEA detail GO). USEEIO Phoebe sets BasewithRedefinitions: FALSE so getNAICStoBEAAllocation
-    # uses MultiYearIndustryOutput tied to before-redef benchmark IO. Evaluate whether to
-    # branch weight source on model config (e.g. iot_before_or_after_redefinition or a
-    # dedicated flag) for parity vs documenting an intentional difference.
-
-    go = derive_gross_output_after_redefinition(
-        target_year=get_usa_config().usa_ghg_data_year
-    )
+    go = derive_gross_output()
     mapping2['Output'] = mapping2['Activity'].map(go)
     mapping2['Output'] = mapping2['Output'].fillna(0.0)
 
@@ -146,9 +148,7 @@ def _build_naics_to_bea_weighted_mapping() -> pd.DataFrame:
     if get_usa_config().implement_waste_disaggregation:
         mapping = _apply_cornerstone_waste_overrides(mapping)
 
-    go = derive_gross_output_after_redefinition(
-        target_year=get_usa_config().usa_ghg_data_year
-    )
+    go = derive_gross_output()
     mapping['Output'] = mapping['Activity'].map(go).fillna(0.0)
 
     group_sum = mapping.groupby('Sector')['Output'].transform('sum')

--- a/bedrock/transform/eeio/derived_2017.py
+++ b/bedrock/transform/eeio/derived_2017.py
@@ -16,9 +16,9 @@ from bedrock.extract.iot.io_2012 import (
     load_2012_YR_usa,
 )
 from bedrock.extract.iot.io_2017 import (
-    load_2017_Uimp_usa,
-    load_2017_Utot_usa,
-    load_2017_V_usa,
+    load_2017_Uimp_after_redef_usa,
+    load_2017_Utot_after_redef_usa,
+    load_2017_V_after_redef_usa,
     load_2017_value_added_usa,
     load_2017_Ytot_usa,
     load_summary_Uimp_usa,
@@ -136,7 +136,7 @@ def derive_2017_U_set_usa() -> SingleRegionUMatrixSet:
 @functools.cache
 @pa.check_output(VMatrix.to_schema())
 def derive_2017_V_usa() -> pt.DataFrame[VMatrix]:
-    V_2017 = load_2017_V_usa()
+    V_2017 = load_2017_V_after_redef_usa()
     V_2017_structural_reflected = structural_reflect_matrix(
         row_corresp_df=load_usa_2017_industry__ceda_v7_correspondence(),
         col_corresp_df=load_usa_2017_commodity__ceda_v7_correspondence(),
@@ -182,7 +182,7 @@ def derive_2017_Vnorm_scrap_corrected() -> pt.DataFrame[VMatrix]:
     q = compute_q(V=V_usa)
     Vnorm = compute_Vnorm_matrix(V=V_usa, q=q)
 
-    scrap_2017 = load_2017_V_usa().loc[:, "S00401"]
+    scrap_2017 = load_2017_V_after_redef_usa().loc[:, "S00401"]
     scrap_faction = structural_reflect_vector(
         corresp_df=load_usa_2017_industry__ceda_v7_correspondence(),
         ser_base=scrap_2017,
@@ -198,8 +198,8 @@ def derive_2017_Vnorm_scrap_corrected() -> pt.DataFrame[VMatrix]:
 
 @functools.cache
 def derive_2017_U_with_negatives() -> SingleRegionUMatrixSet:
-    Utot_usa = load_2017_Utot_usa()
-    Uimp_usa = load_2017_Uimp_usa()
+    Utot_usa = load_2017_Utot_after_redef_usa()
+    Uimp_usa = load_2017_Uimp_after_redef_usa()
     Udom_usa = Utot_usa - Uimp_usa
 
     corresp_industry_ceda = load_usa_2017_industry__ceda_v7_correspondence()

--- a/bedrock/transform/eeio/derived_cornerstone.py
+++ b/bedrock/transform/eeio/derived_cornerstone.py
@@ -74,7 +74,7 @@ from bedrock.transform.eeio.waste_disaggregation import (
     apply_waste_disagg_to_Ytot,
 )
 from bedrock.transform.iot.derived_gross_industry_output import (
-    derive_gross_output_after_redefinition,
+    derive_gross_output,
 )
 from bedrock.utils.config.usa_config import EEIOWasteDisaggConfig, get_usa_config
 from bedrock.utils.economic.inflation_helpers_cornerstone import (
@@ -248,9 +248,9 @@ def _distribute_waste_parent_x_using_v_row_shares(
 def derive_cornerstone_x_after_redefinition() -> pd.Series[float]:
     """Gross industry output in Cornerstone schema, after BEA redefinitions.
 
-    Uses BEA's after-redefinition gross-output time series for the configured
-    GHG data year, then expands it to Cornerstone industries via the
-    BEA→Cornerstone industry correspondence.
+    Uses gross-output time series for the configured GHG data year, selecting
+    before/after-redefinition source from config, then expands it to
+    Cornerstone industries via the BEA→Cornerstone industry correspondence.
 
     For one-to-many splits (e.g. waste 562000), ``expand_vector`` first
     duplicates the parent scalar to each child. When waste disaggregation is
@@ -263,8 +263,9 @@ def derive_cornerstone_x_after_redefinition() -> pd.Series[float]:
     ``derive_cornerstone_x()``.
     """
     cfg = get_usa_config()
-    x_bea = derive_gross_output_after_redefinition(
+    x_bea = derive_gross_output(
         target_year=cfg.usa_ghg_data_year,
+        iot_before_or_after_redefinition=cfg.iot_before_or_after_redefinition,
     )
     x_cs = expand_vector(x_bea, CS_INDUSTRY_LIST, cs_industry_to_bea_map())
     x_cs.index.name = "sector"

--- a/bedrock/transform/iot/__tests__/test_derive_gross_output.py
+++ b/bedrock/transform/iot/__tests__/test_derive_gross_output.py
@@ -161,13 +161,13 @@ def test_2017_redefinition_roundtrip() -> None:
     also checks that the absolute per-industry error is negligible.
     """
     from bedrock.extract.iot.io_2017 import (
+        load_2017_V_after_redef_usa,
         load_2017_V_before_redef_usa,
-        load_2017_V_usa,
     )
     from bedrock.utils.math.formulas import compute_x
 
     V_before_redef = load_2017_V_before_redef_usa()
-    V_after_redef = load_2017_V_usa()
+    V_after_redef = load_2017_V_after_redef_usa()
 
     x_before = compute_x(V=V_before_redef)
     x_after_expected = compute_x(V=V_after_redef)

--- a/bedrock/transform/iot/derived_gross_industry_output.py
+++ b/bedrock/transform/iot/derived_gross_industry_output.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import typing as ta
 
 import numpy as np
 import pandas as pd
@@ -11,6 +12,18 @@ from bedrock.utils.taxonomy.bea.matrix_mappings import USA_GROSS_INDUSTRY_OUTPUT
 SECTOR_CODE_COL = 'sector_code'
 
 logger = logging.getLogger(__name__)
+
+RedefinitionMode = ta.Literal['before', 'after']
+
+
+def derive_gross_output(
+    target_year: USA_GROSS_INDUSTRY_OUTPUT_YEARS,
+    iot_before_or_after_redefinition: RedefinitionMode,
+) -> pd.Series:
+    """Return gross output for the selected redefinition mode and target year."""
+    if iot_before_or_after_redefinition == 'before':
+        return derive_gross_output_before_redefinition(target_year=target_year)
+    return derive_gross_output_after_redefinition(target_year=target_year)
 
 
 def _load_mapped_gross_output_before_redefinition(

--- a/bedrock/transform/iot/derived_gross_industry_output.py
+++ b/bedrock/transform/iot/derived_gross_industry_output.py
@@ -13,37 +13,12 @@ SECTOR_CODE_COL = 'sector_code'
 logger = logging.getLogger(__name__)
 
 
-def derive_gross_output_after_redefinition(
+def _load_mapped_gross_output_before_redefinition(
     target_year: USA_GROSS_INDUSTRY_OUTPUT_YEARS,
 ) -> pd.Series:
-    """
-    Derive after-redefinition gross industry output for a target year.
-
-    Loads the 2017 benchmark Make table (before redefinitions), computes
-    co-production ratios, then applies them to the BEA gross-output time
-    series for the requested *target_year*.
-
-    Parameters
-    ----------
-    target_year : int
-        Calendar year (e.g. 2023) for which to derive the adjusted gross
-        output.  Must be present in the BEA detail gross-output workbook.
-
-    Returns
-    -------
-    pd.Series
-        After-redefinition gross output indexed by BEA detail industry code.
-    """
+    """Load mapped BEA detail gross output (before redefinition) for one year."""
     from bedrock.extract.iot.gdp import load_go_detail
-    from bedrock.extract.iot.io_2017 import (
-        load_2017_V_after_redef_usa,
-        load_2017_V_before_redef_usa,
-    )
     from bedrock.transform.iot.helpers import map_detail_table
-
-    V_before_redef = load_2017_V_before_redef_usa()
-    V_after_redef = load_2017_V_after_redef_usa()
-    ratios = compute_coproduction_ratios(V_before_redef, V_after_redef)
 
     go_detail = map_detail_table(load_go_detail())
     unmapped = go_detail[go_detail[SECTOR_CODE_COL].isna()]
@@ -77,10 +52,52 @@ def derive_gross_output_after_redefinition(
 
     go_before = go_detail.set_index(SECTOR_CODE_COL)[year_col]
     assert isinstance(go_before, pd.Series)
-
     if not go_before.index.is_unique:
         logger.warning('Duplicate sector codes in gross output; aggregating by sum.')
         go_before = go_before.groupby(level=0).sum()
+    return go_before
+
+
+def derive_gross_output_before_redefinition(
+    target_year: USA_GROSS_INDUSTRY_OUTPUT_YEARS,
+) -> pd.Series:
+    """Return BEA detail gross output before redefinition for a target year."""
+    return (
+        _load_mapped_gross_output_before_redefinition(target_year)
+        * MILLION_CURRENCY_TO_CURRENCY
+    )
+
+
+def derive_gross_output_after_redefinition(
+    target_year: USA_GROSS_INDUSTRY_OUTPUT_YEARS,
+) -> pd.Series:
+    """
+    Derive after-redefinition gross industry output for a target year.
+
+    Loads the 2017 benchmark Make table (before redefinitions), computes
+    co-production ratios, then applies them to the BEA gross-output time
+    series for the requested *target_year*.
+
+    Parameters
+    ----------
+    target_year : int
+        Calendar year (e.g. 2023) for which to derive the adjusted gross
+        output.  Must be present in the BEA detail gross-output workbook.
+
+    Returns
+    -------
+    pd.Series
+        After-redefinition gross output indexed by BEA detail industry code.
+    """
+    from bedrock.extract.iot.io_2017 import (
+        load_2017_V_after_redef_usa,
+        load_2017_V_before_redef_usa,
+    )
+
+    go_before = _load_mapped_gross_output_before_redefinition(target_year)
+    V_before_redef = load_2017_V_before_redef_usa()
+    V_after_redef = load_2017_V_after_redef_usa()
+    ratios = compute_coproduction_ratios(V_before_redef, V_after_redef)
 
     return adjust_gross_output(go_before, ratios) * MILLION_CURRENCY_TO_CURRENCY
 

--- a/bedrock/transform/iot/derived_gross_industry_output.py
+++ b/bedrock/transform/iot/derived_gross_industry_output.py
@@ -36,13 +36,13 @@ def derive_gross_output_after_redefinition(
     """
     from bedrock.extract.iot.gdp import load_go_detail
     from bedrock.extract.iot.io_2017 import (
+        load_2017_V_after_redef_usa,
         load_2017_V_before_redef_usa,
-        load_2017_V_usa,
     )
     from bedrock.transform.iot.helpers import map_detail_table
 
     V_before_redef = load_2017_V_before_redef_usa()
-    V_after_redef = load_2017_V_usa()
+    V_after_redef = load_2017_V_after_redef_usa()
     ratios = compute_coproduction_ratios(V_before_redef, V_after_redef)
 
     go_detail = map_detail_table(load_go_detail())

--- a/bedrock/utils/taxonomy/bea/matrix_mappings.py
+++ b/bedrock/utils/taxonomy/bea/matrix_mappings.py
@@ -14,6 +14,8 @@ USA_2017_DETAIL_IO_MATRIX_MAPPING = {
 
 USA_2017_DETAIL_IO_BEFORE_REDEF_MATRIX_MAPPING = {
     "Make_detail_before_redef": "IOMake_Before_Redefinitions_2017_Detail.xlsx",
+    "Use_detail_before_redef": "IOUse_Before_Redefinitions_PRO_2017_Detail.xlsx",
+    "Import_detail_before_redef": "ImportMatrices_Before_Redefinitions_DET_2017.xlsx",
 }
 
 USA_2017_DETAIL_IO_SUT_MATRIX_NAMES = ta.Literal[


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

When `iot_before_or_after_redefinition` is `before`, we load a **matched set** of BEA 2017 detail tables for the Make matrix, total Use, and imports. When it is `after`, behavior matches what we had before. Legacy paths that only make sense on after-redefinition tables (CEDA 2017 IO and gross-output adjustment helpers) now call **explicit after-redef loaders** so they do not change when USEEIO model sets `before`. Added access to industry output before redefinitions via `derive_gross_output_before_redefinition()` through helper function `derive_gross_output()` which chooses between before and after.

**Files touched**

- [`bedrock/utils/taxonomy/bea/matrix_mappings.py`](bedrock/utils/taxonomy/bea/matrix_mappings.py) — before-redef Use and Import workbook names for 2017 detail (Make was already mapped).
- [`bedrock/extract/iot/io_2017.py`](bedrock/extract/iot/io_2017.py) — separate cached loaders for after- vs before-redef tables; `load_2017_V_usa`, `load_2017_Utot_usa`, and `load_2017_Uimp_usa` read `USAConfig` and return the matching set (those three are not cached).
- [`bedrock/transform/eeio/derived_cornerstone.py`](bedrock/transform/eeio/derived_cornerstone.py) and [`bedrock/transform/eeio/cornerstone_bea_intermediates.py`](bedrock/transform/eeio/cornerstone_bea_intermediates.py) — use the config-driven `load_2017_*_usa` entry points so V and U stay aligned.
- [`bedrock/transform/eeio/derived_2017.py`](bedrock/transform/eeio/derived_2017.py), [`bedrock/transform/iot/derived_gross_industry_output.py`](bedrock/transform/iot/derived_gross_industry_output.py), and related tests — use explicit `load_*_after_redef_usa` where the pipeline must stay on after-redef BEA data.
- [`bedrock/transform/iot/derived_gross_industry_output.py`](bedrock/transform/iot/derived_gross_industry_output.py) includes new access to gross output before redefinitions based on `iot_before_or_after_redefinition`

## Testing

Confirmed successful generation of V and U before redefs
```
    set_global_usa_config("useeio_phoebe_23")
    cfg = get_usa_config()
    V = derive_cornerstone_V()
    U = derive_cornerstone_U_set()
```



