### PR TITLE
feat(analysis): derive A matrix time series + run-report Sheet

### DIFF
--- a/.github/workflows/a_matrix_analysis.yml
+++ b/.github/workflows/a_matrix_analysis.yml
@@ -1,0 +1,135 @@
+name: a_matrix_analysis
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_url:
+        description: "Optional PR URL to associate with this run"
+        required: false
+        type: string
+        default: ""
+
+env:
+  FORCE_COLOR: 2
+
+jobs:
+  analysis:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      id-token: write
+      contents: read
+    outputs:
+      sheet_id: ${{ steps.capture_sheet.outputs.sheet_id }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python and install dependencies
+        uses: ./.github/actions/setup-python
+
+      - name: Authenticate with Google Cloud
+        uses: "google-github-actions/auth@v2"
+        with:
+          project_id: cornerstone-data
+          workload_identity_provider: projects/75718421862/locations/global/workloadIdentityPools/github-actions/providers/github
+          service_account: github-actions-cornerstone@cornerstone-data.iam.gserviceaccount.com
+
+      - name: Step 1 — derive A matrix time series
+        run: uv run python -m bedrock.analysis.a_matrix_time_series.derive_A_time_series
+
+      - name: Step 2 — cell-by-cell diagnostics + plots
+        run: uv run python -m bedrock.analysis.a_matrix_time_series.derive_A_cells_long
+
+      - name: Capture run-report Sheet ID
+        id: capture_sheet
+        run: |
+          SHEET_ID_PATH="bedrock/analysis/a_matrix_time_series/output/results/last_run_sheet_id.txt"
+          if [ -f "$SHEET_ID_PATH" ]; then
+            echo "sheet_id=$(cat $SHEET_ID_PATH)" >> "$GITHUB_OUTPUT"
+          else
+            echo "sheet_id=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload plots
+        uses: actions/upload-artifact@v4
+        with:
+          name: a_matrix_analysis_plots_${{ github.sha }}
+          path: bedrock/analysis/a_matrix_time_series/output/plots/
+          if-no-files-found: warn
+
+      - name: Upload results CSVs
+        uses: actions/upload-artifact@v4
+        with:
+          name: a_matrix_analysis_results_${{ github.sha }}
+          path: |
+            bedrock/analysis/a_matrix_time_series/output/results/*.csv
+            bedrock/analysis/a_matrix_time_series/output/results/last_run_sheet_id.txt
+          if-no-files-found: warn
+
+  notify_slack_failure:
+    needs: analysis
+    runs-on: ubuntu-latest
+    if: always() && needs.analysis.result == 'failure'
+
+    steps:
+      - name: Notify on Slack - failure
+        uses: slackapi/slack-github-action@v1.24.0
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN }}
+        with:
+          channel-id: C09S03U9CH4 # #alerts-bedrock
+          payload: |
+            {
+              "text": "Bedrock A-matrix Analysis Failure",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                      "type": "mrkdwn",
+                      "text": ":warning: *Bedrock A-matrix Analysis Failure*\nFailed on `${{ github.ref_name }}` `${{ github.sha }}`"
+                  },
+                  "accessory": {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "View logs"
+                    },
+                    "url": "${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}"
+                  }
+                }
+              ]
+            }
+
+  notify_slack_success:
+    needs: analysis
+    runs-on: ubuntu-latest
+    if: always() && needs.analysis.result == 'success'
+
+    steps:
+      - name: Notify on Slack - success
+        uses: slackapi/slack-github-action@v1.24.0
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN }}
+        with:
+          channel-id: C09S03U9CH4 # #alerts-bedrock
+          payload: |
+            {
+              "text": "Bedrock A-matrix Analysis Success",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                      "type": "mrkdwn",
+                      "text": ":white_check_mark: *Bedrock A-matrix Analysis Success*\nCompleted on `${{ github.ref_name }}` `${{ github.sha }}`\n\n*Run-report Sheet:* https://docs.google.com/spreadsheets/d/${{ needs.analysis.outputs.sheet_id }}\n*Plots:* download via the run's Artifacts tab"
+                  },
+                  "accessory": {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "View logs"
+                    },
+                    "url": "${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}"
+                  }
+                }
+              ]
+            }

--- a/bedrock/analysis/a_matrix_time_series/derive_A_cells_long.py
+++ b/bedrock/analysis/a_matrix_time_series/derive_A_cells_long.py
@@ -1,0 +1,650 @@
+"""Step 2 of epic #337: cell-by-cell time-series diagnostics for the A matrix.
+
+Reads the parquet caches produced by ``derive_A_time_series.py`` (Step 1, #340)
+and produces:
+
+- ``A_cells_long.parquet`` — long-format
+  ``(row_sector, col_sector, year, approach, dom_or_imp, A_value,
+    delta_from_2017, delta_yoy, delta_vs_useeio, delta_vs_ceda)``. ~12.8M rows.
+  Two baseline-divergence columns honor the **two-baseline convention** from
+  the analysis plan: every comparison is reported against both USEEIO (the
+  unchanged BEA-2017 base) and CEDA-US (the production-default approach at
+  the same year).
+
+- ``scatter_vs_baselines_{dom,imp}.png`` — 3×2 grid (alternative approach ×
+  baseline) of element-wise scatter plots. Per-row target year is the latest
+  year where the approach and both baselines all have data:
+  ``commodity_price_index`` and ``industry_price_index`` rows resolve to 2024;
+  ``summary_tables`` falls back to 2023 (BEA Excel hasn't published 2024 yet).
+  All 6 panels share the same ``xlim``/``ylim`` so the ``y=x`` line is a true
+  45° reference. Each panel has a top-left summary box with ``n``, mean / p95
+  / max ``|Δ|``, and ``R²``.
+
+- ``divergence_share_{dom,imp}.png`` — 3×2 grid (alternative × baseline) of
+  the share of cells whose ``|A_approach − A_baseline|`` exceeds each
+  threshold (1e-4, 1e-3, 1e-2, 1e-1) plotted over years. Answers "how
+  widespread is the divergence and how does it spread?" — complements the
+  scatter (which shows magnitude at a single year).
+
+- ``baseline_reference_{dom,imp}.png`` — 1×2 reference plot comparing the
+  two baselines directly: USEEIO-vs-CEDA scatter at the latest common year
+  plus share-of-cells over thresholds across years. Provides a "reference
+  floor" for interpreting alternative-vs-baseline divergence — readers can
+  read the alternative-vs-USEEIO and alternative-vs-CEDA panels against
+  the gap between the baselines themselves.
+
+- ``divergence_vs_useeio`` and ``divergence_vs_ceda`` tabs appended to the
+  run-report Sheet. Each row is per (approach, year, dom_or_imp), with
+  ``max``, ``p99``, ``p95``, ``p75``, ``p50``, ``mean``, and
+  ``n_above_1pct`` of ``|delta_vs_<baseline>|``. Sheet ID is read from
+  ``last_run_sheet_id.txt`` (written by Step 1); if missing, Sheet publish
+  is skipped with a warning.
+
+Usage:
+    python -m bedrock.analysis.a_matrix_time_series.derive_A_cells_long
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from bedrock.utils.io.gcp import update_sheet_tab
+
+logger = logging.getLogger(__name__)
+
+OUTPUT_DIR = Path(__file__).parent / "output"
+RESULTS_DIR = OUTPUT_DIR / "results"
+PLOTS_DIR = OUTPUT_DIR / "plots"
+LAST_RUN_SHEET_ID_PATH = RESULTS_DIR / "last_run_sheet_id.txt"
+A_CELLS_LONG_PATH = RESULTS_DIR / "A_cells_long.parquet"
+
+SCATTER_APPROACHES = ("commodity_price_index", "industry_price_index", "summary_tables")
+SCATTER_BASELINES = (("useeio", "USEEIO"), ("ceda_default", "CEDA-US"))
+
+
+def _list_pairs() -> list[tuple[str, int]]:
+    """Discover (approach, year) pairs from the parquet cache.
+
+    Skips files that don't match ``A_{approach}_{4-digit-year}.parquet`` so
+    other artifacts in the same dir (e.g. ``A_cells_long.parquet``) are
+    ignored.
+    """
+    pairs: list[tuple[str, int]] = []
+    for path in sorted(RESULTS_DIR.glob("A_*.parquet")):
+        stem = path.stem  # e.g. A_useeio_2017
+        body = stem[2:]  # strip leading "A_"
+        approach, _, year_str = body.rpartition("_")
+        if not (year_str.isdigit() and len(year_str) == 4):
+            continue
+        pairs.append((approach, int(year_str)))
+    return pairs
+
+
+def _load_pair(approach: str, year: int) -> dict[str, pd.DataFrame]:
+    """Load Adom + Aimp from the combined parquet for one (approach, year)."""
+    combined = pd.read_parquet(RESULTS_DIR / f"A_{approach}_{year}.parquet")
+    return {
+        "dom": pd.DataFrame(combined.loc["dom"]),
+        "imp": pd.DataFrame(combined.loc["imp"]),
+    }
+
+
+def _melt(df: pd.DataFrame, approach: str, year: int, kind: str) -> pd.DataFrame:
+    """Wide A matrix → long (row_sector, col_sector, A_value) + metadata.
+
+    Direct numpy-based melt: faster than ``df.stack().reset_index(...)`` and
+    avoids the duplicate-column collision when both axes share the source
+    parquet's ``sector`` name.
+    """
+    rows = df.index.to_numpy()
+    cols = df.columns.to_numpy()
+    return pd.DataFrame(
+        {
+            "row_sector": np.repeat(rows, len(cols)),
+            "col_sector": np.tile(cols, len(rows)),
+            "A_value": df.to_numpy().ravel(),
+            "approach": approach,
+            "year": year,
+            "dom_or_imp": kind,
+        }
+    )
+
+
+def build_a_cells_long() -> pd.DataFrame:
+    """Concat all cells; attach intra-approach drift (``delta_from_2017``,
+    ``delta_yoy``) and dual-baseline divergence (``delta_vs_useeio``,
+    ``delta_vs_ceda``) per (approach, dom_or_imp, row_sector, col_sector,
+    year)."""
+    chunks: list[pd.DataFrame] = []
+    for approach, year in _list_pairs():
+        matrices = _load_pair(approach, year)
+        for kind, mat in matrices.items():
+            chunks.append(_melt(mat, approach, year, kind))
+
+    long = pd.concat(chunks, ignore_index=True)
+
+    cell_keys = ["approach", "dom_or_imp", "row_sector", "col_sector"]
+    long = long.sort_values(cell_keys + ["year"]).reset_index(drop=True)
+
+    # Intra-approach drift: this approach's value at year y, minus this
+    # approach's value at 2017.
+    base_2017 = (
+        long[long["year"] == 2017]
+        .set_index(cell_keys)["A_value"]
+        .rename("A_value_2017")
+    )
+    long = long.join(base_2017, on=cell_keys)
+    long["delta_from_2017"] = long["A_value"] - long["A_value_2017"]
+    long.drop(columns="A_value_2017", inplace=True)
+
+    long["delta_yoy"] = long.groupby(cell_keys)["A_value"].diff()
+
+    # Cross-approach divergence vs each baseline at the same year.
+    same_year_keys = ["year", "dom_or_imp", "row_sector", "col_sector"]
+    for baseline_approach, col_name in (
+        ("useeio", "delta_vs_useeio"),
+        ("ceda_default", "delta_vs_ceda"),
+    ):
+        baseline = (
+            long[long["approach"] == baseline_approach]
+            .set_index(same_year_keys)["A_value"]
+            .rename(f"A_value_{baseline_approach}")
+        )
+        long = long.join(baseline, on=same_year_keys)
+        long[col_name] = long["A_value"] - long[f"A_value_{baseline_approach}"]
+        long.drop(columns=f"A_value_{baseline_approach}", inplace=True)
+
+    return long[
+        [
+            "approach",
+            "dom_or_imp",
+            "year",
+            "row_sector",
+            "col_sector",
+            "A_value",
+            "delta_from_2017",
+            "delta_yoy",
+            "delta_vs_useeio",
+            "delta_vs_ceda",
+        ]
+    ]
+
+
+def compute_divergence_quantiles(long: pd.DataFrame, baseline: str) -> pd.DataFrame:
+    """Per (approach, year, dom_or_imp): quantile stats of ``|delta_vs_<baseline>|``.
+
+    ``baseline`` is the suffix on the column, i.e. ``"useeio"`` or ``"ceda"``.
+    """
+    col = f"delta_vs_{baseline}"
+    rows: list[dict[str, object]] = []
+    for (approach, year, kind), group in long.groupby(
+        ["approach", "year", "dom_or_imp"]
+    ):
+        abs_delta = group[col].dropna().abs()
+        if abs_delta.empty:
+            continue
+        rows.append(
+            {
+                "approach": approach,
+                "year": int(year),
+                "dom_or_imp": kind,
+                "n_cells": int(abs_delta.size),
+                "max": float(abs_delta.max()),
+                "p99": float(abs_delta.quantile(0.99)),
+                "p95": float(abs_delta.quantile(0.95)),
+                "p75": float(abs_delta.quantile(0.75)),
+                "p50": float(abs_delta.quantile(0.50)),
+                "mean": float(abs_delta.mean()),
+                "n_above_1pct": int((abs_delta > 0.01).sum()),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _latest_common_year(long: pd.DataFrame, approaches: list[str]) -> int | None:
+    """Latest year for which every approach in ``approaches`` has data."""
+    years_per_approach = [
+        set(long.loc[long["approach"] == a, "year"].unique()) for a in approaches
+    ]
+    if not years_per_approach:
+        return None
+    common = set.intersection(*years_per_approach)
+    return max(common) if common else None
+
+
+def plot_scatter_vs_baselines(long: pd.DataFrame, kind: str, path: Path) -> None:
+    """3×2 grid of element-wise scatters; rows = alternative approach,
+    cols = baseline (USEEIO | CEDA-US).
+
+    Per-row target year: the latest year where the approach AND both
+    baselines all have data. ``commodity_price_index`` /
+    ``industry_price_index`` rows resolve to 2024; ``summary_tables`` falls
+    back to 2023 (BEA Excel hasn't published 2024). The actual year used
+    appears in each panel title.
+
+    All 6 panels share the same ``xlim``/``ylim`` (global min/max across
+    every panel's data) so the ``y=x`` line is a true 45° reference and the
+    panels are visually comparable. Each panel has a top-left summary box
+    with ``n``, mean / p95 / max ``|Δ|`` and ``R²``.
+    """
+    sub = long[long["dom_or_imp"] == kind]
+
+    panel_data: list[
+        tuple[int, int, str, str, int, "np.ndarray[Any, Any]", "np.ndarray[Any, Any]"]
+    ] = []
+    global_min = np.inf
+    global_max = -np.inf
+
+    for i, approach in enumerate(SCATTER_APPROACHES):
+        target_year = _latest_common_year(
+            sub, [approach, *(b[0] for b in SCATTER_BASELINES)]
+        )
+        if target_year is None:
+            logger.warning(
+                "No common year between %s and baselines for kind=%s; " "skipping row.",
+                approach,
+                kind,
+            )
+            continue
+
+        year_pivot = sub[sub["year"] == target_year].pivot_table(
+            index=["row_sector", "col_sector"],
+            columns="approach",
+            values="A_value",
+        )
+        for j, (baseline_col, baseline_label) in enumerate(SCATTER_BASELINES):
+            if (
+                approach not in year_pivot.columns
+                or baseline_col not in year_pivot.columns
+            ):
+                continue
+            x = year_pivot[baseline_col].to_numpy()
+            y = year_pivot[approach].to_numpy()
+            # Filter NaN, then drop (0, 0) pairs: A is sparse, ~50% of cells
+            # are jointly zero and trivially correlate, inflating R² and pulling
+            # mean |Δ| toward 0. Stats reported here are over cells where at
+            # least one of (baseline, approach) is non-zero.
+            mask = ~(np.isnan(x) | np.isnan(y)) & ~((x == 0) & (y == 0))
+            x = x[mask]
+            y = y[mask]
+            if x.size == 0:
+                continue
+            global_min = min(global_min, float(x.min()), float(y.min()))
+            global_max = max(global_max, float(x.max()), float(y.max()))
+            panel_data.append((i, j, approach, baseline_label, target_year, x, y))
+
+    if not panel_data:
+        logger.warning("No scatter panels could be drawn for kind=%s.", kind)
+        return
+
+    n_rows = len(SCATTER_APPROACHES)
+    n_cols = len(SCATTER_BASELINES)
+    fig, axes = plt.subplots(
+        n_rows, n_cols, figsize=(4 * n_cols, 4 * n_rows), squeeze=False
+    )
+    fig.suptitle(f"A_approach vs A_baseline — {kind}", fontsize=12)
+
+    for ax_row in axes:
+        for ax in ax_row:
+            ax.axis("off")
+
+    for i, j, approach, baseline_label, target_year, x, y in panel_data:
+        ax = axes[i][j]
+        ax.axis("on")
+        ax.scatter(x, y, s=8, alpha=0.35, color="steelblue", edgecolor="none")
+        ax.plot(
+            [global_min, global_max],
+            [global_min, global_max],
+            "r--",
+            lw=0.6,
+            alpha=0.7,
+            label="y=x",
+        )
+        ax.set_xlim(global_min, global_max)
+        ax.set_ylim(global_min, global_max)
+        ax.set_aspect("equal", adjustable="box")
+        ax.set_xlabel(f"{baseline_label} A_value")
+        ax.set_ylabel(f"{approach} A_value")
+        ax.set_title(f"{approach} vs {baseline_label} ({target_year})", fontsize=9)
+        ax.grid(True, alpha=0.3)
+
+        x_f = np.asarray(x, dtype=float)
+        y_f = np.asarray(y, dtype=float)
+        abs_delta = np.abs(y_f - x_f)
+        r2 = (
+            float(np.corrcoef(x_f, y_f)[0, 1] ** 2)
+            if x_f.std() > 0 and y_f.std() > 0
+            else float("nan")
+        )
+        stats_text = (
+            f"n = {x.size:,}\n"
+            f"mean |Δ| = {abs_delta.mean():.4f}\n"
+            f"p95 |Δ|  = {np.quantile(abs_delta, 0.95):.4f}\n"
+            f"max |Δ|  = {abs_delta.max():.4f}\n"
+            f"R²       = {r2:.4f}"
+        )
+        ax.text(
+            0.02,
+            0.98,
+            stats_text,
+            transform=ax.transAxes,
+            va="top",
+            ha="left",
+            fontsize=11,
+            family="monospace",
+            bbox={
+                "boxstyle": "round,pad=0.3",
+                "facecolor": "white",
+                "alpha": 0.85,
+                "edgecolor": "gray",
+            },
+        )
+
+    fig.tight_layout()
+    fig.savefig(path, dpi=150)
+    plt.close(fig)
+
+
+DIVERGENCE_THRESHOLDS: tuple[float, ...] = (1e-6, 1e-5, 1e-4, 1e-3, 1e-2)
+
+
+def plot_divergence_share(long: pd.DataFrame, kind: str, path: Path) -> None:
+    """3×2 grid: share of cells whose ``|delta_vs_baseline|`` exceeds each
+    threshold, plotted over years.
+
+    Rows are the three alternative approaches; columns are baselines
+    (USEEIO | CEDA-US). Each panel has one line per threshold in
+    ``DIVERGENCE_THRESHOLDS`` (1e-4, 1e-3, 1e-2, 1e-1); y-axis is the
+    fraction of cells whose absolute deviation from the baseline at that
+    year exceeds the threshold. Answers "how widespread is the divergence,
+    and how does it spread over time?" — a complement to
+    ``scatter_vs_baselines`` (which shows magnitude at one snapshot).
+    """
+    sub = long[long["dom_or_imp"] == kind]
+    n_rows = len(SCATTER_APPROACHES)
+    n_cols = len(SCATTER_BASELINES)
+    fig, axes = plt.subplots(
+        n_rows, n_cols, figsize=(6 * n_cols, 4 * n_rows), squeeze=False
+    )
+    fig.suptitle(
+        f"Share of cells with |A_approach − A_baseline| above threshold — {kind}",
+        fontsize=12,
+    )
+
+    cmap = plt.get_cmap("viridis")
+    threshold_colors = [
+        cmap(i / max(len(DIVERGENCE_THRESHOLDS) - 1, 1))
+        for i in range(len(DIVERGENCE_THRESHOLDS))
+    ]
+
+    for i, approach in enumerate(SCATTER_APPROACHES):
+        for j, (baseline_col, baseline_label) in enumerate(SCATTER_BASELINES):
+            ax = axes[i][j]
+            delta_col = (
+                "delta_vs_useeio" if baseline_col == "useeio" else "delta_vs_ceda"
+            )
+            approach_sub = sub[sub["approach"] == approach]
+            pivot = approach_sub.pivot_table(
+                index=["row_sector", "col_sector"],
+                columns="year",
+                values=delta_col,
+            ).abs()
+            years_arr = np.array(sorted(pivot.columns), dtype=float)
+            values_arr = pivot.to_numpy()
+            keep = ~np.isnan(values_arr).any(axis=1)
+            kept_values = values_arr[keep]
+            if kept_values.size == 0:
+                ax.text(
+                    0.5,
+                    0.5,
+                    "no data",
+                    transform=ax.transAxes,
+                    ha="center",
+                    va="center",
+                )
+                continue
+
+            panel_max_share = 0.0
+            for thr, color in zip(DIVERGENCE_THRESHOLDS, threshold_colors, strict=True):
+                share = (kept_values > thr).mean(axis=0)
+                panel_max_share = max(panel_max_share, float(share.max()))
+                ax.plot(
+                    years_arr,
+                    share,
+                    color=color,
+                    lw=1.8,
+                    marker="o",
+                    markersize=3,
+                    label=f"|Δ| > {thr:g}",
+                )
+
+            ax.set_xlim(years_arr.min(), years_arr.max())
+            ax.set_ylim(0, max(panel_max_share * 1.1, 0.01))
+            ax.set_xlabel("year")
+            ax.set_ylabel("share of cells")
+            ax.set_title(
+                f"{approach} vs {baseline_label} (n={int(keep.sum())} cells)",
+                fontsize=10,
+            )
+            ax.grid(True, alpha=0.3)
+            ax.legend(loc="upper left", fontsize=8, framealpha=0.85)
+
+    fig.tight_layout()
+    fig.savefig(path, dpi=150)
+    plt.close(fig)
+
+
+def _publish_divergence_tabs(
+    div_useeio_df: pd.DataFrame, div_ceda_df: pd.DataFrame
+) -> None:
+    """Append divergence summary tabs to the run-report Sheet, if available."""
+    if not LAST_RUN_SHEET_ID_PATH.exists():
+        logger.warning(
+            "No %s found — skipping Sheet publish. Run derive_A_time_series "
+            "first (with valid Drive auth) to create the run report.",
+            LAST_RUN_SHEET_ID_PATH,
+        )
+        return
+    sheet_id = LAST_RUN_SHEET_ID_PATH.read_text().strip()
+    try:
+        update_sheet_tab(sheet_id, "divergence_vs_useeio", div_useeio_df)
+        update_sheet_tab(sheet_id, "divergence_vs_ceda", div_ceda_df)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "Sheet publish skipped (%s: %s). Local artifacts still complete.",
+            type(e).__name__,
+            e,
+        )
+        return
+    logger.info("Updated tabs on sheet %s", sheet_id)
+
+
+def plot_baseline_reference(long: pd.DataFrame, kind: str, path: Path) -> None:
+    """1×2 reference figure comparing the two baselines (USEEIO vs CEDA-US).
+
+    Left: scatter of A_useeio (x) vs A_ceda_default (y) at the latest year
+    both baselines have data, square aspect, shared limits, with summary
+    stats (n, mean / p95 / max ``|Δ|``, R²).
+
+    Right: share of cells with ``|A_useeio − A_ceda_default|`` above each
+    threshold in ``DIVERGENCE_THRESHOLDS``, plotted over years.
+
+    Provides a "reference floor": divergence between alternative approaches
+    and a baseline can be read against the baseline-vs-baseline divergence
+    from the same data.
+    """
+    sub = long[long["dom_or_imp"] == kind]
+    target_year = _latest_common_year(sub, ["useeio", "ceda_default"])
+    if target_year is None:
+        logger.warning(
+            "No common year for useeio + ceda_default, kind=%s; skipping baseline ref.",
+            kind,
+        )
+        return
+
+    fig, axes = plt.subplots(1, 2, figsize=(12, 5), squeeze=False)
+    fig.suptitle(f"Baseline reference: USEEIO vs CEDA-US — {kind}", fontsize=12)
+
+    # --- Left: scatter at latest year --------------------------------------
+    ax_scatter = axes[0][0]
+    year_pivot = sub[sub["year"] == target_year].pivot_table(
+        index=["row_sector", "col_sector"],
+        columns="approach",
+        values="A_value",
+    )
+    if "useeio" in year_pivot.columns and "ceda_default" in year_pivot.columns:
+        x = year_pivot["useeio"].to_numpy()
+        y = year_pivot["ceda_default"].to_numpy()
+        # Drop jointly-zero (sparse-A) cells so R² and mean |Δ| reflect the
+        # active matrix (matches the filter in plot_scatter_vs_baselines).
+        mask = ~(np.isnan(x) | np.isnan(y)) & ~((x == 0) & (y == 0))
+        x_f = np.asarray(x[mask], dtype=float)
+        y_f = np.asarray(y[mask], dtype=float)
+        ax_scatter.scatter(
+            x_f, y_f, s=8, alpha=0.35, color="darkorange", edgecolor="none"
+        )
+        lo = float(min(x_f.min(), y_f.min()))
+        hi = float(max(x_f.max(), y_f.max()))
+        ax_scatter.plot([lo, hi], [lo, hi], "r--", lw=0.6, alpha=0.7, label="y=x")
+        ax_scatter.set_xlim(lo, hi)
+        ax_scatter.set_ylim(lo, hi)
+        ax_scatter.set_aspect("equal", adjustable="box")
+        abs_delta = np.abs(y_f - x_f)
+        r2 = (
+            float(np.corrcoef(x_f, y_f)[0, 1] ** 2)
+            if x_f.std() > 0 and y_f.std() > 0
+            else float("nan")
+        )
+        stats_text = (
+            f"n = {x_f.size:,}\n"
+            f"mean |Δ| = {abs_delta.mean():.4f}\n"
+            f"p95 |Δ|  = {np.quantile(abs_delta, 0.95):.4f}\n"
+            f"max |Δ|  = {abs_delta.max():.4f}\n"
+            f"R²       = {r2:.4f}"
+        )
+        ax_scatter.text(
+            0.02,
+            0.98,
+            stats_text,
+            transform=ax_scatter.transAxes,
+            va="top",
+            ha="left",
+            fontsize=11,
+            family="monospace",
+            bbox={
+                "boxstyle": "round,pad=0.3",
+                "facecolor": "white",
+                "alpha": 0.85,
+                "edgecolor": "gray",
+            },
+        )
+    ax_scatter.set_xlabel("USEEIO A_value")
+    ax_scatter.set_ylabel("CEDA-US A_value")
+    ax_scatter.set_title(f"USEEIO vs CEDA-US ({target_year})", fontsize=10)
+    ax_scatter.grid(True, alpha=0.3)
+
+    # --- Right: share over thresholds, by year ----------------------------
+    ax_share = axes[0][1]
+    pivot_baseline = sub.pivot_table(
+        index=["row_sector", "col_sector"],
+        columns=["approach", "year"],
+        values="A_value",
+    )
+    if "useeio" not in pivot_baseline.columns.get_level_values(
+        0
+    ) or "ceda_default" not in pivot_baseline.columns.get_level_values(0):
+        ax_share.text(
+            0.5,
+            0.5,
+            "no baseline data",
+            transform=ax_share.transAxes,
+            ha="center",
+            va="center",
+        )
+    else:
+        useeio_wide = pivot_baseline["useeio"]
+        ceda_wide = pivot_baseline["ceda_default"]
+        common_years = sorted(set(useeio_wide.columns) & set(ceda_wide.columns))
+        if not common_years:
+            ax_share.text(
+                0.5,
+                0.5,
+                "no common years",
+                transform=ax_share.transAxes,
+                ha="center",
+                va="center",
+            )
+        else:
+            useeio_arr = useeio_wide[common_years].to_numpy()
+            ceda_arr = ceda_wide[common_years].to_numpy()
+            abs_delta_arr = np.abs(useeio_arr - ceda_arr)
+            keep = ~np.isnan(abs_delta_arr).any(axis=1)
+            kept = abs_delta_arr[keep]
+            years_arr = np.array(common_years, dtype=float)
+            cmap = plt.get_cmap("viridis")
+            colors = [
+                cmap(i / max(len(DIVERGENCE_THRESHOLDS) - 1, 1))
+                for i in range(len(DIVERGENCE_THRESHOLDS))
+            ]
+            panel_max = 0.0
+            for thr, color in zip(DIVERGENCE_THRESHOLDS, colors, strict=True):
+                share = (kept > thr).mean(axis=0)
+                panel_max = max(panel_max, float(share.max()))
+                ax_share.plot(
+                    years_arr,
+                    share,
+                    color=color,
+                    lw=1.8,
+                    marker="o",
+                    markersize=3,
+                    label=f"|Δ| > {thr:g}",
+                )
+            ax_share.set_xlim(years_arr.min(), years_arr.max())
+            ax_share.set_ylim(0, max(panel_max * 1.1, 0.01))
+            ax_share.legend(loc="upper left", fontsize=8, framealpha=0.85)
+    ax_share.set_xlabel("year")
+    ax_share.set_ylabel("share of cells")
+    ax_share.set_title("Share with |USEEIO − CEDA-US| above threshold", fontsize=10)
+    ax_share.grid(True, alpha=0.3)
+
+    fig.tight_layout()
+    fig.savefig(path, dpi=150)
+    plt.close(fig)
+
+
+def main() -> None:
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    PLOTS_DIR.mkdir(parents=True, exist_ok=True)
+
+    logger.info("Building A_cells_long.parquet from %s", RESULTS_DIR)
+    long = build_a_cells_long()
+    long.to_parquet(A_CELLS_LONG_PATH)
+    logger.info("Wrote %s (rows=%d)", A_CELLS_LONG_PATH, len(long))
+
+    div_useeio_df = compute_divergence_quantiles(long, "useeio")
+    div_ceda_df = compute_divergence_quantiles(long, "ceda")
+    div_useeio_df.to_csv(RESULTS_DIR / "divergence_vs_useeio.csv", index=False)
+    div_ceda_df.to_csv(RESULTS_DIR / "divergence_vs_ceda.csv", index=False)
+
+    for kind in ("dom", "imp"):
+        plot_scatter_vs_baselines(
+            long, kind, PLOTS_DIR / f"scatter_vs_baselines_{kind}.png"
+        )
+        plot_divergence_share(long, kind, PLOTS_DIR / f"divergence_share_{kind}.png")
+        plot_baseline_reference(
+            long, kind, PLOTS_DIR / f"baseline_reference_{kind}.png"
+        )
+
+    _publish_divergence_tabs(div_useeio_df, div_ceda_df)
+    logger.info("Step 2 outputs written to %s and %s", RESULTS_DIR, PLOTS_DIR)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/bedrock/analysis/a_matrix_time_series/derive_A_time_series.py
+++ b/bedrock/analysis/a_matrix_time_series/derive_A_time_series.py
@@ -1,0 +1,304 @@
+"""Derive A matrices for every (approach × year) combination.
+
+Step 1 of epic #337. Produces parquet caches as the raw substrate for
+Steps 2–6, and creates a per-run Google Sheet in the analysis Drive folder
+(`1UcPmwLnL6MwTq9pMYJw5d43FJQOFQVO_`) with two summary tabs:
+
+- ``cache_summary`` — per (approach, year, matrix_kind) shape + integrity stats
+- ``sanity_2017_identity_check`` — confirms ``useeio``, ``industry_price_index``,
+  and ``commodity_price_index`` collapse to the BEA-2017 base A at
+  ``model_base_year = 2017``. ``summary_tables`` reads BEA's *summary*
+  aggregation rather than the *detail* base, so it isn't expected to be
+  identity at any year (recorded but not pass-fail tested). ``ceda_default``
+  does a non-inverse round trip via the legacy CEDA io_year, same treatment.
+
+The new sheet ID is logged and persisted to ``last_run_sheet_id.txt`` so the
+downstream steps (#341–#344) can append their own summary tabs to the same
+report.
+
+Usage:
+    python -m bedrock.analysis.a_matrix_time_series.derive_A_time_series
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+import os
+import subprocess
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import yaml
+
+import bedrock.utils.config.usa_config as cfg_module
+from bedrock.utils.config.usa_config import USAConfig
+from bedrock.utils.io.gcp import create_spreadsheet_in_folder, update_sheet_tab
+
+logger = logging.getLogger(__name__)
+
+ANALYSIS_DRIVE_FOLDER_ID = "1UcPmwLnL6MwTq9pMYJw5d43FJQOFQVO_"
+
+APPROACH_YAMLS: dict[str, str] = {
+    "useeio": "2025_usa_cornerstone_A_useeio.yaml",
+    "summary_tables": "2025_usa_cornerstone_A_summary_tables.yaml",
+    "industry_price_index": "2025_usa_cornerstone_A_industry_price_index.yaml",
+    "commodity_price_index": "2025_usa_cornerstone_A_commodity_price_index.yaml",
+    "ceda_default": "2025_usa_cornerstone_taxonomy.yaml",  # CEDA baseline with Cornerstone schema
+}
+APPROACHES: list[str] = list(APPROACH_YAMLS.keys())
+TARGET_YEARS: list[int] = [2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024]
+
+OUTPUT_DIR = Path(__file__).parent / "output"
+RESULTS_DIR = OUTPUT_DIR / "results"
+PLOTS_DIR = OUTPUT_DIR / "plots"
+LAST_RUN_SHEET_ID_PATH = RESULTS_DIR / "last_run_sheet_id.txt"
+
+# Modules whose @functools.cache outputs are config-dependent and must be
+# invalidated between (approach, year) iterations.
+_CACHE_BEARING_MODULE_PATHS = (
+    "bedrock.transform.eeio.derived_cornerstone",
+    "bedrock.transform.eeio.cornerstone_bea_intermediates",
+    "bedrock.utils.economic.inflate_cornerstone_to_target_year",
+)
+
+
+def _clear_config_dependent_caches() -> None:
+    """Clear `@functools.cache` outputs in all config-dependent modules."""
+    import importlib  # noqa: PLC0415
+
+    for module_path in _CACHE_BEARING_MODULE_PATHS:
+        module = importlib.import_module(module_path)
+        for name in dir(module):
+            obj = getattr(module, name, None)
+            if callable(obj) and hasattr(obj, "cache_clear"):
+                obj.cache_clear()
+
+
+def _set_config(approach: str, year: int) -> None:
+    """Install a config for the given (approach, year), bypassing pydantic
+    Literal validation on ``model_base_year`` since we run for 2017–2024 but
+    the schema only allows 2022–2024.
+
+    Uses ``USAConfig.model_construct`` to skip validation. Also clears the
+    ``USA_CONFIG_FILE`` env var and ``_usa_config`` module global so each call
+    is fresh — ``set_global_usa_config`` raises if invoked twice.
+    """
+    yaml_path = Path(cfg_module.CONFIG_DIR) / APPROACH_YAMLS[approach]
+    with open(yaml_path) as f:
+        data = yaml.safe_load(f) or {}
+    data["model_base_year"] = year
+
+    cfg_module._usa_config = USAConfig.model_construct(**data)
+    os.environ[cfg_module.USA_CONFIG_ENV_VAR] = APPROACH_YAMLS[approach]
+
+
+def _reset_config() -> None:
+    cfg_module._usa_config = None
+    os.environ.pop(cfg_module.USA_CONFIG_ENV_VAR, None)
+
+
+def _derive_one_pair(
+    approach: str, year: int
+) -> tuple[pd.DataFrame, pd.DataFrame, pd.Series]:
+    """Run the cornerstone A pipeline for one (approach, year) pair.
+
+    Returns ``(Adom, Aimp, q)``. Caches are cleared and the config is
+    reinstalled before the call to guarantee a fresh derivation.
+    """
+    _reset_config()
+    _clear_config_dependent_caches()
+    _set_config(approach, year)
+
+    from bedrock.transform.eeio.derived_cornerstone import (  # noqa: PLC0415
+        derive_cornerstone_Aq_scaled,
+    )
+
+    aq = derive_cornerstone_Aq_scaled()
+    return aq.Adom, aq.Aimp, aq.scaled_q
+
+
+def _save_parquets(
+    approach: str, year: int, adom: pd.DataFrame, aimp: pd.DataFrame, q: pd.Series
+) -> tuple[Path, Path]:
+    """Write the (Adom, Aimp, q) triple as two parquets under ``output/results/``.
+
+    Adom + Aimp are stacked into a single multi-index DataFrame (index level
+    ``dom_or_imp`` ∈ {dom, imp}); q is written separately because its single
+    column makes a stacked layout awkward.
+    """
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    a_path = RESULTS_DIR / f"A_{approach}_{year}.parquet"
+    q_path = RESULTS_DIR / f"q_{approach}_{year}.parquet"
+
+    combined = pd.concat({"dom": adom, "imp": aimp}, axis=0, names=["dom_or_imp"])
+    combined.to_parquet(a_path)
+    q.to_frame("q").to_parquet(q_path)
+
+    return a_path, q_path
+
+
+def _matrix_stats(
+    approach: str, year: int, kind: str, df: pd.DataFrame, file_path: Path
+) -> dict[str, object]:
+    """Per-matrix summary row for the cache_summary tab."""
+    arr = df.to_numpy()
+    return {
+        "approach": approach,
+        "year": year,
+        "matrix_kind": kind,
+        "n_rows": int(df.shape[0]),
+        "n_cols": int(df.shape[1]),
+        "nan_count": int(np.isnan(arr).sum()),
+        "neg_count": int((arr < 0).sum()),
+        "max_col_sum": float(np.nansum(arr, axis=0).max()) if arr.size else 0.0,
+        "file_size_bytes": int(file_path.stat().st_size),
+    }
+
+
+_EXPECTED_IDENTITY_AT_2017 = {
+    "useeio",
+    "industry_price_index",
+    "commodity_price_index",
+}
+"""Approaches whose 2017 output should equal the BEA-2017 base A within rtol.
+
+``summary_tables`` reads BEA *summary*-level tables rather than the *detail*
+base; the two aggregations differ even at the same year, so it isn't expected
+to be identity. ``ceda_default`` does ``scale(2017→io_year)`` then
+``inflate(io_year→2017)`` — not an inverse pair, so its 2017 output is also
+expected to deviate."""
+
+
+def _build_sanity_2017(
+    matrices_2017: dict[str, tuple[pd.DataFrame, pd.DataFrame, pd.Series]],
+    rtol: float = 1e-10,
+) -> pd.DataFrame:
+    """At ``model_base_year = 2017``, the four alternative approaches must
+    collapse to the BEA-2017 base A (identity transformations); ``ceda_default``
+    does a non-inverse round trip and is recorded but not pass-fail tested.
+
+    Reference is ``useeio`` (returns ``base`` directly — simplest semantics).
+    """
+    if not matrices_2017 or "useeio" not in matrices_2017:
+        return pd.DataFrame()
+
+    ref_dom, ref_imp, ref_q = matrices_2017["useeio"]
+
+    def _max_rel_dev(a: pd.DataFrame, b: pd.DataFrame) -> float:
+        diff = a.to_numpy() - b.to_numpy()
+        denom = np.where(np.abs(b.to_numpy()) > 0, np.abs(b.to_numpy()), 1.0)
+        return float(np.abs(diff / denom).max())
+
+    rows = []
+    for name, (dom, imp, q) in sorted(matrices_2017.items()):
+        max_dom = _max_rel_dev(dom, ref_dom)
+        max_imp = _max_rel_dev(imp, ref_imp)
+        max_q = _max_rel_dev(q.to_frame(), ref_q.to_frame())
+        expected_identity = name in _EXPECTED_IDENTITY_AT_2017
+        max_rel_dev = max(max_dom, max_imp, max_q)
+        rows.append(
+            {
+                "approach": name,
+                "reference": "useeio",
+                "expected_identity": expected_identity,
+                "max_rel_dev_Adom": max_dom,
+                "max_rel_dev_Aimp": max_imp,
+                "max_rel_dev_q": max_q,
+                "passes": (bool(max_rel_dev <= rtol) if expected_identity else None),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _git_sha_short() -> str:
+    try:
+        sha = subprocess.check_output(
+            ["git", "rev-parse", "--short=7", "HEAD"], text=True
+        ).strip()
+        return sha or "unknown"
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
+
+
+def _publish_run_report(summary_df: pd.DataFrame, sanity_df: pd.DataFrame) -> str:
+    """Create the run-report Sheet and write the two summary tabs.
+
+    Returns the new sheet ID.
+    """
+    title = (
+        f"a_matrix_time_series__{_git_sha_short()}__"
+        f"{dt.datetime.now(dt.timezone.utc).strftime('%Y%m%dT%H%M%SZ')}"
+    )
+    sheet_id = create_spreadsheet_in_folder(
+        title=title, folder_id=ANALYSIS_DRIVE_FOLDER_ID
+    )
+    update_sheet_tab(sheet_id, "cache_summary", summary_df)
+    if not sanity_df.empty:
+        update_sheet_tab(sheet_id, "sanity_2017_identity_check", sanity_df)
+    return sheet_id
+
+
+def main() -> None:
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    PLOTS_DIR.mkdir(parents=True, exist_ok=True)
+    summary_rows: list[dict[str, object]] = []
+    matrices_2017: dict[str, tuple[pd.DataFrame, pd.DataFrame, pd.Series]] = {}
+
+    for approach in APPROACHES:
+        for year in TARGET_YEARS:
+            logger.info("Deriving A matrix: approach=%s year=%d", approach, year)
+            try:
+                adom, aimp, q = _derive_one_pair(approach, year)
+            except Exception as e:  # noqa: BLE001 — record any per-pair failure
+                logger.warning("Pair (%s, %d) failed: %s", approach, year, e)
+                summary_rows.append(
+                    {
+                        "approach": approach,
+                        "year": year,
+                        "matrix_kind": "FAILED",
+                        "error": f"{type(e).__name__}: {e}",
+                    }
+                )
+                continue
+
+            a_path, q_path = _save_parquets(approach, year, adom, aimp, q)
+            summary_rows.append(_matrix_stats(approach, year, "Adom", adom, a_path))
+            summary_rows.append(_matrix_stats(approach, year, "Aimp", aimp, a_path))
+            summary_rows.append(
+                _matrix_stats(approach, year, "q", q.to_frame("q"), q_path)
+            )
+
+            if year == 2017:
+                matrices_2017[approach] = (adom, aimp, q)
+
+    summary_df = pd.DataFrame(summary_rows)
+    sanity_df = _build_sanity_2017(matrices_2017)
+    summary_df.to_csv(RESULTS_DIR / "cache_summary.csv", index=False)
+    if not sanity_df.empty:
+        sanity_df.to_csv(RESULTS_DIR / "sanity_2017_identity_check.csv", index=False)
+
+    try:
+        sheet_id = _publish_run_report(summary_df, sanity_df)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "Sheet publish skipped (%s: %s). Local parquet caches and CSVs in "
+            "%s are complete; Steps 2-5 that read last_run_sheet_id.txt won't "
+            "have a target until the run is re-published with valid Drive auth.",
+            type(e).__name__,
+            e,
+            RESULTS_DIR,
+        )
+        return
+
+    LAST_RUN_SHEET_ID_PATH.write_text(sheet_id + "\n")
+    sheet_url = f"https://docs.google.com/spreadsheets/d/{sheet_id}"
+    logger.info("Run report: %s", sheet_url)
+    print(f"Run report Sheet: {sheet_url}")
+    print(f"Sheet ID written to: {LAST_RUN_SHEET_ID_PATH}")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/bedrock/extract/iot/io_2017.py
+++ b/bedrock/extract/iot/io_2017.py
@@ -17,6 +17,7 @@ from bedrock.utils.taxonomy.bea.matrix_mappings import (
     USA_2017_DETAIL_IO_SUT_MATRIX_NAMES,
     USA_SUMMARY_MUT_MAPPING_1997_2022,
     USA_SUMMARY_MUT_MAPPING_1997_2023,
+    USA_SUMMARY_MUT_MAPPING_1997_2024,
     USA_SUMMARY_MUT_NAMES,
     USA_SUMMARY_MUT_YEARS,
     USA_SUMMARY_SUT_MAPPING_2017_2022,
@@ -382,16 +383,16 @@ def _load_usa_summary_mut(
     Load USA Summary SUT matrix
     """
 
-    # BEA revises historical data in each new release, so the 2022 values in the
-    # 1997-2023 file differ from those in the 1997-2022 file. We pin years ≤ 2022 to
-    # the 1997-2022 file for consistency with the rest of the pipeline (e.g.
-    # scale_cornerstone_B uses years 2017 and 2022), and only switch to the 1997-2023
-    # file when year 2023 data is explicitly needed.
-    mapping = (
-        USA_SUMMARY_MUT_MAPPING_1997_2023
-        if year > 2022
-        else USA_SUMMARY_MUT_MAPPING_1997_2022
-    )
+    # BEA revises historical data in each new release. We pin older years to the
+    # oldest file containing them so values stay stable across releases (e.g.
+    # scale_cornerstone_B uses years 2017 and 2022, which must not change as new
+    # vintages add years on the right).
+    if year > 2023:
+        mapping = USA_SUMMARY_MUT_MAPPING_1997_2024
+    elif year > 2022:
+        mapping = USA_SUMMARY_MUT_MAPPING_1997_2023
+    else:
+        mapping = USA_SUMMARY_MUT_MAPPING_1997_2022
     df = (
         load_from_gcs(
             name=mapping[matrix_name],

--- a/bedrock/utils/taxonomy/bea/matrix_mappings.py
+++ b/bedrock/utils/taxonomy/bea/matrix_mappings.py
@@ -40,6 +40,11 @@ USA_SUMMARY_MUT_MAPPING_1997_2023 = {
     "Use_summary": "IOUse_After_Redefinitions_PRO_1997-2023_Summary.xlsx",
     "Import_summary": "IOImportMatrices_After_Redefinitions_SUM_1997-2023.xlsx",
 }
+USA_SUMMARY_MUT_MAPPING_1997_2024 = {
+    "Make_summary": "IOMake_After_Redefinitions_PRO_1997-2024_Summary.xlsx",
+    "Use_summary": "IOUse_After_Redefinitions_PRO_1997-2024_Summary.xlsx",
+    "Import_summary": "IOImportMatrices_After_Redefinitions_SUM_1997-2024.xlsx",
+}
 
 USA_SUMMARY_SUT_NAMES = ta.Literal[
     "Supply_summary",


### PR DESCRIPTION
cc:
Closes: #340

## What changed? Why?

Driver script `derive_A_time_series.py` for Step 1 of epic #337 (#340). Loops `(approach × year)` for 5 approaches × 8 years and caches each `(Adom, Aimp, q)` triple as parquet, then creates a per-run Google Sheet under the [analysis Drive folder](https://drive.google.com/drive/u/1/folders/1UcPmwLnL6MwTq9pMYJw5d43FJQOFQVO_) with `cache_summary` and `sanity_2017_identity_check` tabs. The sheet ID is persisted to `output/last_run_sheet_id.txt` so Steps 2–5 append to the same report.

Per-pair `try/except` catches data-availability gaps without aborting the run. Caches in three config-dependent modules are cleared between iterations to force fresh derivations (`derived_cornerstone`, `cornerstone_bea_intermediates`, `inflate_cornerstone_to_target_year`). `model_base_year` `Literal[2022, 2023, 2024]` is bypassed via `USAConfig.model_construct` so the analysis can cover 2017–2024.

**Also wires up 2024 BEA summary IOTs**: adds `USA_SUMMARY_MUT_MAPPING_1997_2024` in `matrix_mappings.py` and updates `_load_usa_summary_mut` to a three-way version ladder (2024 → new file, 2023 → 1997-2023, ≤2022 → 1997-2022). Older years stay pinned to the oldest file containing them so values used downstream (e.g. `scale_cornerstone_B`) remain stable across BEA revisions. Unblocks `summary_tables` for 2024.

Stacks on #350.

## Auth requirement

Local runs need ADC creds with the `drive` scope, which `gcloud auth application-default login` doesn't grant. Use either a service-account JSON key or a custom OAuth client. Follow-up: add a GHA workflow analogous to `generate_diagnostics.yml` that triggers this via workload identity.

## Testing

- 40-pair loop ran end-to-end; parquet shapes look sane.
- `sanity_2017_identity_check` confirms the V-norm fix from #349 lands cleanly: `commodity_price_index` deviates from `useeio` at 2017 by max 5.9e-16 (FP noise).
- `summary_tables` 2024 succeeds with the new wire-up; `load_summary_V_usa(2024)` returns 71×73 and `load_summary_Utot_usa(2024)` returns 73×71.
- Ruff / black / mypy clean.