### PR TITLE
fix(eeio): correct V inflation axis and wire commodity-PI flow correctly

### DIFF
--- a/bedrock/transform/eeio/derived_2017.py
+++ b/bedrock/transform/eeio/derived_2017.py
@@ -34,7 +34,6 @@ from bedrock.transform.eeio.derived_2017_helpers import (
     derive_2017_V_weight,
     derive_2017_Y_weight,
 )
-from bedrock.utils.economic.inflation_helpers_ceda import inflate_usa_V_to_target_year
 from bedrock.utils.math.formulas import (
     compute_A_matrix,
     compute_q,
@@ -178,16 +177,8 @@ def derive_q_from_U_usa_and_Ytot_usa() -> pd.Series[float]:
 
 @functools.cache
 @pa.check_output(VMatrix.to_schema())
-def derive_2017_Vnorm_scrap_corrected(
-    apply_inflation: bool = False, target_year: int = 0
-) -> pt.DataFrame[VMatrix]:
+def derive_2017_Vnorm_scrap_corrected() -> pt.DataFrame[VMatrix]:
     V_usa = derive_2017_V_usa()
-
-    if apply_inflation:
-        V_usa = inflate_usa_V_to_target_year(
-            V=V_usa, original_year=2017, target_year=target_year
-        )
-
     q = compute_q(V=V_usa)
     Vnorm = compute_Vnorm_matrix(V=V_usa, q=q)
 

--- a/bedrock/transform/eeio/derived_cornerstone.py
+++ b/bedrock/transform/eeio/derived_cornerstone.py
@@ -282,8 +282,10 @@ def derive_cornerstone_q() -> pd.Series[float]:
 @functools.cache
 @pa.check_output(CornerstoneVMatrix.to_schema())
 def derive_cornerstone_Vnorm_scrap_corrected(
-    apply_inflation: bool = False, target_year: int = 0
+    apply_inflation: bool = False,
 ) -> pd.DataFrame:
+    cfg = get_usa_config()
+
     V = derive_cornerstone_V()
 
     if apply_inflation:
@@ -291,9 +293,16 @@ def derive_cornerstone_Vnorm_scrap_corrected(
             get_cornerstone_industry_price_ratio,
         )
 
-        price_ratio = get_cornerstone_industry_price_ratio(2017, target_year)
+        # Adjust V by applying industry price ratio
+        price_ratio = get_cornerstone_industry_price_ratio(
+            cfg.usa_base_io_data_year,  # 2017 by default
+            cfg.model_base_year,
+        )
         V = pd.DataFrame(
-            V.multiply(price_ratio, axis=1).values,
+            V.multiply(
+                price_ratio,
+                axis=0,  # axis=0 means aligning on rows (i.e. industries)
+            ).values,
             index=V.index,
             columns=V.columns,
         )

--- a/bedrock/transform/iot/derived_price_index.py
+++ b/bedrock/transform/iot/derived_price_index.py
@@ -53,9 +53,6 @@ DISAGGREGATED_CODES = [
     "562920",  # Material separation/recovery facilities
     "562OTH",  # Other waste collection and treatment services
 ]
-INFLATION_SECTORS = [
-    c for c in BEA_2017_INDUSTRY_CODES + DISAGGREGATED_CODES + ["333914", "335220"]
-]
 
 
 def derive_industry_price_index() -> pd.DataFrame:

--- a/bedrock/utils/economic/__tests__/test_inflation_helpers_cornerstone.py
+++ b/bedrock/utils/economic/__tests__/test_inflation_helpers_cornerstone.py
@@ -1,3 +1,6 @@
+from bedrock.transform.eeio.derived_cornerstone import (
+    derive_cornerstone_Vnorm_scrap_corrected,
+)
 from bedrock.utils.economic.inflation_helpers_cornerstone import (
     get_vnorm_adjusted_commodity_price_ratio,
 )
@@ -18,3 +21,40 @@ def test_vnorm_commodity_price_ratio_is_identity_at_year_to_self() -> None:
     assert (
         max_abs_dev < 1e-12
     ), f"Expected ratio == 1.0 at year=year, got max abs deviation {max_abs_dev:.2e}"
+
+
+def test_v_inflation_uses_industry_row_axis() -> None:
+    """Regression guard: V inflation in
+    ``derive_cornerstone_Vnorm_scrap_corrected(apply_inflation=True)`` must
+    scale industry rows of V by their own price ratio (axis=0), not commodity
+    columns (axis=1). Cornerstone industry & commodity codes overlap on
+    ~404/405 string values, so axis=1 silently aligns by name and "works"
+    while applying the wrong ratio per cell.
+
+    Discriminating property used here: the per-cell ratio
+    ``Vnorm_True / Vnorm_False`` must vary across commodity columns within
+    at least some industry rows.
+
+    - Under axis=0 (correct): per-row scaling produces a column-varying ratio
+      because each commodity has a different supplier mix
+      (pi[i] / weighted_avg_pi[c] depends on c).
+    - Under axis=1 (incorrect): uniform per-column scaling cancels in
+      column-normalization, leaving V-norm itself unchanged. The True/False
+      ratio reduces to a row-wise scrap-correction factor — *constant* across
+      commodity columns within each row → row std = 0.
+    """
+    Vnorm_True = derive_cornerstone_Vnorm_scrap_corrected(apply_inflation=True)
+    Vnorm_False = derive_cornerstone_Vnorm_scrap_corrected(apply_inflation=False)
+
+    both_nonzero = (Vnorm_True.abs() > 1e-12) & (Vnorm_False.abs() > 1e-12)
+    ratio = (Vnorm_True / Vnorm_False).where(both_nonzero)
+
+    row_stds = ratio.std(axis=1, ddof=0).dropna()
+    max_row_std = float(row_stds.max())
+
+    assert max_row_std > 1e-3, (
+        f"Vnorm True/False ratio appears row-uniform across commodity columns "
+        f"(max row std {max_row_std:.2e}). Under correct axis=0, per-industry "
+        f"scaling yields column-varying ratios; under axis=1, uniform column "
+        f"scaling cancels in normalization, yielding row-constant ratios."
+    )

--- a/bedrock/utils/economic/inflation_helpers_ceda.py
+++ b/bedrock/utils/economic/inflation_helpers_ceda.py
@@ -5,13 +5,10 @@ import os
 
 import numpy as np
 import pandas as pd
-import pandera.pandas as pa
-import pandera.typing as pt
 
 from bedrock.utils.io.gcp import download_gcs_file_if_not_exists
 from bedrock.utils.io.gcp_paths import gcs_extract_input_path
 from bedrock.utils.io.local_extract_input_data import local_extract_input_dir
-from bedrock.utils.schemas.single_region_schemas import VMatrix
 from bedrock.utils.taxonomy.bea.ceda_v5 import CEDA_V5_SECTORS
 from bedrock.utils.taxonomy.mappings.ceda_v7__ceda_v5 import CEDA_V5_TO_CEDA_V7_CODES
 
@@ -55,41 +52,6 @@ def obtain_inflation_factors_from_reference_data() -> pd.DataFrame:
 get_price_index = functools.cache(
     lambda: obtain_inflation_factors_from_reference_data()
 )
-
-
-def inflate_usa_U_to_target_year(
-    U: pd.DataFrame,
-    original_year: int,
-    target_year: int,
-) -> pd.DataFrame:
-    assert U.shape == (400, 400)
-    if "33391A" in U.index:
-        U = U.rename(index=CEDA_V5_TO_CEDA_V7_CODES, columns=CEDA_V5_TO_CEDA_V7_CODES)
-
-    price_index = get_price_index()
-    price_ratio_base_to_target = price_index[target_year] / price_index[original_year]
-
-    return U.multiply(price_ratio_base_to_target, axis=0)
-
-
-@pa.check_output(VMatrix.to_schema())
-def inflate_usa_V_to_target_year(
-    V: pt.DataFrame[VMatrix],
-    original_year: int,
-    target_year: int,
-) -> pt.DataFrame[VMatrix]:
-    assert V.shape == (400, 400)
-
-    price_index = get_price_index()
-    price_ratio_base_to_target = price_index[target_year] / price_index[original_year]
-
-    # TODO: Must confirm this.
-    # V is industry x commodity. Should we inflate how much of
-    # each commodity the industry makes? Or inflate the relative
-    # value of the industry?
-    # My initial guess was opposite of U since the dimension
-    # is opposite..
-    return pt.DataFrame[VMatrix](V.multiply(price_ratio_base_to_target, axis=1))
 
 
 def inflate_A_matrix(

--- a/bedrock/utils/economic/inflation_helpers_cornerstone.py
+++ b/bedrock/utils/economic/inflation_helpers_cornerstone.py
@@ -115,7 +115,7 @@ def get_vnorm_adjusted_commodity_price_ratio(
     )
 
     industry_ratio = get_cornerstone_industry_price_ratio(original_year, target_year)
-    Vnorm = derive_cornerstone_Vnorm_scrap_corrected()
+    Vnorm = derive_cornerstone_Vnorm_scrap_corrected(apply_inflation=True)
     aligned = industry_ratio.reindex(Vnorm.index, fill_value=1.0)
 
     # Normalize V_norm columns to sum to 1 so the dot-product is a true weighted


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?
- `derive_cornerstone_Vnorm_scrap_corrected(apply_inflation=True)` now scales V's industry rows on `axis=0` instead of `axis=1`.
- Bug introduced when `get_cornerstone_price_ratio` (commodity-indexed) was renamed to `get_cornerstone_industry_price_ratio` (industry-indexed) without flipping the axis at the call site.
- Also wires `apply_inflation=True` into the commodity-PI flow so V_norm reflects target-year prices, and replaces a hardcoded `2017` / caller-supplied `target_year` with `cfg.usa_base_io_data_year` and `cfg.model_base_year`. This only affects only `scale_a_matrix_with_commodity_price_index=True`.

## Testing

New regression test `test_v_inflation_uses_industry_row_axis` asserts the axis property; flipping back to `axis=1` triggers a hard `ValueError: Shape of passed values is (405, 406)`.