### PR TITLE
Implement phase 1 of disagg extract rename

### DIFF
--- a/bedrock/extract/disaggregation/__tests__/test_disagg_weights_parity.py
+++ b/bedrock/extract/disaggregation/__tests__/test_disagg_weights_parity.py
@@ -46,7 +46,6 @@ def old_weights() -> WasteDisaggWeights:
         disagg_new_codes=_WASTE_CODES,
         waste_sectors=_WASTE_CODES,
         va_row_codes=_VA_ROWS,
-        naics_to_cornerstone=None,
     )
 
 
@@ -58,7 +57,6 @@ def new_weights() -> DisaggWeights:
         new_codes=_WASTE_CODES,
         disagg_sectors=_WASTE_CODES,
         va_row_codes=_VA_ROWS,
-        naics_to_cornerstone=None,
     )
 
 
@@ -182,7 +180,6 @@ def _build_weights_via_direct_api() -> WasteDisaggWeights:
         new_codes=list(dc._WASTE_NEW_CODES),
         disagg_sectors=list(dc._WASTE_NEW_CODES),
         va_row_codes=list(dc.VALUE_ADDEDS),
-        naics_to_cornerstone=None,
     )
     return WasteDisaggWeights.from_disagg_weights(dw)
 

--- a/bedrock/extract/disaggregation/__tests__/test_disagg_weights_parity.py
+++ b/bedrock/extract/disaggregation/__tests__/test_disagg_weights_parity.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import pathlib
+from collections.abc import Generator
+from typing import ClassVar, TypedDict, cast
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from bedrock.extract.disaggregation.disagg_weights import (
+    DisaggWeights,
+    load_disagg_weights,
+)
+from bedrock.extract.disaggregation.waste_weights import (
+    WasteDisaggWeights,
+    load_waste_disagg_weights,
+)
+from bedrock.transform.eeio import derived_cornerstone as dc
+from bedrock.transform.eeio.__tests__.test_waste_disagg_pipeline_integration import (
+    _setup_config,
+    _teardown,
+)
+from bedrock.utils.config.usa_config import EEIOWasteDisaggConfig
+from bedrock.utils.taxonomy.cornerstone.commodities import WASTE_DISAGG_COMMODITIES
+
+_DATA_DIR = pathlib.Path(__file__).resolve().parents[1]
+_USE_PATH = _DATA_DIR / "WasteDisaggregationDetail2017_Use.csv"
+_MAKE_PATH = _DATA_DIR / "WasteDisaggregationDetail2017_Make.csv"
+_WASTE_CODES = cast(list[str], list(WASTE_DISAGG_COMMODITIES["562000"]))
+_VA_ROWS = ["V00100", "V00200", "V00300"]
+
+_cfg = EEIOWasteDisaggConfig(
+    use_weights_file=str(_USE_PATH),
+    make_weights_file=str(_MAKE_PATH),
+    year=2017,
+    source_name="WasteDisaggregationDetail2017",
+)
+
+
+@pytest.fixture(scope="module")
+def old_weights() -> WasteDisaggWeights:
+    return load_waste_disagg_weights(
+        _cfg,
+        disagg_original_code="562000",
+        disagg_new_codes=_WASTE_CODES,
+        waste_sectors=_WASTE_CODES,
+        va_row_codes=_VA_ROWS,
+        naics_to_cornerstone=None,
+    )
+
+
+@pytest.fixture(scope="module")
+def new_weights() -> DisaggWeights:
+    return load_disagg_weights(
+        _cfg,
+        original_code="562000",
+        new_codes=_WASTE_CODES,
+        disagg_sectors=_WASTE_CODES,
+        va_row_codes=_VA_ROWS,
+        naics_to_cornerstone=None,
+    )
+
+
+def _assert_slices_equal(old: pd.DataFrame, new: pd.DataFrame, name: str) -> None:
+    pd.testing.assert_frame_equal(old, new, check_names=True, obj=name)
+
+
+@pytest.mark.eeio_integration
+class TestDisaggWeightsParity:
+    def test_use_intersection(
+        self, old_weights: WasteDisaggWeights, new_weights: DisaggWeights
+    ) -> None:
+        _assert_slices_equal(
+            old_weights.use_intersection,
+            new_weights.use_intersection,
+            "use_intersection",
+        )
+
+    def test_use_disagg_industry_columns_all_rows(
+        self, old_weights: WasteDisaggWeights, new_weights: DisaggWeights
+    ) -> None:
+        _assert_slices_equal(
+            old_weights.use_waste_industry_columns_all_rows,
+            new_weights.use_disagg_industry_columns_all_rows,
+            "use_disagg_industry_columns_all_rows",
+        )
+
+    def test_use_disagg_commodity_rows_all_columns(
+        self, old_weights: WasteDisaggWeights, new_weights: DisaggWeights
+    ) -> None:
+        _assert_slices_equal(
+            old_weights.use_waste_commodity_rows_all_columns,
+            new_weights.use_disagg_commodity_rows_all_columns,
+            "use_disagg_commodity_rows_all_columns",
+        )
+
+    def test_use_disagg_rows_specific_columns(
+        self, old_weights: WasteDisaggWeights, new_weights: DisaggWeights
+    ) -> None:
+        _assert_slices_equal(
+            old_weights.use_waste_rows_specific_columns,
+            new_weights.use_disagg_rows_specific_columns,
+            "use_disagg_rows_specific_columns",
+        )
+
+    def test_use_va_rows_for_disagg_industry_columns(
+        self, old_weights: WasteDisaggWeights, new_weights: DisaggWeights
+    ) -> None:
+        _assert_slices_equal(
+            old_weights.use_va_rows_for_waste_industry_columns,
+            new_weights.use_va_rows_for_disagg_industry_columns,
+            "use_va_rows_for_disagg_industry_columns",
+        )
+
+    def test_use_fd_columns_for_disagg_commodity_rows(
+        self, old_weights: WasteDisaggWeights, new_weights: DisaggWeights
+    ) -> None:
+        _assert_slices_equal(
+            old_weights.use_fd_columns_for_waste_commodity_rows,
+            new_weights.use_fd_columns_for_disagg_commodity_rows,
+            "use_fd_columns_for_disagg_commodity_rows",
+        )
+
+    def test_make_intersection(
+        self, old_weights: WasteDisaggWeights, new_weights: DisaggWeights
+    ) -> None:
+        _assert_slices_equal(
+            old_weights.make_intersection,
+            new_weights.make_intersection,
+            "make_intersection",
+        )
+
+    def test_make_disagg_commodity_columns_all_rows(
+        self, old_weights: WasteDisaggWeights, new_weights: DisaggWeights
+    ) -> None:
+        _assert_slices_equal(
+            old_weights.make_waste_commodity_columns_all_rows,
+            new_weights.make_disagg_commodity_columns_all_rows,
+            "make_disagg_commodity_columns_all_rows",
+        )
+
+    def test_make_disagg_commodity_columns_specific_rows(
+        self, old_weights: WasteDisaggWeights, new_weights: DisaggWeights
+    ) -> None:
+        _assert_slices_equal(
+            old_weights.make_waste_commodity_columns_specific_rows,
+            new_weights.make_disagg_commodity_columns_specific_rows,
+            "make_disagg_commodity_columns_specific_rows",
+        )
+
+    def test_make_disagg_industry_rows_specific_columns(
+        self, old_weights: WasteDisaggWeights, new_weights: DisaggWeights
+    ) -> None:
+        _assert_slices_equal(
+            old_weights.make_waste_industry_rows_specific_columns,
+            new_weights.make_disagg_industry_rows_specific_columns,
+            "make_disagg_industry_rows_specific_columns",
+        )
+
+    def test_year_and_source_name(
+        self, old_weights: WasteDisaggWeights, new_weights: DisaggWeights
+    ) -> None:
+        assert old_weights.year == new_weights.year
+        assert old_weights.source_name == new_weights.source_name
+
+
+def _build_weights_via_direct_api() -> WasteDisaggWeights:
+    cfg = dc.get_usa_config()
+    waste_cfg = cfg.eeio_waste_disaggregation
+    if waste_cfg is None:
+        waste_cfg = dc.EEIOWasteDisaggConfig(
+            use_weights_file="extract/disaggregation/WasteDisaggregationDetail2017_Use.csv",
+            make_weights_file="extract/disaggregation/WasteDisaggregationDetail2017_Make.csv",
+            year=2017,
+            source_name="WasteDisaggregationDetail2017",
+        )
+    resolved_cfg = dc._resolve_waste_cfg_paths(waste_cfg)
+    dw = load_disagg_weights(
+        resolved_cfg,
+        original_code=dc._WASTE_ORIGINAL_CODE,
+        new_codes=list(dc._WASTE_NEW_CODES),
+        disagg_sectors=list(dc._WASTE_NEW_CODES),
+        va_row_codes=list(dc.VALUE_ADDEDS),
+        naics_to_cornerstone=None,
+    )
+    return WasteDisaggWeights.from_disagg_weights(dw)
+
+
+class PipelineSnapshot(TypedDict):
+    V: pd.DataFrame
+    Udom: pd.DataFrame
+    Uimp: pd.DataFrame
+    VA: pd.DataFrame
+    Ytot: pd.DataFrame
+    Adom: pd.DataFrame
+    Aimp: pd.DataFrame
+    B: pd.DataFrame
+    q_from_aq: pd.Series
+    q: pd.Series
+    x: pd.Series
+
+
+def _run_pipeline_snapshot() -> PipelineSnapshot:
+    uset = dc.derive_cornerstone_U_with_negatives()
+    aq = dc.derive_cornerstone_Aq()
+    return {
+        "V": dc.derive_cornerstone_V(),
+        "Udom": pd.DataFrame(uset.Udom),
+        "Uimp": pd.DataFrame(uset.Uimp),
+        "VA": dc.derive_cornerstone_VA(),
+        "Ytot": dc._derive_cornerstone_Ytot_with_trade(),
+        "Adom": pd.DataFrame(aq.Adom),
+        "Aimp": pd.DataFrame(aq.Aimp),
+        "q_from_aq": aq.scaled_q.copy(),
+        "q": dc.derive_cornerstone_q().copy(),
+        "B": dc.derive_cornerstone_B_via_vnorm(),
+        "x": dc.derive_cornerstone_x().copy(),
+    }
+
+
+@pytest.mark.eeio_integration
+class TestFullPipelineParity:
+    run_a: ClassVar[PipelineSnapshot]
+    run_b: ClassVar[PipelineSnapshot]
+
+    @pytest.fixture(scope="class", autouse=True)
+    def pipeline_results(
+        self, request: pytest.FixtureRequest
+    ) -> Generator[None, None, None]:
+        _setup_config("test_usa_config_waste_disagg")
+        try:
+            run_a = _run_pipeline_snapshot()
+            _teardown()
+            _setup_config("test_usa_config_waste_disagg")
+            direct_weights = _build_weights_via_direct_api()
+            with patch.object(
+                dc, "get_waste_disagg_weights", return_value=direct_weights
+            ):
+                run_b = _run_pipeline_snapshot()
+            request.cls.run_a = run_a
+            request.cls.run_b = run_b
+            yield
+        finally:
+            _teardown()
+
+    def test_pipeline_parity(self) -> None:
+        pd.testing.assert_frame_equal(
+            self.run_a["V"], self.run_b["V"], check_like=False, obj="V"
+        )
+        pd.testing.assert_frame_equal(
+            self.run_a["Udom"], self.run_b["Udom"], check_like=False, obj="Udom"
+        )
+        pd.testing.assert_frame_equal(
+            self.run_a["Uimp"], self.run_b["Uimp"], check_like=False, obj="Uimp"
+        )
+        pd.testing.assert_frame_equal(
+            self.run_a["VA"], self.run_b["VA"], check_like=False, obj="VA"
+        )
+        pd.testing.assert_frame_equal(
+            self.run_a["Ytot"], self.run_b["Ytot"], check_like=False, obj="Ytot"
+        )
+        pd.testing.assert_frame_equal(
+            self.run_a["Adom"], self.run_b["Adom"], check_like=False, obj="Adom"
+        )
+        pd.testing.assert_frame_equal(
+            self.run_a["Aimp"], self.run_b["Aimp"], check_like=False, obj="Aimp"
+        )
+        pd.testing.assert_frame_equal(
+            self.run_a["B"], self.run_b["B"], check_like=False, obj="B"
+        )
+        pd.testing.assert_series_equal(
+            self.run_a["q_from_aq"], self.run_b["q_from_aq"], obj="q_from_aq"
+        )
+        pd.testing.assert_series_equal(self.run_a["q"], self.run_b["q"], obj="q")
+        pd.testing.assert_series_equal(self.run_a["x"], self.run_b["x"], obj="x")

--- a/bedrock/extract/disaggregation/__tests__/test_waste_weights.py
+++ b/bedrock/extract/disaggregation/__tests__/test_waste_weights.py
@@ -148,7 +148,6 @@ def test_load_waste_disagg_weights_normalizes_slices(tmp_path: pathlib.Path) -> 
         disagg_original_code="562000",
         disagg_new_codes=waste_sectors,
         waste_sectors=waste_sectors,
-        naics_to_cornerstone=None,
     )
 
     assert pytest.approx(float(weights.use_intersection.values.sum()), rel=1e-6) == 1.0
@@ -199,7 +198,6 @@ def test_load_waste_disagg_weights_missing_sectors_get_zero_weight(
         disagg_original_code="562000",
         disagg_new_codes=waste_sectors,
         waste_sectors=waste_sectors,
-        naics_to_cornerstone=None,
     )
 
     assert weights.use_intersection.loc["562212", :].sum() == pytest.approx(0.0)
@@ -245,7 +243,6 @@ def test_load_waste_disagg_weights_all_zero_raises(tmp_path: pathlib.Path) -> No
             disagg_original_code="562000",
             disagg_new_codes=["562111"],
             waste_sectors=["562111"],
-            naics_to_cornerstone=None,
         )
 
 
@@ -287,7 +284,6 @@ def test_load_waste_disagg_weights_missing_required_column(
             disagg_original_code="562000",
             disagg_new_codes=["562111"],
             waste_sectors=["562111"],
-            naics_to_cornerstone=None,
         )
 
 
@@ -328,7 +324,6 @@ def test_load_waste_disagg_weights_nan_values_raise(tmp_path: pathlib.Path) -> N
             disagg_original_code="562000",
             disagg_new_codes=["562111"],
             waste_sectors=["562111"],
-            naics_to_cornerstone=None,
         )
 
 
@@ -531,7 +526,6 @@ def weights_2017() -> WasteDisaggWeights:
         disagg_new_codes=WASTE_CODES,
         waste_sectors=WASTE_CODES,
         va_row_codes=VA_ROWS,
-        naics_to_cornerstone=None,
     )
 
 
@@ -863,7 +857,6 @@ def test_load_waste_disagg_weights_integration_with_2017_files() -> None:
         disagg_original_code="562000",
         disagg_new_codes=waste_codes,
         waste_sectors=waste_codes,
-        naics_to_cornerstone=None,
     )
 
     assert weights.year == 2017

--- a/bedrock/extract/disaggregation/disagg_weights.py
+++ b/bedrock/extract/disaggregation/disagg_weights.py
@@ -1,0 +1,566 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import IO, TYPE_CHECKING, Literal, Protocol, runtime_checkable
+
+import pandas as pd
+
+from bedrock.utils.taxonomy.correspondence import create_correspondence_matrix
+
+try:
+    from bedrock.utils.taxonomy.cornerstone.value_added import VALUE_ADDEDS
+except ImportError:
+    VALUE_ADDEDS = []
+
+try:
+    from bedrock.utils.taxonomy.cornerstone.final_demand import FINAL_DEMANDS
+except ImportError:
+    FINAL_DEMANDS = []
+
+if TYPE_CHECKING:
+    DisaggWeightSeries = pd.Series[float]
+    DisaggWeightTable = pd.DataFrame
+else:
+    DisaggWeightSeries = pd.Series
+    DisaggWeightTable = pd.DataFrame
+
+
+@runtime_checkable
+class DisaggConfig(Protocol):
+    use_weights_file: str
+    make_weights_file: str
+    year: int
+    source_name: str
+
+
+class DisaggWeightError(Exception):
+    pass
+
+
+class DisaggCorrespondenceError(Exception):
+    pass
+
+
+def _empty_weight_table() -> DisaggWeightTable:
+    """Empty DisaggWeightTable (0 rows, 0 columns) for slices with no data."""
+    return pd.DataFrame(dtype=float)
+
+
+@dataclass
+class DisaggWeights:
+    """Weights for disaggregation; all slices are DisaggWeightTable (pd.DataFrame)."""
+
+    use_intersection: DisaggWeightTable
+    use_disagg_industry_columns_all_rows: DisaggWeightTable
+    use_disagg_commodity_rows_all_columns: DisaggWeightTable
+    use_disagg_rows_specific_columns: DisaggWeightTable
+    use_va_rows_for_disagg_industry_columns: DisaggWeightTable
+    use_fd_columns_for_disagg_commodity_rows: DisaggWeightTable
+    make_intersection: DisaggWeightTable
+    make_disagg_commodity_columns_all_rows: DisaggWeightTable
+    make_disagg_commodity_columns_specific_rows: DisaggWeightTable
+    make_disagg_industry_rows_specific_columns: DisaggWeightTable
+    year: int
+    source_name: str
+
+
+def _normalize_code(code: str) -> str:
+    code = code.strip()
+    if "/" in code:
+        code = code.split("/", maxsplit=1)[0]
+    return code
+
+
+def load_weights_csv(path: str, percent_column: str) -> pd.DataFrame:
+    try:
+        df = pd.read_csv(path, dtype=str)
+    except FileNotFoundError as exc:
+        raise DisaggWeightError(f"Weight file not found: {path}") from exc
+
+    required_columns = {"IndustryCode", "CommodityCode", percent_column}
+    missing_columns = required_columns.difference(df.columns)
+    if missing_columns:
+        missing_display = ", ".join(sorted(missing_columns))
+        raise DisaggWeightError(f"Missing required columns in {path}: {missing_display}")
+
+    df["IndustryCode"] = df["IndustryCode"].map(_normalize_code)
+    df["CommodityCode"] = df["CommodityCode"].map(_normalize_code)
+
+    df[percent_column] = pd.to_numeric(df[percent_column], errors="coerce")
+    if df[percent_column].isna().any():
+        raise DisaggWeightError(
+            f"Non-numeric or NaN values in {percent_column} column for file {path}"
+        )
+
+    return df
+
+
+def _apply_correspondence_to_series(
+    series: pd.Series,
+    mapping: dict[str, list[str]] | None,
+    target_codes: list[str],
+) -> pd.Series:
+    if mapping is None:
+        return series
+
+    try:
+        correspondence = create_correspondence_matrix(
+            mapping,
+            domain=list(mapping.keys()),
+            range=target_codes,
+            is_injective=True,
+            is_surjective=True,
+            is_complete=True,
+        )
+    except AssertionError as exc:
+        raise DisaggCorrespondenceError(
+            "Incomplete or invalid correspondence for disaggregation weights"
+        ) from exc
+
+    aligned = series.reindex(correspondence.columns).fillna(0.0).astype(float)
+    result = correspondence @ aligned
+    return result.astype(float)
+
+
+def _pivot_and_align(
+    df: pd.DataFrame,
+    value_col: str,
+    index_col: str,
+    columns_col: str,
+    index_codes: list[str],
+    column_codes: list[str],
+) -> pd.DataFrame:
+    if df.empty:
+        return pd.DataFrame(0.0, index=index_codes, columns=column_codes, dtype=float)
+    pivoted = df.pivot_table(
+        index=index_col, columns=columns_col, values=value_col, aggfunc="sum"
+    ).fillna(0.0)
+    return pivoted.reindex(
+        index=index_codes, columns=column_codes, fill_value=0.0
+    ).astype(float)
+
+
+def _build_specific_rows_table(
+    df: pd.DataFrame,
+    *,
+    row_dim: str,
+    col_dim: str,
+    col_subsectors: list[str],
+    value_col: str,
+) -> DisaggWeightTable:
+    if df.empty:
+        out_empty = pd.DataFrame(columns=col_subsectors, dtype=float)
+        out_empty.index.name = row_dim
+        return out_empty
+    rows: list[pd.DataFrame] = []
+    index_vals: list[str] = []
+    for key, grp in df.groupby(row_dim):
+        ser = grp.set_index(col_dim)[value_col]
+        ser = ser.reindex(col_subsectors, fill_value=0.0).astype(float)
+        if ser.sum() <= 0:
+            continue
+        row = (ser / ser.sum()).to_frame().T
+        row = row.reindex(columns=col_subsectors, fill_value=0.0)
+        rows.append(row)
+        index_vals.append(str(key))
+    if not rows:
+        out_empty = pd.DataFrame(columns=col_subsectors, dtype=float)
+        out_empty.index.name = row_dim
+        return out_empty
+    out = pd.concat(rows, axis=0)
+    out.index = pd.Index(index_vals, name=row_dim)
+    return out.astype(float)
+
+
+def _normalize_table(
+    df: pd.DataFrame,
+    *,
+    table: str,
+    slice_name: str,
+    index_codes: list[str] | None = None,
+    column_codes: list[str] | None = None,
+    axis: Literal[0, 1] | None = 1,
+) -> DisaggWeightTable:
+    if not isinstance(df, pd.DataFrame):
+        raise DisaggWeightError("weights must be a pandas DataFrame")
+
+    if (df < 0).any().any():
+        raise DisaggWeightError(
+            f"Negative weights encountered for table={table}, slice={slice_name}"
+        )
+
+    out = df.copy()
+    if index_codes is not None:
+        out = out.reindex(index=index_codes, fill_value=0.0)
+    if column_codes is not None:
+        out = out.reindex(columns=column_codes, fill_value=0.0)
+    out = out.astype(float)
+
+    if axis is None:
+        total_scalar = float(out.sum().sum())
+        if total_scalar <= 0.0:
+            raise DisaggWeightError(f"All-zero weights for table={table}, slice={slice_name}")
+        return (out / total_scalar).astype(float)
+
+    total_series = out.sum(axis=axis)
+    if (total_series <= 0).any():
+        raise DisaggWeightError(f"All-zero weights for table={table}, slice={slice_name}")
+    if axis == 1:
+        return (out.div(total_series, axis=0)).astype(float)
+    return (out.div(total_series, axis=1)).astype(float)
+
+
+def load_disagg_weights(
+    cfg: DisaggConfig,
+    *,
+    original_code: str,
+    new_codes: list[str],
+    disagg_sectors: list[str],
+    naics_to_cornerstone: dict[str, list[str]] | None = None,
+    va_row_codes: list[str] | None = None,
+    industry_subsectors: list[str] | None = None,
+) -> DisaggWeights:
+    _ = naics_to_cornerstone
+    make_df = load_weights_csv(cfg.make_weights_file, "PercentMake")
+    use_df = load_weights_csv(cfg.use_weights_file, "PercentUsed")
+
+    original = original_code
+    new_codes_set = set(new_codes)
+    va_rows_list = va_row_codes if va_row_codes is not None else list(VALUE_ADDEDS)
+    va_rows: set[str] = set(va_rows_list)
+    industry_sectors: list[str] = (
+        industry_subsectors if industry_subsectors is not None else disagg_sectors
+    )
+
+    make_intersection_df = make_df[
+        make_df["IndustryCode"].isin(new_codes_set)
+        & make_df["CommodityCode"].isin(new_codes_set)
+    ]
+    make_col_df = make_df[
+        make_df["CommodityCode"].isin(new_codes_set)
+        & (
+            (~make_df["IndustryCode"].isin({original} | new_codes_set))
+            | (make_df["IndustryCode"] == original)
+        )
+    ]
+    make_row_df = make_df[
+        make_df["IndustryCode"].isin(new_codes_set)
+        & (~make_df["CommodityCode"].isin({original} | new_codes_set))
+    ]
+
+    fd_cols: set[str] = set(
+        use_df.loc[
+            use_df["CommodityCode"].isin(new_codes_set)
+            & use_df["IndustryCode"].isin(set(FINAL_DEMANDS)),
+            "IndustryCode",
+        ].unique()
+    )
+
+    use_intersection_df = use_df[
+        use_df["IndustryCode"].isin(new_codes_set)
+        & use_df["CommodityCode"].isin(new_codes_set)
+    ]
+    use_col_df = use_df[
+        use_df["IndustryCode"].isin(new_codes_set)
+        & (
+            (~use_df["CommodityCode"].isin(new_codes_set | va_rows))
+            | (use_df["CommodityCode"] == original)
+        )
+    ]
+    use_row_df = use_df[
+        use_df["CommodityCode"].isin(new_codes_set)
+        & (
+            (~use_df["IndustryCode"].isin(fd_cols | new_codes_set))
+            | (use_df["IndustryCode"] == original)
+        )
+    ]
+    fd_percentages_df = use_df[use_df["IndustryCode"].isin(fd_cols)]
+    va_percentages_df = use_df[use_df["CommodityCode"].isin(va_rows)]
+
+    make_intersection_piv = _pivot_and_align(
+        make_intersection_df,
+        "PercentMake",
+        "IndustryCode",
+        "CommodityCode",
+        disagg_sectors,
+        disagg_sectors,
+    )
+    if make_intersection_piv.sum().sum() <= 0:
+        make_intersection_piv = pd.DataFrame(
+            1.0 / (len(disagg_sectors) ** 2),
+            index=disagg_sectors,
+            columns=disagg_sectors,
+            dtype=float,
+        )
+    make_intersection = _normalize_table(
+        make_intersection_piv,
+        table="Make",
+        slice_name="intersection",
+        index_codes=disagg_sectors,
+        column_codes=disagg_sectors,
+        axis=None,
+    )
+
+    make_col_default_df = make_col_df[make_col_df["IndustryCode"] == original]
+    if make_col_default_df.empty:
+        default_row = make_intersection.sum(axis=0)
+        make_disagg_commodity_columns_all_rows = pd.DataFrame(
+            [default_row.values],
+            index=["__default__"],
+            columns=disagg_sectors,
+            dtype=float,
+        )
+    else:
+        make_disagg_commodity_columns_all_rows = _build_specific_rows_table(
+            make_col_default_df,
+            row_dim="IndustryCode",
+            col_dim="CommodityCode",
+            col_subsectors=disagg_sectors,
+            value_col="PercentMake",
+        )
+    make_disagg_commodity_columns_all_rows.index.name = "IndustryCode"
+
+    make_disagg_industry_rows_specific_columns = _build_specific_rows_table(
+        make_row_df,
+        row_dim="CommodityCode",
+        col_dim="IndustryCode",
+        col_subsectors=industry_sectors,
+        value_col="PercentMake",
+    )
+
+    make_col_specific_df = make_col_df[
+        ~make_col_df["IndustryCode"].isin({original} | new_codes_set)
+    ]
+    make_disagg_commodity_columns_specific_rows = _build_specific_rows_table(
+        make_col_specific_df,
+        row_dim="IndustryCode",
+        col_dim="CommodityCode",
+        col_subsectors=disagg_sectors,
+        value_col="PercentMake",
+    )
+
+    use_intersection_piv = _pivot_and_align(
+        use_intersection_df,
+        "PercentUsed",
+        "IndustryCode",
+        "CommodityCode",
+        disagg_sectors,
+        disagg_sectors,
+    )
+    if use_intersection_piv.sum().sum() <= 0:
+        raise DisaggWeightError("All-zero weights for table=Use, slice=intersection")
+    use_intersection = _normalize_table(
+        use_intersection_piv,
+        table="Use",
+        slice_name="intersection",
+        index_codes=disagg_sectors,
+        column_codes=disagg_sectors,
+        axis=None,
+    )
+
+    use_col_piv = _pivot_and_align(
+        use_col_df,
+        "PercentUsed",
+        "CommodityCode",
+        "IndustryCode",
+        use_col_df["CommodityCode"].unique().tolist() if not use_col_df.empty else [],
+        disagg_sectors,
+    )
+    if use_col_piv.empty or use_col_piv.sum(axis=1).sum() <= 0:
+        default_row = use_intersection.sum(axis=1)
+        use_disagg_industry_columns_all_rows = pd.DataFrame(
+            [default_row.values] * 1,
+            index=["__default__"],
+            columns=disagg_sectors,
+            dtype=float,
+        )
+    else:
+        use_disagg_industry_columns_all_rows = _normalize_table(
+            use_col_piv,
+            table="Use",
+            slice_name="disagg_industry_columns_all_rows",
+            column_codes=disagg_sectors,
+            axis=1,
+        )
+
+    use_row_default_df = use_row_df[use_row_df["IndustryCode"] == original]
+    if use_row_default_df.empty:
+        uniform_share = 1.0 / len(disagg_sectors)
+        default_row = pd.Series({s: uniform_share for s in disagg_sectors}, dtype=float)
+        use_disagg_commodity_rows_all_columns = pd.DataFrame(
+            [default_row.values],
+            index=["__default__"],
+            columns=disagg_sectors,
+            dtype=float,
+        )
+    else:
+        use_disagg_commodity_rows_all_columns = _build_specific_rows_table(
+            use_row_default_df,
+            row_dim="IndustryCode",
+            col_dim="CommodityCode",
+            col_subsectors=disagg_sectors,
+            value_col="PercentUsed",
+        )
+    use_disagg_commodity_rows_all_columns.index.name = "IndustryCode"
+
+    use_row_specific_df = use_row_df[
+        ~use_row_df["IndustryCode"].isin({original} | new_codes_set)
+    ]
+    use_disagg_rows_specific_columns = _build_specific_rows_table(
+        use_row_specific_df,
+        row_dim="IndustryCode",
+        col_dim="CommodityCode",
+        col_subsectors=disagg_sectors,
+        value_col="PercentUsed",
+    )
+
+    fd_rows: list[pd.DataFrame] = []
+    fd_index: list[str] = []
+    for fd_col in fd_cols:
+        fd_slice = fd_percentages_df[fd_percentages_df["IndustryCode"] == fd_col]
+        if fd_slice.empty:
+            continue
+        ser = fd_slice.set_index("CommodityCode")["PercentUsed"]
+        ser = ser.reindex(disagg_sectors, fill_value=0.0).astype(float)
+        if ser.sum() <= 0:
+            continue
+        row = (
+            (ser / ser.sum())
+            .to_frame()
+            .T.reindex(columns=disagg_sectors, fill_value=0.0)
+        )
+        row.index = pd.Index([fd_col])
+        fd_rows.append(row)
+        fd_index.append(fd_col)
+    if fd_rows:
+        use_fd_columns_for_disagg_commodity_rows = pd.concat(fd_rows, axis=0).astype(float)
+        use_fd_columns_for_disagg_commodity_rows.index = pd.Index(fd_index)
+    else:
+        use_fd_columns_for_disagg_commodity_rows = pd.DataFrame(
+            columns=disagg_sectors, dtype=float
+        )
+
+    if not va_percentages_df.empty:
+        va_piv = _pivot_and_align(
+            va_percentages_df,
+            "PercentUsed",
+            "CommodityCode",
+            "IndustryCode",
+            va_percentages_df["CommodityCode"].unique().tolist(),
+            disagg_sectors,
+        )
+        use_va_rows_for_disagg_industry_columns = _normalize_table(
+            va_piv,
+            table="Use",
+            slice_name="va_rows_for_disagg_industry_columns",
+            column_codes=disagg_sectors,
+            axis=1,
+        )
+    else:
+        use_va_rows_for_disagg_industry_columns = pd.DataFrame(
+            [[1.0 / len(disagg_sectors)] * len(disagg_sectors)] * 1,
+            index=["__default__"],
+            columns=disagg_sectors,
+            dtype=float,
+        )
+
+    return DisaggWeights(
+        use_intersection=use_intersection,
+        use_disagg_industry_columns_all_rows=use_disagg_industry_columns_all_rows,
+        use_disagg_commodity_rows_all_columns=use_disagg_commodity_rows_all_columns,
+        use_disagg_rows_specific_columns=use_disagg_rows_specific_columns,
+        use_va_rows_for_disagg_industry_columns=use_va_rows_for_disagg_industry_columns,
+        use_fd_columns_for_disagg_commodity_rows=use_fd_columns_for_disagg_commodity_rows,
+        make_intersection=make_intersection,
+        make_disagg_commodity_columns_all_rows=make_disagg_commodity_columns_all_rows,
+        make_disagg_commodity_columns_specific_rows=make_disagg_commodity_columns_specific_rows,
+        make_disagg_industry_rows_specific_columns=make_disagg_industry_rows_specific_columns,
+        year=cfg.year,
+        source_name=cfg.source_name,
+    )
+
+
+def weights_to_csv(weights: DisaggWeights, file: IO[str] | None = None) -> None:
+    rows: list[dict[str, str | float]] = []
+
+    def add_table(
+        tbl: DisaggWeightTable,
+        table: str,
+        slice_name: str,
+        *,
+        index_is_industry: bool = True,
+    ) -> None:
+        for ind in tbl.index:
+            for col in tbl.columns:
+                val = tbl.loc[ind, col]
+                if val != 0.0:
+                    if index_is_industry:
+                        industry_val, commodity_val = str(ind), str(col)
+                    else:
+                        industry_val, commodity_val = str(col), str(ind)
+                    rows.append(
+                        {
+                            "table": table,
+                            "slice": slice_name,
+                            "industry": industry_val,
+                            "commodity": commodity_val,
+                            "weight": float(val),
+                        }
+                    )
+
+    add_table(weights.use_intersection, "Use", "use_intersection")
+    add_table(
+        weights.use_disagg_industry_columns_all_rows,
+        "Use",
+        "use_disagg_industry_columns_all_rows",
+        index_is_industry=False,
+    )
+    add_table(
+        weights.use_disagg_commodity_rows_all_columns,
+        "Use",
+        "use_disagg_commodity_rows_all_columns",
+    )
+    add_table(
+        weights.use_disagg_rows_specific_columns,
+        "Use",
+        "use_disagg_rows_specific_columns",
+    )
+    add_table(
+        weights.use_va_rows_for_disagg_industry_columns,
+        "Use",
+        "use_va_rows_for_disagg_industry_columns",
+        index_is_industry=False,
+    )
+    add_table(
+        weights.use_fd_columns_for_disagg_commodity_rows,
+        "Use",
+        "use_fd_columns_for_disagg_commodity_rows",
+    )
+
+    add_table(weights.make_intersection, "Make", "make_intersection")
+    add_table(
+        weights.make_disagg_commodity_columns_all_rows,
+        "Make",
+        "make_disagg_commodity_columns_all_rows",
+    )
+    add_table(
+        weights.make_disagg_commodity_columns_specific_rows,
+        "Make",
+        "make_disagg_commodity_columns_specific_rows",
+    )
+    add_table(
+        weights.make_disagg_industry_rows_specific_columns,
+        "Make",
+        "make_disagg_industry_rows_specific_columns",
+        index_is_industry=False,
+    )
+
+    df = pd.DataFrame(
+        rows,
+        columns=["table", "slice", "industry", "commodity", "weight"],
+    )
+    if file is None:
+        csv_str = df.to_csv(index=False)
+        print(csv_str, end="")
+    else:
+        df.to_csv(file, index=False)

--- a/bedrock/extract/disaggregation/disagg_weights.py
+++ b/bedrock/extract/disaggregation/disagg_weights.py
@@ -5,17 +5,9 @@ from typing import IO, TYPE_CHECKING, Literal, Protocol, runtime_checkable
 
 import pandas as pd
 
+from bedrock.utils.taxonomy.cornerstone.final_demand import FINAL_DEMANDS
+from bedrock.utils.taxonomy.cornerstone.value_added import VALUE_ADDEDS
 from bedrock.utils.taxonomy.correspondence import create_correspondence_matrix
-
-try:
-    from bedrock.utils.taxonomy.cornerstone.value_added import VALUE_ADDEDS
-except ImportError:
-    VALUE_ADDEDS = []
-
-try:
-    from bedrock.utils.taxonomy.cornerstone.final_demand import FINAL_DEMANDS
-except ImportError:
-    FINAL_DEMANDS = []
 
 if TYPE_CHECKING:
     DisaggWeightSeries = pd.Series[float]
@@ -222,11 +214,9 @@ def load_disagg_weights(
     original_code: str,
     new_codes: list[str],
     disagg_sectors: list[str],
-    naics_to_cornerstone: dict[str, list[str]] | None = None,
     va_row_codes: list[str] | None = None,
     industry_subsectors: list[str] | None = None,
 ) -> DisaggWeights:
-    _ = naics_to_cornerstone
     make_df = load_weights_csv(cfg.make_weights_file, "PercentMake")
     use_df = load_weights_csv(cfg.use_weights_file, "PercentUsed")
 
@@ -254,7 +244,7 @@ def load_disagg_weights(
         & (~make_df["CommodityCode"].isin({original} | new_codes_set))
     ]
 
-    fd_cols: set[str] = set(
+    fd_cols: list[str] = sorted(
         use_df.loc[
             use_df["CommodityCode"].isin(new_codes_set)
             & use_df["IndustryCode"].isin(set(FINAL_DEMANDS)),
@@ -276,7 +266,7 @@ def load_disagg_weights(
     use_row_df = use_df[
         use_df["CommodityCode"].isin(new_codes_set)
         & (
-            (~use_df["IndustryCode"].isin(fd_cols | new_codes_set))
+            (~use_df["IndustryCode"].isin(set(fd_cols) | new_codes_set))
             | (use_df["IndustryCode"] == original)
         )
     ]

--- a/bedrock/extract/disaggregation/disagg_weights.py
+++ b/bedrock/extract/disaggregation/disagg_weights.py
@@ -81,7 +81,9 @@ def load_weights_csv(path: str, percent_column: str) -> pd.DataFrame:
     missing_columns = required_columns.difference(df.columns)
     if missing_columns:
         missing_display = ", ".join(sorted(missing_columns))
-        raise DisaggWeightError(f"Missing required columns in {path}: {missing_display}")
+        raise DisaggWeightError(
+            f"Missing required columns in {path}: {missing_display}"
+        )
 
     df["IndustryCode"] = df["IndustryCode"].map(_normalize_code)
     df["CommodityCode"] = df["CommodityCode"].map(_normalize_code)
@@ -199,12 +201,16 @@ def _normalize_table(
     if axis is None:
         total_scalar = float(out.sum().sum())
         if total_scalar <= 0.0:
-            raise DisaggWeightError(f"All-zero weights for table={table}, slice={slice_name}")
+            raise DisaggWeightError(
+                f"All-zero weights for table={table}, slice={slice_name}"
+            )
         return (out / total_scalar).astype(float)
 
     total_series = out.sum(axis=axis)
     if (total_series <= 0).any():
-        raise DisaggWeightError(f"All-zero weights for table={table}, slice={slice_name}")
+        raise DisaggWeightError(
+            f"All-zero weights for table={table}, slice={slice_name}"
+        )
     if axis == 1:
         return (out.div(total_series, axis=0)).astype(float)
     return (out.div(total_series, axis=1)).astype(float)
@@ -433,7 +439,9 @@ def load_disagg_weights(
         fd_rows.append(row)
         fd_index.append(fd_col)
     if fd_rows:
-        use_fd_columns_for_disagg_commodity_rows = pd.concat(fd_rows, axis=0).astype(float)
+        use_fd_columns_for_disagg_commodity_rows = pd.concat(fd_rows, axis=0).astype(
+            float
+        )
         use_fd_columns_for_disagg_commodity_rows.index = pd.Index(fd_index)
     else:
         use_fd_columns_for_disagg_commodity_rows = pd.DataFrame(

--- a/bedrock/extract/disaggregation/waste_weights.py
+++ b/bedrock/extract/disaggregation/waste_weights.py
@@ -1,4 +1,5 @@
 """Backward-compatibility shim. Prefer disagg_weights.py for new code."""
+
 from __future__ import annotations
 
 import pathlib
@@ -7,20 +8,48 @@ from typing import TYPE_CHECKING, cast
 
 from bedrock.extract.disaggregation.disagg_weights import (
     DisaggCorrespondenceError as WasteDisaggCorrespondenceError,
+)
+from bedrock.extract.disaggregation.disagg_weights import (
     DisaggWeightError as WasteDisaggWeightError,
+)
+from bedrock.extract.disaggregation.disagg_weights import (
     DisaggWeights,
-    DisaggWeightSeries as WasteWeightSeries,
-    DisaggWeightTable as WasteWeightTable,
     _apply_correspondence_to_series,
+    _build_specific_rows_table,
     _empty_weight_table,
     _normalize_code,
-    _pivot_and_align,
-    _build_specific_rows_table,
     _normalize_table,
+    _pivot_and_align,
     load_disagg_weights,
     load_weights_csv,
+)
+from bedrock.extract.disaggregation.disagg_weights import (
+    DisaggWeightSeries as WasteWeightSeries,
+)
+from bedrock.extract.disaggregation.disagg_weights import (
+    DisaggWeightTable as WasteWeightTable,
+)
+from bedrock.extract.disaggregation.disagg_weights import (
     weights_to_csv as _weights_to_csv,
 )
+
+__all__ = [
+    "WasteDisaggWeights",
+    "WasteDisaggCorrespondenceError",
+    "WasteDisaggWeightError",
+    "WasteWeightSeries",
+    "WasteWeightTable",
+    "_apply_correspondence_to_series",
+    "_build_specific_rows_table",
+    "_empty_weight_table",
+    "_normalize_code",
+    "_normalize_table",
+    "_pivot_and_align",
+    "load_disagg_weights",
+    "load_weights_csv",
+    "load_waste_disagg_weights",
+    "weights_to_csv",
+]
 
 if TYPE_CHECKING:
     from typing import IO

--- a/bedrock/extract/disaggregation/waste_weights.py
+++ b/bedrock/extract/disaggregation/waste_weights.py
@@ -112,7 +112,6 @@ def load_waste_disagg_weights(
     disagg_original_code: str,
     disagg_new_codes: list[str],
     waste_sectors: list[str],
-    naics_to_cornerstone: dict[str, list[str]] | None = None,
     va_row_codes: list[str] | None = None,
     waste_industry_sectors: list[str] | None = None,
 ) -> WasteDisaggWeights:
@@ -121,7 +120,6 @@ def load_waste_disagg_weights(
         original_code=disagg_original_code,
         new_codes=disagg_new_codes,
         disagg_sectors=waste_sectors,
-        naics_to_cornerstone=naics_to_cornerstone,
         va_row_codes=va_row_codes,
         industry_subsectors=waste_industry_sectors,
     )
@@ -148,7 +146,6 @@ if __name__ == "__main__":
         disagg_original_code="562000",
         disagg_new_codes=cast(list[str], list(WASTE_DISAGG_COMMODITIES["562000"])),
         waste_sectors=cast(list[str], list(WASTE_DISAGG_COMMODITIES["562000"])),
-        naics_to_cornerstone=None,
     )
     # weights_to_csv(_weights, 'weights.csv')
 

--- a/bedrock/extract/disaggregation/waste_weights.py
+++ b/bedrock/extract/disaggregation/waste_weights.py
@@ -1,247 +1,80 @@
+"""Backward-compatibility shim. Prefer disagg_weights.py for new code."""
 from __future__ import annotations
 
 import pathlib
 from dataclasses import dataclass
-from typing import IO, TYPE_CHECKING, Literal, cast
+from typing import TYPE_CHECKING, cast
 
-import pandas as pd
-
-from bedrock.utils.taxonomy.correspondence import create_correspondence_matrix
-
-try:
-    from bedrock.utils.taxonomy.cornerstone.value_added import VALUE_ADDEDS
-except ImportError:
-    VALUE_ADDEDS = []
-
-try:
-    from bedrock.utils.taxonomy.cornerstone.final_demand import FINAL_DEMANDS
-except ImportError:
-    FINAL_DEMANDS = []
+from bedrock.extract.disaggregation.disagg_weights import (
+    DisaggCorrespondenceError as WasteDisaggCorrespondenceError,
+    DisaggWeightError as WasteDisaggWeightError,
+    DisaggWeights,
+    DisaggWeightSeries as WasteWeightSeries,
+    DisaggWeightTable as WasteWeightTable,
+    _apply_correspondence_to_series,
+    _empty_weight_table,
+    _normalize_code,
+    _pivot_and_align,
+    _build_specific_rows_table,
+    _normalize_table,
+    load_disagg_weights,
+    load_weights_csv,
+    weights_to_csv as _weights_to_csv,
+)
 
 if TYPE_CHECKING:
+    from typing import IO
+
     from bedrock.utils.config.usa_config import EEIOWasteDisaggConfig
-
-    WasteWeightSeries = pd.Series[float]
-    WasteWeightTable = pd.DataFrame
-else:
-    WasteWeightSeries = pd.Series
-    WasteWeightTable = pd.DataFrame
-
-
-class WasteDisaggWeightError(Exception):
-    pass
-
-
-class WasteDisaggCorrespondenceError(Exception):
-    pass
-
-
-def _empty_weight_table() -> WasteWeightTable:
-    """Empty WasteWeightTable (0 rows, 0 columns) for slices with no data."""
-    return pd.DataFrame(dtype=float)
 
 
 @dataclass
 class WasteDisaggWeights:
-    """Weights for waste disaggregation; all slices are WasteWeightTable (pd.DataFrame).
-
-    Each slice is a 2D table with index and columns encoding (industry, commodity) or
-    (row_dim, col_dim). No dicts: every slice is a single table.
-    - Intersection slices: index=industry_subsectors, columns=commodity_subsectors (table sum = 1).
-    - Row/column slices: one dimension = context (industry or commodity), other = subsectors; rows sum to 1.
-    - Specific slices: index=context codes, columns=subsectors (one row per context).
-    """
-
-    use_intersection: (
-        WasteWeightTable  # index=industry_subsectors, columns=commodity_subsectors
-    )
-    use_waste_industry_columns_all_rows: (
-        WasteWeightTable  # index=commodity, columns=industry_subsectors
-    )
-    use_waste_commodity_rows_all_columns: (
-        WasteWeightTable  # index=industry, columns=commodity_subsectors
-    )
-    use_waste_rows_specific_columns: (
-        WasteWeightTable  # index=industry_col, columns=commodity_subsectors
-    )
-    use_va_rows_for_waste_industry_columns: (
-        WasteWeightTable  # index=va_row, columns=industry_subsectors
-    )
-    use_fd_columns_for_waste_commodity_rows: (
-        WasteWeightTable  # index=fd_col, columns=commodity_subsectors
-    )
-    make_intersection: (
-        WasteWeightTable  # index=industry_subsectors, columns=commodity_subsectors
-    )
-    make_waste_commodity_columns_all_rows: (
-        WasteWeightTable  # index=industry, columns=commodity_subsectors
-    )
-    make_waste_commodity_columns_specific_rows: (
-        WasteWeightTable  # index=industry, columns=commodity_subsectors
-    )
-    make_waste_industry_rows_specific_columns: (
-        WasteWeightTable  # index=commodity_col, columns=industry_subsectors
-    )
+    use_intersection: WasteWeightTable
+    use_waste_industry_columns_all_rows: WasteWeightTable
+    use_waste_commodity_rows_all_columns: WasteWeightTable
+    use_waste_rows_specific_columns: WasteWeightTable
+    use_va_rows_for_waste_industry_columns: WasteWeightTable
+    use_fd_columns_for_waste_commodity_rows: WasteWeightTable
+    make_intersection: WasteWeightTable
+    make_waste_commodity_columns_all_rows: WasteWeightTable
+    make_waste_commodity_columns_specific_rows: WasteWeightTable
+    make_waste_industry_rows_specific_columns: WasteWeightTable
     year: int
     source_name: str
 
-
-def _normalize_code(code: str) -> str:
-    code = code.strip()
-    if "/" in code:
-        code = code.split("/", maxsplit=1)[0]
-    return code
-
-
-def load_weights_csv(path: str, percent_column: str) -> pd.DataFrame:
-    try:
-        df = pd.read_csv(path, dtype=str)
-    except FileNotFoundError as exc:
-        raise WasteDisaggWeightError(f"Weight file not found: {path}") from exc
-
-    required_columns = {"IndustryCode", "CommodityCode", percent_column}
-    missing_columns = required_columns.difference(df.columns)
-    if missing_columns:
-        missing_display = ", ".join(sorted(missing_columns))
-        raise WasteDisaggWeightError(
-            f"Missing required columns in {path}: {missing_display}"
+    @classmethod
+    def from_disagg_weights(cls, dw: DisaggWeights) -> WasteDisaggWeights:
+        return cls(
+            use_intersection=dw.use_intersection,
+            use_waste_industry_columns_all_rows=dw.use_disagg_industry_columns_all_rows,
+            use_waste_commodity_rows_all_columns=dw.use_disagg_commodity_rows_all_columns,
+            use_waste_rows_specific_columns=dw.use_disagg_rows_specific_columns,
+            use_va_rows_for_waste_industry_columns=dw.use_va_rows_for_disagg_industry_columns,
+            use_fd_columns_for_waste_commodity_rows=dw.use_fd_columns_for_disagg_commodity_rows,
+            make_intersection=dw.make_intersection,
+            make_waste_commodity_columns_all_rows=dw.make_disagg_commodity_columns_all_rows,
+            make_waste_commodity_columns_specific_rows=dw.make_disagg_commodity_columns_specific_rows,
+            make_waste_industry_rows_specific_columns=dw.make_disagg_industry_rows_specific_columns,
+            year=dw.year,
+            source_name=dw.source_name,
         )
 
-    df["IndustryCode"] = df["IndustryCode"].map(_normalize_code)
-    df["CommodityCode"] = df["CommodityCode"].map(_normalize_code)
-
-    df[percent_column] = pd.to_numeric(df[percent_column], errors="coerce")
-    if df[percent_column].isna().any():
-        raise WasteDisaggWeightError(
-            f"Non-numeric or NaN values in {percent_column} column for file {path}"
+    def to_disagg_weights(self) -> DisaggWeights:
+        return DisaggWeights(
+            use_intersection=self.use_intersection,
+            use_disagg_industry_columns_all_rows=self.use_waste_industry_columns_all_rows,
+            use_disagg_commodity_rows_all_columns=self.use_waste_commodity_rows_all_columns,
+            use_disagg_rows_specific_columns=self.use_waste_rows_specific_columns,
+            use_va_rows_for_disagg_industry_columns=self.use_va_rows_for_waste_industry_columns,
+            use_fd_columns_for_disagg_commodity_rows=self.use_fd_columns_for_waste_commodity_rows,
+            make_intersection=self.make_intersection,
+            make_disagg_commodity_columns_all_rows=self.make_waste_commodity_columns_all_rows,
+            make_disagg_commodity_columns_specific_rows=self.make_waste_commodity_columns_specific_rows,
+            make_disagg_industry_rows_specific_columns=self.make_waste_industry_rows_specific_columns,
+            year=self.year,
+            source_name=self.source_name,
         )
-
-    return df
-
-
-def _apply_correspondence_to_series(
-    series: pd.Series,
-    mapping: dict[str, list[str]] | None,
-    target_codes: list[str],
-) -> pd.Series:
-    if mapping is None:
-        return series
-
-    try:
-        correspondence = create_correspondence_matrix(
-            mapping,
-            domain=list(mapping.keys()),
-            range=target_codes,
-            is_injective=True,
-            is_surjective=True,
-            is_complete=True,
-        )
-    except AssertionError as exc:
-        raise WasteDisaggCorrespondenceError(
-            "Incomplete or invalid correspondence for waste disaggregation weights"
-        ) from exc
-
-    aligned = series.reindex(correspondence.columns).fillna(0.0).astype(float)
-    result = correspondence @ aligned
-    return result.astype(float)
-
-
-def _pivot_and_align(
-    df: pd.DataFrame,
-    value_col: str,
-    index_col: str,
-    columns_col: str,
-    index_codes: list[str],
-    column_codes: list[str],
-) -> pd.DataFrame:
-    """Pivot to (index_col x columns_col), reindex to given codes, fill 0."""
-    if df.empty:
-        return pd.DataFrame(0.0, index=index_codes, columns=column_codes, dtype=float)
-    pivoted = df.pivot_table(
-        index=index_col, columns=columns_col, values=value_col, aggfunc="sum"
-    ).fillna(0.0)
-    return pivoted.reindex(
-        index=index_codes, columns=column_codes, fill_value=0.0
-    ).astype(float)
-
-
-def _build_specific_rows_table(
-    df: pd.DataFrame,
-    *,
-    row_dim: str,
-    col_dim: str,
-    col_subsectors: list[str],
-    value_col: str,
-) -> WasteWeightTable:
-    """Build one WasteWeightTable: index=context codes (row_dim), columns=col_subsectors; each row sums to 1."""
-    if df.empty:
-        out_empty = pd.DataFrame(columns=col_subsectors, dtype=float)
-        out_empty.index.name = row_dim
-        return out_empty
-    rows: list[pd.DataFrame] = []
-    index_vals: list[str] = []
-    for key, grp in df.groupby(row_dim):
-        ser = grp.set_index(col_dim)[value_col]
-        ser = ser.reindex(col_subsectors, fill_value=0.0).astype(float)
-        if ser.sum() <= 0:
-            continue
-        row = (ser / ser.sum()).to_frame().T
-        row = row.reindex(columns=col_subsectors, fill_value=0.0)
-        rows.append(row)
-        index_vals.append(str(key))
-    if not rows:
-        out_empty = pd.DataFrame(columns=col_subsectors, dtype=float)
-        out_empty.index.name = row_dim
-        return out_empty
-    out = pd.concat(rows, axis=0)
-    out.index = pd.Index(index_vals, name=row_dim)
-    return out.astype(float)
-
-
-def _normalize_table(
-    df: pd.DataFrame,
-    *,
-    table: str,
-    slice_name: str,
-    index_codes: list[str] | None = None,
-    column_codes: list[str] | None = None,
-    axis: Literal[0, 1] | None = 1,
-) -> WasteWeightTable:
-    """Normalize a weight table. axis=1: each row sums to 1; axis=None: whole table sums to 1.
-    If index_codes/column_codes are given, reindex to those; otherwise keep existing index/columns.
-    """
-    if not isinstance(df, pd.DataFrame):
-        raise WasteDisaggWeightError("weights must be a pandas DataFrame")
-
-    if (df < 0).any().any():
-        raise WasteDisaggWeightError(
-            f"Negative weights encountered for table={table}, slice={slice_name}"
-        )
-
-    out = df.copy()
-    if index_codes is not None:
-        out = out.reindex(index=index_codes, fill_value=0.0)
-    if column_codes is not None:
-        out = out.reindex(columns=column_codes, fill_value=0.0)
-    out = out.astype(float)
-
-    if axis is None:
-        total_scalar = float(out.sum().sum())
-        if total_scalar <= 0.0:
-            raise WasteDisaggWeightError(
-                f"All-zero weights for table={table}, slice={slice_name}"
-            )
-        return (out / total_scalar).astype(float)
-
-    # axis is 0 or 1 here, so sum returns a Series
-    total_series = out.sum(axis=axis)
-    if (total_series <= 0).any():
-        raise WasteDisaggWeightError(
-            f"All-zero weights for table={table}, slice={slice_name}"
-        )
-    if axis == 1:
-        return (out.div(total_series, axis=0)).astype(float)
-    return (out.div(total_series, axis=1)).astype(float)
 
 
 def load_waste_disagg_weights(
@@ -254,381 +87,22 @@ def load_waste_disagg_weights(
     va_row_codes: list[str] | None = None,
     waste_industry_sectors: list[str] | None = None,
 ) -> WasteDisaggWeights:
-    # naics_to_cornerstone reserved for future index/column correspondence mapping
-    _ = naics_to_cornerstone
-    make_df = load_weights_csv(cfg.make_weights_file, "PercentMake")
-    use_df = load_weights_csv(cfg.use_weights_file, "PercentUsed")
-
-    original = disagg_original_code
-    new_codes = set(disagg_new_codes)
-    va_rows_list = va_row_codes if va_row_codes is not None else list(VALUE_ADDEDS)
-    va_rows: set[str] = set(va_rows_list)
-    industry_sectors: list[str] = (
-        waste_industry_sectors if waste_industry_sectors is not None else waste_sectors
+    dw = load_disagg_weights(
+        cfg,
+        original_code=disagg_original_code,
+        new_codes=disagg_new_codes,
+        disagg_sectors=waste_sectors,
+        naics_to_cornerstone=naics_to_cornerstone,
+        va_row_codes=va_row_codes,
+        industry_subsectors=waste_industry_sectors,
     )
-
-    make_intersection_df = make_df[
-        make_df["IndustryCode"].isin(new_codes)
-        & make_df["CommodityCode"].isin(new_codes)
-    ]
-    # Commodity disaggregation: industries (other or aggregated) × commodity subsectors
-    # Include both: other industries with waste commodity columns, and original industry (562000) with new commodity codes (Make column sum)
-    make_col_df = make_df[
-        make_df["CommodityCode"].isin(new_codes)
-        & (
-            (~make_df["IndustryCode"].isin({original} | new_codes))
-            | (make_df["IndustryCode"] == original)
-        )
-    ]
-    # Industry disaggregation
-    make_row_df = make_df[
-        make_df["IndustryCode"].isin(new_codes)
-        & (~make_df["CommodityCode"].isin({original} | new_codes))
-    ]
-
-    fd_cols: set[str] = set(
-        use_df.loc[
-            use_df["CommodityCode"].isin(new_codes)
-            & use_df["IndustryCode"].isin(set(FINAL_DEMANDS)),
-            "IndustryCode",
-        ].unique()
-    )
-
-    use_intersection_df = use_df[
-        use_df["IndustryCode"].isin(new_codes) & use_df["CommodityCode"].isin(new_codes)
-    ]
-    # Use industry columns: commodity rows (other or aggregated) × industry subsectors
-    # Include both: non-waste commodity rows, and original commodity (562000) for column totals (Use column sum)
-    use_col_df = use_df[
-        use_df["IndustryCode"].isin(new_codes)
-        & (
-            (~use_df["CommodityCode"].isin(new_codes | va_rows))
-            | (use_df["CommodityCode"] == original)
-        )
-    ]
-    # Use commodity rows: industry columns (other or aggregated) × commodity subsectors
-    # Include both: non-FD/non-waste industry columns, and original industry (562000) for row totals (Use row sum)
-    use_row_df = use_df[
-        use_df["CommodityCode"].isin(new_codes)
-        & (
-            (~use_df["IndustryCode"].isin(fd_cols | new_codes))
-            | (use_df["IndustryCode"] == original)
-        )
-    ]
-    fd_percentages_df = use_df[use_df["IndustryCode"].isin(fd_cols)]
-    va_percentages_df = use_df[use_df["CommodityCode"].isin(va_rows)]
-
-    # --- Make intersection: (industry_subsectors x commodity_subsectors), table sum = 1
-    make_intersection_piv = _pivot_and_align(
-        make_intersection_df,
-        "PercentMake",
-        "IndustryCode",
-        "CommodityCode",
-        waste_sectors,
-        waste_sectors,
-    )
-    if make_intersection_piv.sum().sum() <= 0:
-        make_intersection_piv = pd.DataFrame(
-            1.0 / (len(waste_sectors) ** 2),
-            index=waste_sectors,
-            columns=waste_sectors,
-            dtype=float,
-        )
-    make_intersection = _normalize_table(
-        make_intersection_piv,
-        table="Make",
-        slice_name="intersection",
-        index_codes=waste_sectors,
-        column_codes=waste_sectors,
-        axis=None,
-    )
-
-    # --- Make commodity columns all rows: default allocation only (1 row: original or __default__)
-    # Used when an industry has no row in make_waste_commodity_columns_specific_rows.
-    make_col_default_df = make_col_df[make_col_df["IndustryCode"] == original]
-    if make_col_default_df.empty:
-        default_row = make_intersection.sum(axis=0)
-        make_waste_commodity_columns_all_rows = pd.DataFrame(
-            [default_row.values],
-            index=["__default__"],
-            columns=waste_sectors,
-            dtype=float,
-        )
-    else:
-        make_waste_commodity_columns_all_rows = _build_specific_rows_table(
-            make_col_default_df,
-            row_dim="IndustryCode",
-            col_dim="CommodityCode",
-            col_subsectors=waste_sectors,
-            value_col="PercentMake",
-        )
-    make_waste_commodity_columns_all_rows.index.name = "IndustryCode"
-
-    # --- Make industry rows specific columns: index=commodity_col, columns=industry_subsectors
-    make_waste_industry_rows_specific_columns = _build_specific_rows_table(
-        make_row_df,
-        row_dim="CommodityCode",
-        col_dim="IndustryCode",
-        col_subsectors=industry_sectors,
-        value_col="PercentMake",
-    )
-
-    # --- Make commodity columns specific rows: row-specific overrides only (exclude original)
-    # Industries with explicit allocations; lookup here first, else use make_waste_commodity_columns_all_rows.
-    make_col_specific_df = make_col_df[
-        ~make_col_df["IndustryCode"].isin({original} | new_codes)
-    ]
-    make_waste_commodity_columns_specific_rows = _build_specific_rows_table(
-        make_col_specific_df,
-        row_dim="IndustryCode",
-        col_dim="CommodityCode",
-        col_subsectors=waste_sectors,
-        value_col="PercentMake",
-    )
-
-    # --- Use intersection: (industry_subsectors x commodity_subsectors), table sum = 1
-    use_intersection_piv = _pivot_and_align(
-        use_intersection_df,
-        "PercentUsed",
-        "IndustryCode",
-        "CommodityCode",
-        waste_sectors,
-        waste_sectors,
-    )
-    if use_intersection_piv.sum().sum() <= 0:
-        raise WasteDisaggWeightError(
-            "All-zero weights for table=Use, slice=intersection"
-        )
-    use_intersection = _normalize_table(
-        use_intersection_piv,
-        table="Use",
-        slice_name="intersection",
-        index_codes=waste_sectors,
-        column_codes=waste_sectors,
-        axis=None,
-    )
-
-    # --- Use industry columns all rows: (commodity x industry_subsectors), each row sum = 1
-    use_col_piv = _pivot_and_align(
-        use_col_df,
-        "PercentUsed",
-        "CommodityCode",
-        "IndustryCode",
-        use_col_df["CommodityCode"].unique().tolist() if not use_col_df.empty else [],
-        waste_sectors,
-    )
-    if use_col_piv.empty or use_col_piv.sum(axis=1).sum() <= 0:
-        default_row = use_intersection.sum(axis=1)
-        use_waste_industry_columns_all_rows = pd.DataFrame(
-            [default_row.values] * 1,
-            index=["__default__"],
-            columns=waste_sectors,
-            dtype=float,
-        )
-    else:
-        use_waste_industry_columns_all_rows = _normalize_table(
-            use_col_piv,
-            table="Use",
-            slice_name="waste_industry_columns_all_rows",
-            column_codes=waste_sectors,
-            axis=1,
-        )
-
-    # --- Use commodity rows all columns: default allocation only (1 row: original or __default__)
-    # Used when an industry column has no row in use_waste_rows_specific_columns.
-    # Matches useeior: when no UseFileDF row with IndustryCode=OriginalSectorCode, use uniform.
-    use_row_default_df = use_row_df[use_row_df["IndustryCode"] == original]
-    if use_row_default_df.empty:
-        uniform_share = 1.0 / len(waste_sectors)
-        default_row = pd.Series(
-            {s: uniform_share for s in waste_sectors},
-            dtype=float,
-        )
-        use_waste_commodity_rows_all_columns = pd.DataFrame(
-            [default_row.values],
-            index=["__default__"],
-            columns=waste_sectors,
-            dtype=float,
-        )
-    else:
-        use_waste_commodity_rows_all_columns = _build_specific_rows_table(
-            use_row_default_df,
-            row_dim="IndustryCode",
-            col_dim="CommodityCode",
-            col_subsectors=waste_sectors,
-            value_col="PercentUsed",
-        )
-    use_waste_commodity_rows_all_columns.index.name = "IndustryCode"
-
-    # --- Use rows specific columns: industry columns with explicit allocations (exclude original)
-    use_row_specific_df = use_row_df[
-        ~use_row_df["IndustryCode"].isin({original} | new_codes)
-    ]
-    use_waste_rows_specific_columns = _build_specific_rows_table(
-        use_row_specific_df,
-        row_dim="IndustryCode",
-        col_dim="CommodityCode",
-        col_subsectors=waste_sectors,
-        value_col="PercentUsed",
-    )
-
-    # --- FD columns: index=fd_col, columns=commodity_subsectors
-    fd_rows: list[pd.DataFrame] = []
-    fd_index: list[str] = []
-    for fd_col in fd_cols:
-        fd_slice = fd_percentages_df[fd_percentages_df["IndustryCode"] == fd_col]
-        if fd_slice.empty:
-            continue
-        ser = fd_slice.set_index("CommodityCode")["PercentUsed"]
-        ser = ser.reindex(waste_sectors, fill_value=0.0).astype(float)
-        if ser.sum() <= 0:
-            continue
-        row = (
-            (ser / ser.sum())
-            .to_frame()
-            .T.reindex(columns=waste_sectors, fill_value=0.0)
-        )
-        row.index = pd.Index([fd_col])
-        fd_rows.append(row)
-        fd_index.append(fd_col)
-    if fd_rows:
-        use_fd_columns_for_waste_commodity_rows = pd.concat(fd_rows, axis=0).astype(
-            float
-        )
-        use_fd_columns_for_waste_commodity_rows.index = pd.Index(fd_index)
-    else:
-        use_fd_columns_for_waste_commodity_rows = pd.DataFrame(
-            columns=waste_sectors, dtype=float
-        )
-
-    # --- VA rows: (va_row x industry_subsectors), each row sum = 1
-    if not va_percentages_df.empty:
-        va_piv = _pivot_and_align(
-            va_percentages_df,
-            "PercentUsed",
-            "CommodityCode",
-            "IndustryCode",
-            va_percentages_df["CommodityCode"].unique().tolist(),
-            waste_sectors,
-        )
-        use_va_rows_for_waste_industry_columns = _normalize_table(
-            va_piv,
-            table="Use",
-            slice_name="va_rows_for_waste_industry_columns",
-            column_codes=waste_sectors,
-            axis=1,
-        )
-    else:
-        use_va_rows_for_waste_industry_columns = pd.DataFrame(
-            [[1.0 / len(waste_sectors)] * len(waste_sectors)] * 1,
-            index=["__default__"],
-            columns=waste_sectors,
-            dtype=float,
-        )
-
-    return WasteDisaggWeights(
-        use_intersection=use_intersection,
-        use_waste_industry_columns_all_rows=use_waste_industry_columns_all_rows,
-        use_waste_commodity_rows_all_columns=use_waste_commodity_rows_all_columns,
-        use_waste_rows_specific_columns=use_waste_rows_specific_columns,
-        use_va_rows_for_waste_industry_columns=use_va_rows_for_waste_industry_columns,
-        use_fd_columns_for_waste_commodity_rows=use_fd_columns_for_waste_commodity_rows,
-        make_intersection=make_intersection,
-        make_waste_commodity_columns_all_rows=make_waste_commodity_columns_all_rows,
-        make_waste_commodity_columns_specific_rows=make_waste_commodity_columns_specific_rows,
-        make_waste_industry_rows_specific_columns=make_waste_industry_rows_specific_columns,
-        year=cfg.year,
-        source_name=cfg.source_name,
-    )
+    return WasteDisaggWeights.from_disagg_weights(dw)
 
 
 def weights_to_csv(weights: WasteDisaggWeights, file: IO[str] | None = None) -> None:
-    rows: list[dict[str, str | float]] = []
-
-    def add_table(
-        tbl: WasteWeightTable,
-        table: str,
-        slice_name: str,
-        *,
-        index_is_industry: bool = True,
-    ) -> None:
-        for ind in tbl.index:
-            for col in tbl.columns:
-                val = tbl.loc[ind, col]
-                if val != 0.0:
-                    if index_is_industry:
-                        industry_val, commodity_val = str(ind), str(col)
-                    else:
-                        industry_val, commodity_val = str(col), str(ind)
-                    rows.append(
-                        {
-                            "table": table,
-                            "slice": slice_name,
-                            "industry": industry_val,
-                            "commodity": commodity_val,
-                            "weight": float(val),
-                        }
-                    )
-
-    add_table(weights.use_intersection, "Use", "use_intersection")
-    add_table(
-        weights.use_waste_industry_columns_all_rows,
-        "Use",
-        "use_waste_industry_columns_all_rows",
-        index_is_industry=False,  # slice: index=commodity, columns=industry_subsectors
-    )
-    add_table(
-        weights.use_waste_commodity_rows_all_columns,
-        "Use",
-        "use_waste_commodity_rows_all_columns",
-    )
-    add_table(
-        weights.use_waste_rows_specific_columns,
-        "Use",
-        "use_waste_rows_specific_columns",
-    )
-    add_table(
-        weights.use_va_rows_for_waste_industry_columns,
-        "Use",
-        "use_va_rows_for_waste_industry_columns",
-        index_is_industry=False,  # slice: index=va_row, columns=industry_subsectors
-    )
-    add_table(
-        weights.use_fd_columns_for_waste_commodity_rows,
-        "Use",
-        "use_fd_columns_for_waste_commodity_rows",
-    )
-
-    add_table(weights.make_intersection, "Make", "make_intersection")
-    add_table(
-        weights.make_waste_commodity_columns_all_rows,
-        "Make",
-        "make_waste_commodity_columns_all_rows",
-    )
-    add_table(
-        weights.make_waste_commodity_columns_specific_rows,
-        "Make",
-        "make_waste_commodity_columns_specific_rows",
-    )
-    add_table(
-        weights.make_waste_industry_rows_specific_columns,
-        "Make",
-        "make_waste_industry_rows_specific_columns",
-        index_is_industry=False,  # slice: index=commodity_col, columns=industry_subsectors
-    )
-
-    df = pd.DataFrame(
-        rows,
-        columns=["table", "slice", "industry", "commodity", "weight"],
-    )
-    if file is None:
-        csv_str = df.to_csv(index=False)
-        print(csv_str, end="")
-    else:
-        df.to_csv(file, index=False)
+    _weights_to_csv(weights.to_disagg_weights(), file=file)
 
 
-# %%
 if __name__ == "__main__":
     from bedrock.utils.config.usa_config import EEIOWasteDisaggConfig
     from bedrock.utils.taxonomy.cornerstone.commodities import WASTE_DISAGG_COMMODITIES

--- a/bedrock/transform/eeio/__tests__/test_waste_disaggregation.py
+++ b/bedrock/transform/eeio/__tests__/test_waste_disaggregation.py
@@ -541,7 +541,6 @@ def weights_2017() -> WasteDisaggWeights:
         disagg_new_codes=_WASTE_CODES_2017,
         waste_sectors=_WASTE_CODES_2017,
         va_row_codes=_VA_ROWS,
-        naics_to_cornerstone=None,
     )
 
 


### PR DESCRIPTION
cc: https://github.com/cornerstone-data/bedrock/issues/367
Closes:

## What changed? Why?

The disaggregation weights logic previously lived entirely in `waste_weights.py` under waste-specific naming (`WasteDisaggWeights`, `load_waste_disagg_weights`, etc.). This logic has been extracted into a new generic `disagg_weights.py` module introducing `DisaggWeights` and `load_disagg_weights`, making the disaggregation machinery reusable beyond waste sectors.

`waste_weights.py` is now a backward-compatibility shim: `WasteDisaggWeights` delegates to `DisaggWeights` via `from_disagg_weights()` and `to_disagg_weights()` conversion methods, and `load_waste_disagg_weights` simply calls `load_disagg_weights` and wraps the result. All internal helpers (`_normalize_code`, `_pivot_and_align`, `_build_specific_rows_table`, `_normalize_table`, `load_weights_csv`, `weights_to_csv`, etc.) are now defined once in `disagg_weights.py` and re-exported from `waste_weights.py`.

## Testing

Two new integration test classes were added in `test_disagg_weights_parity.py`:

- `TestDisaggWeightsParity` — asserts that every weight slice produced by `load_disagg_weights` is numerically identical to the corresponding slice from the old `load_waste_disagg_weights`, covering all Use and Make table slices as well as `year` and `source_name`.
- `TestFullPipelineParity` — runs the full EEIO cornerstone pipeline twice (once with the original code path, once injecting weights built via the new `load_disagg_weights` API wrapped back into `WasteDisaggWeights`) and asserts that V, Udom, Uimp, VA, Ytot, Adom, Aimp, B, q, and x are all identical between the two runs.