### PR TITLE
feat(analysis): step 3 — A-matrix cross-approach hexbins at 2024

### DIFF
--- a/.github/workflows/run_a_matrix_analysis.yml
+++ b/.github/workflows/run_a_matrix_analysis.yml
@@ -1,4 +1,4 @@
-name: a_matrix_analysis
+name: run_a_matrix_analysis
 
 on:
   workflow_dispatch:
@@ -40,6 +40,9 @@ jobs:
       - name: Step 2 — cell-by-cell diagnostics + plots
         run: uv run python -m bedrock.analysis.a_matrix_time_series.derive_A_cells_long
 
+      - name: Step 2.5 — cell-level stability + persistence
+        run: uv run python -m bedrock.analysis.a_matrix_time_series.derive_A_cells_stability
+
       - name: Capture run-report Sheet ID
         id: capture_sheet
         run: |
@@ -53,14 +56,14 @@ jobs:
       - name: Upload plots
         uses: actions/upload-artifact@v4
         with:
-          name: a_matrix_analysis_plots_${{ github.sha }}
+          name: run_a_matrix_analysis_plots_${{ github.sha }}
           path: bedrock/analysis/a_matrix_time_series/output/plots/
           if-no-files-found: warn
 
       - name: Upload results CSVs
         uses: actions/upload-artifact@v4
         with:
-          name: a_matrix_analysis_results_${{ github.sha }}
+          name: run_a_matrix_analysis_results_${{ github.sha }}
           path: |
             bedrock/analysis/a_matrix_time_series/output/results/*.csv
             bedrock/analysis/a_matrix_time_series/output/results/last_run_sheet_id.txt

--- a/bedrock/analysis/a_matrix_time_series/compare_approaches.py
+++ b/bedrock/analysis/a_matrix_time_series/compare_approaches.py
@@ -3,7 +3,7 @@
 Reads the parquet caches produced by ``derive_A_time_series.py`` (Step 1) and
 produces:
 
-- ``step3_pairwise_hexbins_{dom,imp}.png`` — 1×3 grid of log-log hexbin
+- ``pairwise_hexbins_{dom,imp}.png`` — 1×3 grid of log-log hexbin
   density plots between the three alternative approaches at 2024
   (``summary_tables`` vs ``industry_price_index``,
   ``summary_tables`` vs ``commodity_price_index``,
@@ -14,14 +14,14 @@ produces:
   this figure adds the alternative-vs-alternative angle that Step 2 can't
   show, on log-log axes that resolve the dense low-magnitude region.
 
-- ``step3_column_cap_audit.csv`` — every (year, dom_or_imp, col_sector)
+- ``column_cap_audit.csv`` — every (year, dom_or_imp, col_sector)
   where the 0.98 column-cap inside ``scale_cornerstone_A`` fired on the
   ``summary_tables`` approach. Cap-fired detection: column sum within
   ``CAP_TOL`` of 0.98 after scaling. Columns just below 0.98 (sum > 0.97
   but cap not reached) are also written so reviewers can see how close
   the cap was to firing.
 
-- Sheet tab ``step3_column_cap_audit`` appended to the run-report Sheet
+- Sheet tab ``column_cap_audit`` appended to the run-report Sheet
   (sheet ID read from ``last_run_sheet_id.txt``).
 
 Usage:
@@ -235,8 +235,8 @@ def column_cap_audit(years: list[int]) -> pd.DataFrame:
 # ---------------------------------------------------------------------------
 
 
-def _publish_step3_tabs(cap_audit_df: pd.DataFrame) -> None:
-    """Append Step 3 summary tab to the run-report Sheet, if available."""
+def _publish_cap_audit_tab(cap_audit_df: pd.DataFrame) -> None:
+    """Append the column-cap audit tab to the run-report Sheet, if available."""
     if not LAST_RUN_SHEET_ID_PATH.exists():
         logger.warning(
             "No %s found — skipping Sheet publish. Run derive_A_time_series "
@@ -246,7 +246,7 @@ def _publish_step3_tabs(cap_audit_df: pd.DataFrame) -> None:
         return
     sheet_id = LAST_RUN_SHEET_ID_PATH.read_text().strip()
     try:
-        update_sheet_tab(sheet_id, "step3_column_cap_audit", cap_audit_df)
+        update_sheet_tab(sheet_id, "column_cap_audit", cap_audit_df)
     except Exception as e:  # noqa: BLE001
         logger.warning(
             "Sheet publish skipped (%s: %s). Local artifacts still complete.",
@@ -254,7 +254,7 @@ def _publish_step3_tabs(cap_audit_df: pd.DataFrame) -> None:
             e,
         )
         return
-    logger.info("Updated Step 3 tab on sheet %s", sheet_id)
+    logger.info("Updated column_cap_audit tab on sheet %s", sheet_id)
 
 
 def main() -> None:
@@ -266,7 +266,7 @@ def main() -> None:
 
     for kind in KINDS:
         plot_pairwise_hexbins(
-            matrices, kind, PLOTS_DIR / f"step3_pairwise_hexbins_{kind}.png"
+            matrices, kind, PLOTS_DIR / f"pairwise_hexbins_{kind}.png"
         )
 
     # Cap audit spans all available summary_tables years to give a full picture
@@ -276,9 +276,9 @@ def main() -> None:
         for p in RESULTS_DIR.glob("A_summary_tables_*.parquet")
     )
     cap_audit_df = column_cap_audit(audit_years)
-    cap_audit_df.to_csv(RESULTS_DIR / "step3_column_cap_audit.csv", index=False)
+    cap_audit_df.to_csv(RESULTS_DIR / "column_cap_audit.csv", index=False)
 
-    _publish_step3_tabs(cap_audit_df)
+    _publish_cap_audit_tab(cap_audit_df)
     logger.info("Step 3 outputs written to %s and %s", RESULTS_DIR, PLOTS_DIR)
 
 

--- a/bedrock/analysis/a_matrix_time_series/compare_approaches.py
+++ b/bedrock/analysis/a_matrix_time_series/compare_approaches.py
@@ -1,0 +1,287 @@
+"""Step 3 of epic #337: cross-approach comparison at fixed target year (2024).
+
+Reads the parquet caches produced by ``derive_A_time_series.py`` (Step 1) and
+produces:
+
+- ``step3_pairwise_hexbins_{dom,imp}.png`` — 1×3 grid of log-log hexbin
+  density plots between the three alternative approaches at 2024
+  (``summary_tables`` vs ``industry_price_index``,
+  ``summary_tables`` vs ``commodity_price_index``,
+  ``industry_price_index`` vs ``commodity_price_index``). Hexbin density
+  uses ``bins='log'`` because A cells span ~6 orders of magnitude and a
+  linear color scale would be dominated by the near-zero peak. Step 2
+  already covers alternative-vs-baseline scatters at 2024 (linear axes);
+  this figure adds the alternative-vs-alternative angle that Step 2 can't
+  show, on log-log axes that resolve the dense low-magnitude region.
+
+- ``step3_column_cap_audit.csv`` — every (year, dom_or_imp, col_sector)
+  where the 0.98 column-cap inside ``scale_cornerstone_A`` fired on the
+  ``summary_tables`` approach. Cap-fired detection: column sum within
+  ``CAP_TOL`` of 0.98 after scaling. Columns just below 0.98 (sum > 0.97
+  but cap not reached) are also written so reviewers can see how close
+  the cap was to firing.
+
+- Sheet tab ``step3_column_cap_audit`` appended to the run-report Sheet
+  (sheet ID read from ``last_run_sheet_id.txt``).
+
+Usage:
+    python -m bedrock.analysis.a_matrix_time_series.compare_approaches
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from bedrock.utils.io.gcp import update_sheet_tab
+
+logger = logging.getLogger(__name__)
+
+OUTPUT_DIR = Path(__file__).parent / "output"
+RESULTS_DIR = OUTPUT_DIR / "results"
+PLOTS_DIR = OUTPUT_DIR / "plots"
+LAST_RUN_SHEET_ID_PATH = RESULTS_DIR / "last_run_sheet_id.txt"
+
+TARGET_YEAR = 2024
+
+ALTERNATIVE_APPROACHES: tuple[str, ...] = (
+    "summary_tables",
+    "industry_price_index",
+    "commodity_price_index",
+)
+BASELINE_APPROACHES: tuple[str, ...] = ("useeio", "ceda_default")
+PAIRS: tuple[tuple[str, str], ...] = (
+    ("summary_tables", "industry_price_index"),
+    ("summary_tables", "commodity_price_index"),
+    ("industry_price_index", "commodity_price_index"),
+)
+KINDS: tuple[str, ...] = ("dom", "imp")
+
+# Column cap inside scale_cornerstone_A — re-stated here as a constant so the
+# audit can test for it without importing the production helper.
+COLUMN_CAP = 0.98
+CAP_TOL = 1e-9
+NEAR_CAP_THRESHOLD = 0.97  # report borderline columns too
+
+
+def _load_pair(approach: str, year: int) -> dict[str, pd.DataFrame]:
+    """Load the (Adom, Aimp) parquet for one (approach, year) into a dict."""
+    combined = pd.read_parquet(RESULTS_DIR / f"A_{approach}_{year}.parquet")
+    return {
+        "dom": pd.DataFrame(combined.loc["dom"]),
+        "imp": pd.DataFrame(combined.loc["imp"]),
+    }
+
+
+def _load_all_at_year(year: int) -> dict[str, dict[str, pd.DataFrame]]:
+    """Returns ``{kind: {approach: A_matrix}}`` at ``year``.
+
+    Only loads the alternative approaches — Step 3's hexbins compare
+    alternatives against each other, not against baselines.
+    """
+    out: dict[str, dict[str, pd.DataFrame]] = {kind: {} for kind in KINDS}
+    for approach in ALTERNATIVE_APPROACHES:
+        pair = _load_pair(approach, year)
+        for kind in KINDS:
+            out[kind][approach] = pair[kind]
+    return out
+
+
+def _aligned_arrays(a: pd.DataFrame, b: pd.DataFrame) -> tuple[np.ndarray, np.ndarray]:
+    """Reindex ``b`` to ``a``'s row/column order and return raveled values."""
+    b_aligned = b.reindex(index=a.index, columns=a.columns)
+    return a.to_numpy().ravel(), b_aligned.to_numpy().ravel()
+
+
+# ---------------------------------------------------------------------------
+# Pairwise hexbins
+# ---------------------------------------------------------------------------
+
+
+def plot_pairwise_hexbins(
+    matrices: dict[str, dict[str, pd.DataFrame]], kind: str, path: Path
+) -> None:
+    """1×3 log-log hexbin density grid: pairs of alternative approaches.
+
+    Cells where both values are zero (joint sparsity in A) are dropped — they
+    inflate the density at the origin and obscure the disagreement story.
+    Each panel reports n_cells, R², and the share of cells off the y=x
+    diagonal by more than 1× (i.e. ratio outside [0.5, 2]).
+    """
+    fig, axes = plt.subplots(1, len(PAIRS), figsize=(5 * len(PAIRS), 5), squeeze=False)
+    fig.suptitle(f"Pairwise A-matrix comparison — {kind} — {TARGET_YEAR}", fontsize=12)
+    eps = 1e-12
+
+    for ax_idx, (a_name, b_name) in enumerate(PAIRS):
+        ax = axes[0][ax_idx]
+        x, y = _aligned_arrays(matrices[kind][a_name], matrices[kind][b_name])
+        mask = ~(np.isnan(x) | np.isnan(y)) & ~((x == 0) & (y == 0))
+        x_pos = x[mask]
+        y_pos = y[mask]
+        if x_pos.size == 0:
+            ax.text(0.5, 0.5, "no data", transform=ax.transAxes, ha="center")
+            continue
+
+        # Log-log because A spans many orders of magnitude. eps shifts joint
+        # zero-on-one-side cells onto the plot rather than dropping them.
+        log_x = np.log10(x_pos + eps)
+        log_y = np.log10(y_pos + eps)
+        hb = ax.hexbin(log_x, log_y, gridsize=60, bins="log", cmap="viridis")
+        cbar = fig.colorbar(hb, ax=ax)
+        cbar.set_label("log10(count)", fontsize=9)
+
+        lo = float(min(log_x.min(), log_y.min()))
+        hi = float(max(log_x.max(), log_y.max()))
+        ax.plot([lo, hi], [lo, hi], "r--", lw=0.8, alpha=0.8, label="y=x")
+        ax.set_xlim(lo, hi)
+        ax.set_ylim(lo, hi)
+        ax.set_aspect("equal", adjustable="box")
+        ax.set_xlabel(f"log10({a_name})")
+        ax.set_ylabel(f"log10({b_name})")
+        ax.set_title(f"{a_name} vs {b_name}", fontsize=10)
+        ax.grid(True, alpha=0.3)
+
+        # Stats: R² in original (non-log) space; off-diagonal share = cells
+        # where ratio is outside [0.5, 2] (i.e. one side ≥2× the other).
+        x_f = np.asarray(x_pos, dtype=float)
+        y_f = np.asarray(y_pos, dtype=float)
+        r2 = (
+            float(np.corrcoef(x_f, y_f)[0, 1] ** 2)
+            if x_f.std() > 0 and y_f.std() > 0
+            else float("nan")
+        )
+        denom = np.where(np.abs(x_f) > 0, np.abs(x_f), np.nan)
+        ratio = np.abs(y_f / denom)
+        valid = ~np.isnan(ratio)
+        off_diag_share = (
+            float(((ratio[valid] < 0.5) | (ratio[valid] > 2.0)).mean())
+            if valid.any()
+            else float("nan")
+        )
+        stats_text = (
+            f"n = {x_pos.size:,}\n"
+            f"R² = {r2:.4f}\n"
+            f"|y/x| outside [0.5,2]: {off_diag_share:.1%}"
+        )
+        ax.text(
+            0.02,
+            0.98,
+            stats_text,
+            transform=ax.transAxes,
+            va="top",
+            ha="left",
+            fontsize=9,
+            family="monospace",
+            bbox={
+                "boxstyle": "round,pad=0.3",
+                "facecolor": "white",
+                "alpha": 0.85,
+                "edgecolor": "gray",
+            },
+        )
+
+    fig.tight_layout()
+    fig.savefig(path, dpi=150)
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# Column-cap audit (summary_tables only, all years)
+# ---------------------------------------------------------------------------
+
+
+def column_cap_audit(years: list[int]) -> pd.DataFrame:
+    """For each (year, kind) of ``summary_tables``, list every column whose
+    sum is at the 0.98 cap or close to it.
+
+    The cap fires inside ``scale_cornerstone_A`` whenever the post-scaling
+    column sum exceeds 1; the column is then rescaled to exactly 0.98. So
+    "cap fired" ⇔ column sum within ``CAP_TOL`` of 0.98 after scaling.
+    Columns just below the cap (sum > 0.97) are also reported so reviewers
+    can see how close the cap was to engaging.
+    """
+    rows: list[dict[str, object]] = []
+    for year in years:
+        pair = _load_pair("summary_tables", year)
+        for kind in KINDS:
+            col_sum = pair[kind].sum(axis=0)
+            for col, val in col_sum.items():
+                cap_fired = abs(val - COLUMN_CAP) <= CAP_TOL
+                if cap_fired or float(val) > NEAR_CAP_THRESHOLD:
+                    rows.append(
+                        {
+                            "year": year,
+                            "dom_or_imp": kind,
+                            "col_sector": col,
+                            "col_sum": float(val),
+                            "cap_fired": bool(cap_fired),
+                        }
+                    )
+    df = pd.DataFrame(rows)
+    if not df.empty:
+        df = df.sort_values(
+            ["year", "dom_or_imp", "cap_fired", "col_sum"],
+            ascending=[True, True, False, False],
+        ).reset_index(drop=True)
+    return df
+
+
+# ---------------------------------------------------------------------------
+# Sheet publish
+# ---------------------------------------------------------------------------
+
+
+def _publish_step3_tabs(cap_audit_df: pd.DataFrame) -> None:
+    """Append Step 3 summary tab to the run-report Sheet, if available."""
+    if not LAST_RUN_SHEET_ID_PATH.exists():
+        logger.warning(
+            "No %s found — skipping Sheet publish. Run derive_A_time_series "
+            "first (with valid Drive auth) to create the run report.",
+            LAST_RUN_SHEET_ID_PATH,
+        )
+        return
+    sheet_id = LAST_RUN_SHEET_ID_PATH.read_text().strip()
+    try:
+        update_sheet_tab(sheet_id, "step3_column_cap_audit", cap_audit_df)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "Sheet publish skipped (%s: %s). Local artifacts still complete.",
+            type(e).__name__,
+            e,
+        )
+        return
+    logger.info("Updated Step 3 tab on sheet %s", sheet_id)
+
+
+def main() -> None:
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    PLOTS_DIR.mkdir(parents=True, exist_ok=True)
+
+    logger.info("Loading matrices for %d", TARGET_YEAR)
+    matrices = _load_all_at_year(TARGET_YEAR)
+
+    for kind in KINDS:
+        plot_pairwise_hexbins(
+            matrices, kind, PLOTS_DIR / f"step3_pairwise_hexbins_{kind}.png"
+        )
+
+    # Cap audit spans all available summary_tables years to give a full picture
+    # of how often the 0.98 cap engages, not just at the focus year.
+    audit_years = sorted(
+        int(p.stem.rsplit("_", 1)[-1])
+        for p in RESULTS_DIR.glob("A_summary_tables_*.parquet")
+    )
+    cap_audit_df = column_cap_audit(audit_years)
+    cap_audit_df.to_csv(RESULTS_DIR / "step3_column_cap_audit.csv", index=False)
+
+    _publish_step3_tabs(cap_audit_df)
+    logger.info("Step 3 outputs written to %s and %s", RESULTS_DIR, PLOTS_DIR)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/bedrock/analysis/a_matrix_time_series/derive_A_cells_stability.py
+++ b/bedrock/analysis/a_matrix_time_series/derive_A_cells_stability.py
@@ -280,8 +280,13 @@ def _draw_jaccard_panel(
                 continue
             color = "white" if val < (HEATMAP_VMIN + HEATMAP_VMAX) / 2 else "black"
             ax.text(
-                bi, ai, f"{val:.2f}",
-                ha="center", va="center", fontsize=7, color=color,
+                bi,
+                ai,
+                f"{val:.2f}",
+                ha="center",
+                va="center",
+                fontsize=7,
+                color=color,
             )
 
     off_diag_mask = ~np.eye(n, dtype=bool)
@@ -347,9 +352,7 @@ def _draw_baseline_grouped_persistence(
             (panel_sub["approach"] == approach)
             & (panel_sub["baseline"] == baseline_col)
         ]
-        n_ever_per_bar.append(
-            int(row["n_ever_above"].iloc[0]) if len(row) > 0 else 0
-        )
+        n_ever_per_bar.append(int(row["n_ever_above"].iloc[0]) if len(row) > 0 else 0)
 
     # Min segment height (as fraction of full bar) to qualify for an in-bar
     # n_cells label. Below this, a label would visually collide with neighbors.
@@ -389,15 +392,20 @@ def _draw_baseline_grouped_persistence(
         r, g, b = seg_color[0], seg_color[1], seg_color[2]
         luminance = 0.299 * r + 0.587 * g + 0.114 * b
         text_color = "white" if luminance < 0.55 else "black"
-        for ti, (h, n_cells) in enumerate(zip(heights_arr, n_cells_per_bar, strict=True)):
+        for ti, (h, n_cells) in enumerate(
+            zip(heights_arr, n_cells_per_bar, strict=True)
+        ):
             if h < min_label_height or n_cells == 0:
                 continue
             center_y = bottom[ti] + h / 2.0
             ax.text(
-                x_positions[ti], center_y,
+                x_positions[ti],
+                center_y,
                 f"{n_cells}",
-                ha="center", va="center",
-                fontsize=8, color=text_color,
+                ha="center",
+                va="center",
+                fontsize=8,
+                color=text_color,
             )
         bottom = bottom + heights_arr
 
@@ -417,9 +425,13 @@ def _draw_baseline_grouped_persistence(
     # because few cells disagree at all" vs "many cells, none consistent".
     for ti, n_ever in enumerate(n_ever_per_bar):
         ax.text(
-            x_positions[ti], 1.02,
+            x_positions[ti],
+            1.02,
             f"n={n_ever}",
-            ha="center", va="bottom", fontsize=11, color="dimgray",
+            ha="center",
+            va="bottom",
+            fontsize=11,
+            color="dimgray",
             transform=ax.get_xaxis_transform(),
         )
 
@@ -430,7 +442,8 @@ def _draw_baseline_grouped_persistence(
     labels = labels[::-1]
     if show_legend:
         ax.legend(
-            handles, labels,
+            handles,
+            labels,
             title="years above threshold",
             loc="center left",
             bbox_to_anchor=(1.02, 0.5),
@@ -449,8 +462,7 @@ def plot_set_stability_heatmap(
 ) -> None:
     """3×2 grid of improved year×year Jaccard heatmaps (approach × baseline)."""
     sub: pd.DataFrame = stability_df.loc[
-        (stability_df["dom_or_imp"] == kind)
-        & (stability_df["threshold"] == threshold)
+        (stability_df["dom_or_imp"] == kind) & (stability_df["threshold"] == threshold)
     ]
     n_rows = len(APPROACHES_FOR_STABILITY)
     n_cols = len(BASELINES)
@@ -492,7 +504,8 @@ def plot_persistence_by_threshold(
     n_cols = 2
     n_rows = (n_thr + 1 + n_cols - 1) // n_cols  # +1 reserves a slot for the legend
     fig, axes = plt.subplots(
-        n_rows, n_cols,
+        n_rows,
+        n_cols,
         figsize=(8.5 * n_cols, 5.5 * n_rows),
         squeeze=False,
     )
@@ -513,7 +526,10 @@ def plot_persistence_by_threshold(
             & (persistence_df["n_years_above"] > 0)
         ]
         handles, labels = _draw_baseline_grouped_persistence(
-            panel, ax, threshold=threshold, show_legend=False,
+            panel,
+            ax,
+            threshold=threshold,
+            show_legend=False,
         )
         if handles and not legend_handles:
             legend_handles, legend_labels = handles, labels
@@ -526,9 +542,11 @@ def plot_persistence_by_threshold(
         ax.axis("off")
         if not legend_placed and legend_handles:
             ax.legend(
-                legend_handles, legend_labels,
+                legend_handles,
+                legend_labels,
                 title="years above threshold",
-                loc="center", fontsize=11,
+                loc="center",
+                fontsize=11,
             )
             legend_placed = True
 
@@ -560,7 +578,8 @@ def _publish_stability_tabs(
     except Exception as e:  # noqa: BLE001
         logger.warning(
             "Sheet publish skipped (%s: %s). Local artifacts still complete.",
-            type(e).__name__, e,
+            type(e).__name__,
+            e,
         )
         return
     logger.info("Updated stability tabs on sheet %s", sheet_id)
@@ -590,20 +609,18 @@ def main() -> None:
                     stab,
                     kind,
                     threshold,
-                    PLOTS_DIR
-                    / f"set_stability_jaccard_thr{threshold:g}_{kind}.png",
+                    PLOTS_DIR / f"set_stability_jaccard_thr{threshold:g}_{kind}.png",
                 )
 
     stability_df = pd.concat(stability_chunks, ignore_index=True)
     persistence_df = pd.concat(persistence_chunks, ignore_index=True)
     stability_df.to_csv(RESULTS_DIR / "set_stability_jaccard.csv", index=False)
-    persistence_df.to_csv(
-        RESULTS_DIR / "persistence_categories.csv", index=False
-    )
+    persistence_df.to_csv(RESULTS_DIR / "persistence_categories.csv", index=False)
 
     for kind in ("dom", "imp"):
         plot_persistence_by_threshold(
-            persistence_df, kind,
+            persistence_df,
+            kind,
             PLOTS_DIR / f"persistence_by_threshold_{kind}.png",
         )
 

--- a/bedrock/analysis/a_matrix_time_series/derive_A_cells_stability.py
+++ b/bedrock/analysis/a_matrix_time_series/derive_A_cells_stability.py
@@ -1,0 +1,616 @@
+"""Step 2.5 of epic #337: cell-level set stability and persistence diagnostics.
+
+Reads ``A_cells_long.parquet`` from Step 2 and unpacks what the share-of-cells
+line chart in Step 2 aggregates away. Two questions:
+
+- **Set stability**: are the cells above a divergence threshold the *same*
+  cells year-over-year (structural offset), or is membership rotating
+  (transient drift averaging to a constant share)?
+- **Persistence**: of the cells that *ever* disagree, how is the disagreement
+  distributed across "always" vs "occasional" — i.e. what fraction of the
+  ever-above-threshold population is consistently above every year?
+
+Outputs:
+
+- ``set_stability_jaccard_thr{thr}_{kind}.png`` — 3×2 grid of year×year
+  Jaccard heatmaps (approach × baseline). Upper-triangle only with
+  ``vmin=0.5`` so the meaningful range fills the colorbar; each panel
+  carries an off-diagonal-mean tag. High off-diagonal mean ⇒ structural
+  offset; low ⇒ rotating membership.
+- ``persistence_by_threshold_{kind}.png`` — multi-threshold conditional
+  persistence composite. One panel per threshold in ``PLOT_THRESHOLDS``
+  (strictest → loosest) plus a shared legend. Bars are baseline-grouped
+  (left 3 = vs USEEIO, gap, right 3 = vs CEDA-US) and stacked by
+  years-above-threshold buckets. Denominator is **cells ever above
+  threshold** so the always-above fraction is directly legible.
+  Structural offsets keep their always-share roughly constant as the
+  threshold tightens; rotating membership doesn't.
+- ``set_stability_jaccard.csv``, ``persistence_categories.csv`` — long-format
+  CSVs covering ``ALL_THRESHOLDS``. ``persistence_categories.csv`` carries
+  both the absolute ``share`` (denominator = all cells) and
+  ``conditional_share`` (denominator = ever-above-threshold cells).
+- ``set_stability_jaccard``, ``persistence_categories`` tabs appended to
+  the run-report Sheet (sheet ID from ``last_run_sheet_id.txt``).
+
+Usage:
+    python -m bedrock.analysis.a_matrix_time_series.derive_A_cells_stability
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from matplotlib.axes import Axes
+from matplotlib.ticker import PercentFormatter
+
+from bedrock.utils.io.gcp import update_sheet_tab
+
+logger = logging.getLogger(__name__)
+
+OUTPUT_DIR = Path(__file__).parent / "output"
+RESULTS_DIR = OUTPUT_DIR / "results"
+PLOTS_DIR = OUTPUT_DIR / "plots"
+LAST_RUN_SHEET_ID_PATH = RESULTS_DIR / "last_run_sheet_id.txt"
+A_CELLS_LONG_PATH = RESULTS_DIR / "A_cells_long.parquet"
+
+# Approaches we plot (rows). Excludes baselines (useeio, ceda_default) which
+# trivially have zero divergence against themselves.
+APPROACHES_FOR_STABILITY: tuple[str, ...] = (
+    "commodity_price_index",
+    "industry_price_index",
+    "summary_tables",
+)
+# (approach_name_in_long, display_label, delta_column_in_long)
+BASELINES: tuple[tuple[str, str, str], ...] = (
+    ("useeio", "USEEIO", "delta_vs_useeio"),
+    ("ceda_default", "CEDA-US", "delta_vs_ceda"),
+)
+
+# CSV/Sheet thresholds — superset of Step 2 (extended up to 1e-1 so the
+# economically-meaningful upper range is available downstream).
+ALL_THRESHOLDS: tuple[float, ...] = (1e-6, 1e-5, 1e-4, 1e-3, 1e-2, 1e-1)
+# Subset rendered as plots — heatmaps (one PNG per threshold) and the
+# persistence-by-threshold composite (one panel per threshold). Strictest
+# first; tighter thresholds (1e-4 and below) are dominated by rounding-noise
+# cells and obscure the signal.
+PLOT_THRESHOLDS: tuple[float, ...] = (1e-1, 1e-2, 1e-3)
+
+# Color stops in the heatmap — meaningful range is ~0.5..1.0; clamp lower so
+# the gradient resolves the high end (where most values live) instead of being
+# wasted on the empty 0..0.5 region.
+HEATMAP_VMIN: float = 0.5
+HEATMAP_VMAX: float = 1.0
+
+
+# ---------------------------------------------------------------------------
+# Core computations
+# ---------------------------------------------------------------------------
+
+
+def _wide_above_threshold(
+    long: pd.DataFrame,
+    approach: str,
+    kind: str,
+    delta_col: str,
+    threshold: float,
+) -> pd.DataFrame:
+    """``(cell × year)`` boolean DataFrame: True where ``|delta_col| > threshold``.
+
+    Drops cells with NaN in any year so the per-year sets are over an aligned
+    cell population — same filter as ``plot_divergence_share`` in Step 2.
+    """
+    sub = long[(long["approach"] == approach) & (long["dom_or_imp"] == kind)]
+    pivot = pd.DataFrame(
+        sub.pivot_table(
+            index=["row_sector", "col_sector"],
+            columns="year",
+            values=delta_col,
+        ).abs()
+    )
+    nan_per_row = np.asarray(pivot.isna().any(axis=1))
+    return pd.DataFrame(pivot.loc[~nan_per_row] > threshold)
+
+
+def compute_set_stability(
+    long: pd.DataFrame, kind: str, threshold: float
+) -> pd.DataFrame:
+    """Year×year Jaccard of "above-threshold" cell sets, per (approach, baseline).
+
+    Long-format rows keyed by (approach, baseline, dom_or_imp, threshold,
+    year_a, year_b) with set sizes and the Jaccard ratio.
+    """
+    rows: list[dict[str, object]] = []
+    for approach in APPROACHES_FOR_STABILITY:
+        for baseline_col, _, delta_col in BASELINES:
+            wide = _wide_above_threshold(long, approach, kind, delta_col, threshold)
+            if wide.empty:
+                continue
+            years = sorted(wide.columns)
+            arr = wide[years].to_numpy()  # (n_cells, n_years)
+            for ai, year_a in enumerate(years):
+                set_a = arr[:, ai]
+                n_a = int(set_a.sum())
+                for bi, year_b in enumerate(years):
+                    set_b = arr[:, bi]
+                    n_b = int(set_b.sum())
+                    intersection = int((set_a & set_b).sum())
+                    union = int((set_a | set_b).sum())
+                    jac = intersection / union if union > 0 else float("nan")
+                    rows.append(
+                        {
+                            "approach": approach,
+                            "baseline": baseline_col,
+                            "dom_or_imp": kind,
+                            "threshold": threshold,
+                            "year_a": int(year_a),
+                            "year_b": int(year_b),
+                            "n_a": n_a,
+                            "n_b": n_b,
+                            "n_intersection": intersection,
+                            "n_union": union,
+                            "jaccard": jac,
+                        }
+                    )
+    return pd.DataFrame(rows)
+
+
+def compute_persistence_categories(
+    long: pd.DataFrame, kind: str, threshold: float
+) -> pd.DataFrame:
+    """Histogram of per-cell "years above threshold" + conditional share.
+
+    Returns long-format rows per (approach, baseline, dom_or_imp, threshold,
+    n_years_above) with:
+      - ``n_cells``: number of cells with exactly ``n_years_above`` years above.
+      - ``share``: ``n_cells / total cells`` (denominator = aligned cell pop).
+      - ``conditional_share``: ``n_cells / cells_ever_above`` (denom excludes
+        the ``n_years_above == 0`` bucket). NaN for the ``0`` bucket and when
+        no cell is ever above threshold.
+      - ``n_ever_above``: count of cells with ``n_years_above >= 1``.
+    """
+    rows: list[dict[str, object]] = []
+    for approach in APPROACHES_FOR_STABILITY:
+        for baseline_col, _, delta_col in BASELINES:
+            wide = _wide_above_threshold(long, approach, kind, delta_col, threshold)
+            if wide.empty:
+                continue
+            persistence = wide.sum(axis=1).to_numpy().astype(int)
+            total = persistence.size
+            n_years = wide.shape[1]
+            counts = np.bincount(persistence, minlength=n_years + 1)
+            n_ever_above = int(total - counts[0])
+            for n_years_above, n_cells in enumerate(counts):
+                if n_years_above == 0:
+                    cond_share = float("nan")
+                elif n_ever_above > 0:
+                    cond_share = float(n_cells) / n_ever_above
+                else:
+                    cond_share = float("nan")
+                rows.append(
+                    {
+                        "approach": approach,
+                        "baseline": baseline_col,
+                        "dom_or_imp": kind,
+                        "threshold": threshold,
+                        "n_years_above": int(n_years_above),
+                        "n_cells": int(n_cells),
+                        "share": (
+                            float(n_cells) / total if total > 0 else float("nan")
+                        ),
+                        "conditional_share": cond_share,
+                        "n_ever_above": n_ever_above,
+                    }
+                )
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# Panel-level plotters (each draws into a provided Axes)
+# ---------------------------------------------------------------------------
+
+
+def _bucket_label(n_years_above: int, max_bucket: int) -> str:
+    if n_years_above == 0:
+        return "0 (never)"
+    if n_years_above == max_bucket:
+        return f"{n_years_above} (always)"
+    if n_years_above == 1:
+        return "1 year"
+    return f"{n_years_above} years"
+
+
+def _draw_jaccard_panel(
+    panel_df: pd.DataFrame,
+    ax: Axes,
+    *,
+    title: str,
+    show_yticklabels: bool = True,
+) -> None:
+    """Improved Jaccard heatmap panel: upper triangle only, ``vmin=0.5``,
+    annotate off-diagonal cells only, off-diagonal mean tag below the panel.
+
+    Lower triangle is masked because the matrix is symmetric (J(a,b)=J(b,a)).
+    Diagonal is suppressed because it is trivially 1 and adds no information.
+    """
+    if len(panel_df) == 0:
+        ax.text(0.5, 0.5, "no data", transform=ax.transAxes, ha="center", va="center")
+        ax.set_xticks([])
+        ax.set_yticks([])
+        ax.set_title(title, fontsize=10)
+        return
+
+    heat = (
+        panel_df.pivot(index="year_a", columns="year_b", values="jaccard")
+        .sort_index()
+        .sort_index(axis=1)
+    )
+    years = list(heat.columns)
+    heat_arr = heat.to_numpy(dtype=float)
+    n = len(years)
+
+    display = heat_arr.copy()
+    lower_mask = np.tri(n, k=-1, dtype=bool)
+    display[lower_mask] = np.nan
+
+    im = ax.imshow(
+        display,
+        vmin=HEATMAP_VMIN,
+        vmax=HEATMAP_VMAX,
+        cmap="viridis",
+        origin="lower",
+        aspect="equal",
+    )
+    ax.set_xticks(range(n))
+    ax.set_yticks(range(n))
+    ax.set_xticklabels([str(y) for y in years], fontsize=8, rotation=45)
+    if show_yticklabels:
+        ax.set_yticklabels([str(y) for y in years], fontsize=8)
+    else:
+        ax.set_yticklabels([])
+
+    for ai in range(n):
+        for bi in range(ai + 1, n):
+            val = float(heat_arr[ai, bi])
+            if np.isnan(val):
+                continue
+            color = "white" if val < (HEATMAP_VMIN + HEATMAP_VMAX) / 2 else "black"
+            ax.text(
+                bi, ai, f"{val:.2f}",
+                ha="center", va="center", fontsize=7, color=color,
+            )
+
+    off_diag_mask = ~np.eye(n, dtype=bool)
+    off_vals = heat_arr[off_diag_mask]
+    off_vals = off_vals[~np.isnan(off_vals)]
+    mean = float(off_vals.mean()) if len(off_vals) > 0 else float("nan")
+    ax.set_title(title, fontsize=10)
+    ax.set_xlabel(f"off-diag mean = {mean:.2f}", fontsize=9)
+
+    plt.colorbar(im, ax=ax, fraction=0.046, pad=0.04)
+
+
+def _draw_baseline_grouped_persistence(
+    panel_sub: pd.DataFrame,
+    ax: Axes,
+    *,
+    threshold: float,
+    show_legend: bool = True,
+    show_title: bool = True,
+) -> tuple[list[Any], list[Any]]:
+    """Stacked persistence bars grouped by baseline.
+
+    Bar order is ``[USEEIO group, spacer, CEDA-US group]``. Within each
+    group the three approaches appear in ``APPROACHES_FOR_STABILITY`` order.
+    A faint dashed vertical separator marks the spacer. Bars stack
+    years-above-threshold buckets ``1..N_years``; legend is reordered so
+    the "always" bucket sits at the top, matching the visual stack.
+
+    Returns ``(handles, labels)`` for the legend so callers (e.g. the
+    dashboard) can build a shared figure-level legend if ``show_legend=False``.
+    """
+    if len(panel_sub) == 0:
+        ax.text(0.5, 0.5, "no data", transform=ax.transAxes, ha="center", va="center")
+        if show_title:
+            ax.set_title(f"|Δ| > {threshold:g}", fontsize=10)
+        return [], []
+
+    # Bar order: group by baseline (outer), approach (inner).
+    bars: list[tuple[str, str, str]] = []
+    for baseline_col, baseline_label, _ in BASELINES:
+        for approach in APPROACHES_FOR_STABILITY:
+            bars.append((approach, baseline_col, baseline_label))
+    bar_labels = [f"{a}\nvs {bl}" for a, _, bl in bars]
+
+    n_per_group = len(APPROACHES_FOR_STABILITY)
+    # Position 3 (between groups) is empty — creates the visual spacer.
+    x_positions = np.concatenate(
+        [
+            np.arange(n_per_group, dtype=float),
+            np.arange(n_per_group, dtype=float) + n_per_group + 1.0,
+        ]
+    )
+
+    max_bucket = int(panel_sub["n_years_above"].max())
+    cmap = plt.get_cmap("viridis")
+    bucket_colors = [
+        cmap((k - 1) / max(max_bucket - 1, 1)) for k in range(1, max_bucket + 1)
+    ]
+
+    n_ever_per_bar: list[int] = []
+    for approach, baseline_col, _ in bars:
+        row = panel_sub.loc[
+            (panel_sub["approach"] == approach)
+            & (panel_sub["baseline"] == baseline_col)
+        ]
+        n_ever_per_bar.append(
+            int(row["n_ever_above"].iloc[0]) if len(row) > 0 else 0
+        )
+
+    # Min segment height (as fraction of full bar) to qualify for an in-bar
+    # n_cells label. Below this, a label would visually collide with neighbors.
+    min_label_height = 0.025
+
+    bottom = np.zeros(len(bars))
+    for k_idx, n_years_above in enumerate(range(1, max_bucket + 1)):
+        heights: list[float] = []
+        n_cells_per_bar: list[int] = []
+        for approach, baseline_col, _ in bars:
+            row = panel_sub.loc[
+                (panel_sub["approach"] == approach)
+                & (panel_sub["baseline"] == baseline_col)
+                & (panel_sub["n_years_above"] == n_years_above)
+            ]
+            if len(row) > 0:
+                cond = float(row["conditional_share"].iloc[0])
+                heights.append(0.0 if np.isnan(cond) else cond)
+                n_cells_per_bar.append(int(row["n_cells"].iloc[0]))
+            else:
+                heights.append(0.0)
+                n_cells_per_bar.append(0)
+        heights_arr = np.asarray(heights, dtype=float)
+        ax.bar(
+            x_positions,
+            heights_arr,
+            bottom=bottom,
+            color=bucket_colors[k_idx],
+            edgecolor="white",
+            linewidth=0.4,
+            label=_bucket_label(n_years_above, max_bucket),
+        )
+        # Annotate each segment with its n_cells. White text on dark
+        # (low-luminance) segments, black on light. Skip segments too thin to
+        # host a label.
+        seg_color = bucket_colors[k_idx]
+        r, g, b = seg_color[0], seg_color[1], seg_color[2]
+        luminance = 0.299 * r + 0.587 * g + 0.114 * b
+        text_color = "white" if luminance < 0.55 else "black"
+        for ti, (h, n_cells) in enumerate(zip(heights_arr, n_cells_per_bar, strict=True)):
+            if h < min_label_height or n_cells == 0:
+                continue
+            center_y = bottom[ti] + h / 2.0
+            ax.text(
+                x_positions[ti], center_y,
+                f"{n_cells}",
+                ha="center", va="center",
+                fontsize=8, color=text_color,
+            )
+        bottom = bottom + heights_arr
+
+    ax.set_xticks(x_positions)
+    ax.set_xticklabels(bar_labels, fontsize=8, rotation=15, ha="right")
+    ax.set_ylim(0, 1)
+    ax.yaxis.set_major_formatter(PercentFormatter(xmax=1.0, decimals=0))
+    ax.set_ylabel("conditional share")
+    if show_title:
+        ax.set_title(f"|Δ| > {threshold:g}", fontsize=10)
+    ax.grid(True, axis="y", alpha=0.3)
+
+    # Dashed separator line between the two baseline groups.
+    ax.axvline(x=n_per_group, color="lightgray", lw=0.8, linestyle="--", zorder=0)
+
+    # n_ever_above annotation above each bar — disambiguates "0% always
+    # because few cells disagree at all" vs "many cells, none consistent".
+    for ti, n_ever in enumerate(n_ever_per_bar):
+        ax.text(
+            x_positions[ti], 1.02,
+            f"n={n_ever}",
+            ha="center", va="bottom", fontsize=11, color="dimgray",
+            transform=ax.get_xaxis_transform(),
+        )
+
+    handles, labels = ax.get_legend_handles_labels()
+    # Reverse so the "always" (yellow) handle sits at the top of the legend,
+    # matching the top of the stack.
+    handles = handles[::-1]
+    labels = labels[::-1]
+    if show_legend:
+        ax.legend(
+            handles, labels,
+            title="years above threshold",
+            loc="center left",
+            bbox_to_anchor=(1.02, 0.5),
+            fontsize=8,
+        )
+    return handles, labels
+
+
+# ---------------------------------------------------------------------------
+# Top-level plot functions (write a PNG)
+# ---------------------------------------------------------------------------
+
+
+def plot_set_stability_heatmap(
+    stability_df: pd.DataFrame, kind: str, threshold: float, path: Path
+) -> None:
+    """3×2 grid of improved year×year Jaccard heatmaps (approach × baseline)."""
+    sub: pd.DataFrame = stability_df.loc[
+        (stability_df["dom_or_imp"] == kind)
+        & (stability_df["threshold"] == threshold)
+    ]
+    n_rows = len(APPROACHES_FOR_STABILITY)
+    n_cols = len(BASELINES)
+    fig, axes = plt.subplots(
+        n_rows, n_cols, figsize=(5.0 * n_cols, 4.5 * n_rows), squeeze=False
+    )
+    fig.suptitle(
+        f"Year×year Jaccard of cells with |A_approach − A_baseline| > {threshold:g} — {kind}",
+        fontsize=12,
+    )
+    for i, approach in enumerate(APPROACHES_FOR_STABILITY):
+        for j, (baseline_col, baseline_label, _) in enumerate(BASELINES):
+            panel: pd.DataFrame = sub.loc[
+                (sub["approach"] == approach) & (sub["baseline"] == baseline_col)
+            ]
+            _draw_jaccard_panel(
+                panel,
+                axes[i][j],
+                title=f"{approach} vs {baseline_label}",
+            )
+    fig.tight_layout()
+    fig.savefig(path, dpi=150)
+    plt.close(fig)
+
+
+def plot_persistence_by_threshold(
+    persistence_df: pd.DataFrame, kind: str, path: Path
+) -> None:
+    """Multi-threshold conditional-persistence composite for one ``kind``.
+
+    One panel per threshold in ``PLOT_THRESHOLDS`` (strictest → loosest)
+    plus a shared legend in the unused grid slot. Each panel uses the
+    baseline-grouped bar layout (left 3 = vs USEEIO, gap, right 3 = vs
+    CEDA-US). Reading across panels shows whether the always-share
+    survives as the threshold tightens — a structural offset stays high;
+    rotating membership doesn't.
+    """
+    n_thr = len(PLOT_THRESHOLDS)
+    n_cols = 2
+    n_rows = (n_thr + 1 + n_cols - 1) // n_cols  # +1 reserves a slot for the legend
+    fig, axes = plt.subplots(
+        n_rows, n_cols,
+        figsize=(8.5 * n_cols, 5.5 * n_rows),
+        squeeze=False,
+    )
+    fig.suptitle(
+        f"Conditional cell persistence by threshold — {kind}\n"
+        "(denominator = cells ever above threshold)",
+        fontsize=13,
+    )
+
+    legend_handles: list[Any] = []
+    legend_labels: list[Any] = []
+    for ti, threshold in enumerate(PLOT_THRESHOLDS):
+        r, c = divmod(ti, n_cols)
+        ax = axes[r][c]
+        panel = persistence_df.loc[
+            (persistence_df["dom_or_imp"] == kind)
+            & (persistence_df["threshold"] == threshold)
+            & (persistence_df["n_years_above"] > 0)
+        ]
+        handles, labels = _draw_baseline_grouped_persistence(
+            panel, ax, threshold=threshold, show_legend=False,
+        )
+        if handles and not legend_handles:
+            legend_handles, legend_labels = handles, labels
+
+    # Hide unused panels and host the shared legend in the first unused slot.
+    legend_placed = False
+    for ti in range(n_thr, n_rows * n_cols):
+        r, c = divmod(ti, n_cols)
+        ax = axes[r][c]
+        ax.axis("off")
+        if not legend_placed and legend_handles:
+            ax.legend(
+                legend_handles, legend_labels,
+                title="years above threshold",
+                loc="center", fontsize=11,
+            )
+            legend_placed = True
+
+    fig.tight_layout(rect=(0, 0, 1, 0.97))
+    fig.savefig(path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# Sheet publish + main
+# ---------------------------------------------------------------------------
+
+
+def _publish_stability_tabs(
+    stability_df: pd.DataFrame, persistence_df: pd.DataFrame
+) -> None:
+    """Append the two summary tabs to the run-report Sheet, if available."""
+    if not LAST_RUN_SHEET_ID_PATH.exists():
+        logger.warning(
+            "No %s found — skipping Sheet publish. Run derive_A_time_series "
+            "first (with valid Drive auth) to create the run report.",
+            LAST_RUN_SHEET_ID_PATH,
+        )
+        return
+    sheet_id = LAST_RUN_SHEET_ID_PATH.read_text().strip()
+    try:
+        update_sheet_tab(sheet_id, "set_stability_jaccard", stability_df)
+        update_sheet_tab(sheet_id, "persistence_categories", persistence_df)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "Sheet publish skipped (%s: %s). Local artifacts still complete.",
+            type(e).__name__, e,
+        )
+        return
+    logger.info("Updated stability tabs on sheet %s", sheet_id)
+
+
+def main() -> None:
+    PLOTS_DIR.mkdir(parents=True, exist_ok=True)
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    if not A_CELLS_LONG_PATH.exists():
+        raise FileNotFoundError(
+            f"{A_CELLS_LONG_PATH} not found. Run derive_A_cells_long first (Step 2)."
+        )
+
+    long = pd.read_parquet(A_CELLS_LONG_PATH)
+    logger.info("Loaded %s (rows=%d)", A_CELLS_LONG_PATH, len(long))
+
+    stability_chunks: list[pd.DataFrame] = []
+    persistence_chunks: list[pd.DataFrame] = []
+    for kind in ("dom", "imp"):
+        for threshold in ALL_THRESHOLDS:
+            stab = compute_set_stability(long, kind, threshold)
+            persist = compute_persistence_categories(long, kind, threshold)
+            stability_chunks.append(stab)
+            persistence_chunks.append(persist)
+            if threshold in PLOT_THRESHOLDS:
+                plot_set_stability_heatmap(
+                    stab,
+                    kind,
+                    threshold,
+                    PLOTS_DIR
+                    / f"set_stability_jaccard_thr{threshold:g}_{kind}.png",
+                )
+
+    stability_df = pd.concat(stability_chunks, ignore_index=True)
+    persistence_df = pd.concat(persistence_chunks, ignore_index=True)
+    stability_df.to_csv(RESULTS_DIR / "set_stability_jaccard.csv", index=False)
+    persistence_df.to_csv(
+        RESULTS_DIR / "persistence_categories.csv", index=False
+    )
+
+    for kind in ("dom", "imp"):
+        plot_persistence_by_threshold(
+            persistence_df, kind,
+            PLOTS_DIR / f"persistence_by_threshold_{kind}.png",
+        )
+
+    _publish_stability_tabs(stability_df, persistence_df)
+    logger.info("Step 2.5 outputs written to %s and %s", RESULTS_DIR, PLOTS_DIR)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main()


### PR DESCRIPTION
cc:
Closes: #342

## What changed? Why?

Add `bedrock/analysis/a_matrix_time_series/compare_approaches.py` producing two artifacts at `model_base_year=2024`:
- `pairwise_hexbins_{dom,imp}.png` — log-log hexbin density of the three alternative approaches against each other (alt-vs-alt, the angle Step 2 doesn't cover).
- `column_cap_audit.csv` and Sheet tab `column_cap_audit` — every column where `scale_cornerstone_A`'s 0.98 cap fired on `summary_tables`, plus near-cap columns (sum > 0.97).

The issue's planned ECDF and relative-divergence-quantile artifacts were dropped — they overlap with Step 2's existing `divergence_share_*.png` and `divergence_vs_*.csv` at 2024.

### Pairwise_hexbins plot
<img width="2250" height="750" alt="pairwise_hexbins_dom" src="https://github.com/user-attachments/assets/d0f4a36e-ae38-4792-a826-dd69f44c1d7d" />


## Testing

Ran the module locally; black/ruff/pyright pass.