### PR TITLE
Drop dead inflation/price-index helpers and parameters

### DIFF
--- a/bedrock/transform/eeio/derived_2017.py
+++ b/bedrock/transform/eeio/derived_2017.py
@@ -34,7 +34,6 @@ from bedrock.transform.eeio.derived_2017_helpers import (
     derive_2017_V_weight,
     derive_2017_Y_weight,
 )
-from bedrock.utils.economic.inflation_helpers_ceda import inflate_usa_V_to_target_year
 from bedrock.utils.math.formulas import (
     compute_A_matrix,
     compute_q,
@@ -178,16 +177,8 @@ def derive_q_from_U_usa_and_Ytot_usa() -> pd.Series[float]:
 
 @functools.cache
 @pa.check_output(VMatrix.to_schema())
-def derive_2017_Vnorm_scrap_corrected(
-    apply_inflation: bool = False, target_year: int = 0
-) -> pt.DataFrame[VMatrix]:
+def derive_2017_Vnorm_scrap_corrected() -> pt.DataFrame[VMatrix]:
     V_usa = derive_2017_V_usa()
-
-    if apply_inflation:
-        V_usa = inflate_usa_V_to_target_year(
-            V=V_usa, original_year=2017, target_year=target_year
-        )
-
     q = compute_q(V=V_usa)
     Vnorm = compute_Vnorm_matrix(V=V_usa, q=q)
 

--- a/bedrock/transform/iot/derived_price_index.py
+++ b/bedrock/transform/iot/derived_price_index.py
@@ -53,9 +53,6 @@ DISAGGREGATED_CODES = [
     "562920",  # Material separation/recovery facilities
     "562OTH",  # Other waste collection and treatment services
 ]
-INFLATION_SECTORS = [
-    c for c in BEA_2017_INDUSTRY_CODES + DISAGGREGATED_CODES + ["333914", "335220"]
-]
 
 
 def derive_industry_price_index() -> pd.DataFrame:

--- a/bedrock/utils/economic/inflation_helpers_ceda.py
+++ b/bedrock/utils/economic/inflation_helpers_ceda.py
@@ -5,13 +5,10 @@ import os
 
 import numpy as np
 import pandas as pd
-import pandera.pandas as pa
-import pandera.typing as pt
 
 from bedrock.utils.io.gcp import download_gcs_file_if_not_exists
 from bedrock.utils.io.gcp_paths import gcs_extract_input_path
 from bedrock.utils.io.local_extract_input_data import local_extract_input_dir
-from bedrock.utils.schemas.single_region_schemas import VMatrix
 from bedrock.utils.taxonomy.bea.ceda_v5 import CEDA_V5_SECTORS
 from bedrock.utils.taxonomy.mappings.ceda_v7__ceda_v5 import CEDA_V5_TO_CEDA_V7_CODES
 
@@ -55,41 +52,6 @@ def obtain_inflation_factors_from_reference_data() -> pd.DataFrame:
 get_price_index = functools.cache(
     lambda: obtain_inflation_factors_from_reference_data()
 )
-
-
-def inflate_usa_U_to_target_year(
-    U: pd.DataFrame,
-    original_year: int,
-    target_year: int,
-) -> pd.DataFrame:
-    assert U.shape == (400, 400)
-    if "33391A" in U.index:
-        U = U.rename(index=CEDA_V5_TO_CEDA_V7_CODES, columns=CEDA_V5_TO_CEDA_V7_CODES)
-
-    price_index = get_price_index()
-    price_ratio_base_to_target = price_index[target_year] / price_index[original_year]
-
-    return U.multiply(price_ratio_base_to_target, axis=0)
-
-
-@pa.check_output(VMatrix.to_schema())
-def inflate_usa_V_to_target_year(
-    V: pt.DataFrame[VMatrix],
-    original_year: int,
-    target_year: int,
-) -> pt.DataFrame[VMatrix]:
-    assert V.shape == (400, 400)
-
-    price_index = get_price_index()
-    price_ratio_base_to_target = price_index[target_year] / price_index[original_year]
-
-    # TODO: Must confirm this.
-    # V is industry x commodity. Should we inflate how much of
-    # each commodity the industry makes? Or inflate the relative
-    # value of the industry?
-    # My initial guess was opposite of U since the dimension
-    # is opposite..
-    return pt.DataFrame[VMatrix](V.multiply(price_ratio_base_to_target, axis=1))
 
 
 def inflate_A_matrix(


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

Pure dead-code cleanup across the inflation/price-index modules — three orphaned items, no behavior change.

`derive_2017_Vnorm_scrap_corrected` carried `apply_inflation` and `target_year` parameters with no caller ever passing `True`. Drops both, the dead branch, and the now-unused `inflate_usa_V_to_target_year` import.

`inflation_helpers_ceda.py` shed two functions that had no callers anywhere:

- `inflate_usa_U_to_target_year` — orphaned for a while
- `inflate_usa_V_to_target_year` — orphaned by the change above

This also frees their exclusive imports (`pandera.pandas`, `pandera.typing`, `VMatrix`), pulled in this commit.

`derived_price_index.py` drops the `INFLATION_SECTORS` constant — defined but never read anywhere.

## Testing

Existing tests pass; ruff + mypy + black all green locally.