### PR TITLE
Remove derive_cornerstone_E function and calls to it

### DIFF
--- a/bedrock/transform/eeio/__tests__/test_waste_disagg_pipeline_integration.py
+++ b/bedrock/transform/eeio/__tests__/test_waste_disagg_pipeline_integration.py
@@ -446,6 +446,7 @@ class TestPipelineB:
             atol=1e-6,
         ), "B non-waste columns should match between baseline and disaggregated configs"
 
+    @pytest.mark.eeio_integration
     def test_runtime_B_path_does_not_use_bea_expansion_helpers(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -470,6 +471,7 @@ class TestPipelineB:
 
         assert B.shape[1] == 405
 
+    @pytest.mark.eeio_integration
     def test_runtime_B_formula_matches_implementation(self) -> None:
         _setup_config("2025_usa_cornerstone_full_model.yaml")
         try:

--- a/bedrock/transform/eeio/__tests__/test_waste_disagg_pipeline_integration.py
+++ b/bedrock/transform/eeio/__tests__/test_waste_disagg_pipeline_integration.py
@@ -14,7 +14,11 @@ import pandas as pd
 import pytest
 
 from bedrock.extract.disaggregation.waste_weights import WasteDisaggWeights
-from bedrock.transform.eeio.cornerstone_bea_intermediates import bea_E
+from bedrock.transform.allocation.derived import derive_E_usa
+from bedrock.transform.eeio import (
+    cornerstone_bea_intermediates,
+    cornerstone_expansion,
+)
 from bedrock.transform.eeio.derived_cornerstone import (
     _WASTE_NEW_CODES,
     _derive_cornerstone_Ytot_with_trade,
@@ -22,7 +26,6 @@ from bedrock.transform.eeio.derived_cornerstone import (
     derive_cornerstone_Aq_scaled,
     derive_cornerstone_B_non_finetuned,
     derive_cornerstone_B_via_vnorm,
-    derive_cornerstone_E,
     derive_cornerstone_q,
     derive_cornerstone_U_set,
     derive_cornerstone_U_with_negatives,
@@ -30,11 +33,13 @@ from bedrock.transform.eeio.derived_cornerstone import (
     derive_cornerstone_VA,
     derive_cornerstone_Vnorm_scrap_corrected,
     derive_cornerstone_x,
+    derive_cornerstone_x_after_redefinition,
     derive_cornerstone_y_nab,
     derive_cornerstone_Ytot_matrix_set,
     get_waste_disagg_weights,
 )
 from bedrock.utils.config.usa_config import (
+    get_usa_config,
     reset_usa_config,
     set_global_usa_config,
 )
@@ -56,9 +61,7 @@ _CACHED_FUNCTIONS: list[Callable[..., object]] = [
     derive_cornerstone_Aq,
     derive_cornerstone_Aq_scaled,
     derive_cornerstone_B_non_finetuned,
-    derive_cornerstone_E,
     derive_cornerstone_y_nab,
-    bea_E,  # E is derived from allocators; clear so B uses emissions for current config
 ]
 
 
@@ -442,6 +445,57 @@ class TestPipelineB:
             disagg_B[non_waste_cols].values,
             atol=1e-6,
         ), "B non-waste columns should match between baseline and disaggregated configs"
+
+    def test_runtime_B_path_does_not_use_bea_expansion_helpers(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _setup_config("2025_usa_cornerstone_full_model.yaml")
+
+        def _raise_if_called(*args: object, **kwargs: object) -> None:
+            raise AssertionError(
+                "B runtime path should not call BEA-expansion E helpers"
+            )
+
+        monkeypatch.setattr(cornerstone_bea_intermediates, "bea_E", _raise_if_called)
+        monkeypatch.setattr(
+            cornerstone_expansion,
+            "expand_ghg_matrix_from_bea_to_cornerstone",
+            _raise_if_called,
+        )
+
+        try:
+            B = derive_cornerstone_B_via_vnorm()
+        finally:
+            _teardown()
+
+        assert B.shape[1] == 405
+
+    def test_runtime_B_formula_matches_implementation(self) -> None:
+        _setup_config("2025_usa_cornerstone_full_model.yaml")
+        try:
+            cfg = get_usa_config()
+            actual = derive_cornerstone_B_via_vnorm()
+
+            x = (
+                derive_cornerstone_x_after_redefinition()
+                if cfg.use_E_data_year_for_x_in_B
+                else derive_cornerstone_x()
+            )
+            expected = (
+                derive_E_usa().divide(x, axis=1).fillna(0.0)
+                @ derive_cornerstone_Vnorm_scrap_corrected()
+            )
+        finally:
+            _teardown()
+
+        assert list(actual.index) == list(expected.index)
+        assert list(actual.columns) == list(expected.columns)
+        np.testing.assert_allclose(
+            actual.values,
+            expected.values,
+            rtol=1e-9,
+            atol=1e-12,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/bedrock/transform/eeio/derived_cornerstone.py
+++ b/bedrock/transform/eeio/derived_cornerstone.py
@@ -1,13 +1,14 @@
 """Cornerstone IO data processing pipeline.
 
-Derives 2017 detail IO matrices (V, U, Y, A, B, E, g, q) using the
+Derives 2017 detail IO matrices (V, U, Y, A, B, g, q) using the
 Cornerstone 2026 taxonomy (405 sectors).
 
-**Core approach** — A and B are computed in the original BEA 2017 ~400-sector
+**Core approach** — A is computed in the original BEA 2017 ~400-sector
 space and then *expanded* to 405 Cornerstone sectors by duplicating
-rows/columns for disaggregated codes.  V, U, and Y are mapped via
-correspondence-matrix multiplication.  Waste subsectors receive special
-intragroup treatment to prevent Leontief-inverse inflation.
+rows/columns for disaggregated codes. V, U, and Y are mapped via
+correspondence-matrix multiplication. B is computed directly in
+Cornerstone space from runtime `derive_E_usa()`. Waste subsectors receive
+special intragroup treatment to prevent Leontief-inverse inflation.
 
 Year-scaling logic (summary → detail disaggregation) uses the cornerstone
 summary correspondence instead of the CEDA v7 version.
@@ -46,7 +47,6 @@ from bedrock.extract.iot.io_2017 import (
 from bedrock.transform.allocation.derived import derive_E_usa
 from bedrock.transform.eeio.cornerstone_bea_intermediates import (
     bea_Aq,
-    bea_E,
 )
 from bedrock.transform.eeio.cornerstone_expansion import (
     CS_COMMODITY_LIST,
@@ -54,7 +54,6 @@ from bedrock.transform.eeio.cornerstone_expansion import (
     commodity_corresp,
     cs_commodity_to_bea_map,
     cs_industry_to_bea_map,
-    expand_ghg_matrix_from_bea_to_cornerstone,
     expand_square_matrix,
     expand_vector,
     industry_corresp,
@@ -104,7 +103,6 @@ from bedrock.utils.math.split_using_aggregated_weights import (
 from bedrock.utils.schemas.cornerstone_schemas import (
     CornerstoneAMatrix,
     CornerstoneBMatrix,
-    CornerstoneEMatrix,
     CornerstoneQVectorSchema,
     CornerstoneUMatrix,
     CornerstoneVMatrix,
@@ -615,17 +613,8 @@ def derive_cornerstone_Aq_scaled() -> SingleRegionAqMatrixSet:
 
 
 # ---------------------------------------------------------------------------
-# E and B — expanded from BEA space
+# B matrix (runtime E path)
 # ---------------------------------------------------------------------------
-
-
-@functools.cache
-@pa.check_output(CornerstoneEMatrix.to_schema())
-def derive_cornerstone_E() -> pd.DataFrame:
-    """E (ghg × Cornerstone industry) — expanded from BEA space."""
-    return expand_ghg_matrix_from_bea_to_cornerstone(
-        bea_E(), CS_INDUSTRY_LIST, cs_industry_to_bea_map()
-    )
 
 
 def _normalize_E_for_waste(E: pd.DataFrame, V: pd.DataFrame) -> pd.DataFrame:


### PR DESCRIPTION
cc:
Closes:

## What changed

- Removed `derive_cornerstone_E` from `bedrock.transform.eeio.derived_cornerstone`.
- Removed/cleaned only symbols made dead by that removal (no unrelated helper removals).
- Updated tests that imported/referenced `derive_cornerstone_E`.
- Added guard coverage to ensure runtime `derive_cornerstone_B_via_vnorm()` does not use BEA-expansion helpers.
- Added deterministic numeric consistency test for runtime B formula:
    - `derive_cornerstone_B_via_vnorm()` equals reconstructed `(derive_E_usa() / x) @ Vnorm` using runtime `x` branch logic.

## Why

`derive_cornerstone_E` was not part of the production runtime B codepath. Removing it reduces dead surface area and avoids confusion about which E path is actually used in production.

## Breaking change

- Removed API: `derive_cornerstone_E` from `bedrock.transform.eeio.derived_cornerstone`.
- Replacement: use `derive_E_usa()` from `bedrock.transform.allocation.derived`.

## Validation

- Updated EEIO/waste-disagg integration tests for symbol removal.
- Guard test confirms runtime B path does not call BEA-expansion path.
- Numeric invariant test confirms runtime B output consistency.
- Ran CI-equivalent checks:
    - `uv run pytest bedrock/transform/eeio/__tests__/test_waste_disagg_pipeline_integration.py`
    - `uv run pytest bedrock/transform/__tests__/test_usa.py -m eeio_integration`
    - `uv run ruff check .`
    - `uv run mypy bedrock`
    - (optional) `uv run black --check .`