### PR TITLE
fix(eeio): gate cornerstone industry-PI behind update_inflation_factors

### DIFF
--- a/bedrock/utils/config/usa_config.py
+++ b/bedrock/utils/config/usa_config.py
@@ -81,6 +81,8 @@ class USAConfig(BaseModel):
     )
     update_liming_and_fertilizer_ghg_method: bool = False  # DRI: mo.li
     update_other_gases_ghg_method: bool = False  # DRI: catherine.birney
+    ### Inflation factors
+    update_inflation_factors: bool = False  # mo.li
 
     #####
     # Diagnostics baseline (parquet snapshots vs USEEIO Excel on GCS)

--- a/bedrock/utils/economic/__tests__/test_inflation_helpers_cornerstone.py
+++ b/bedrock/utils/economic/__tests__/test_inflation_helpers_cornerstone.py
@@ -1,6 +1,9 @@
+import pytest
+
 from bedrock.transform.eeio.derived_cornerstone import (
     derive_cornerstone_Vnorm_scrap_corrected,
 )
+from bedrock.utils.config.usa_config import get_usa_config
 from bedrock.utils.economic.inflation_helpers_cornerstone import (
     get_vnorm_adjusted_commodity_price_ratio,
 )
@@ -23,7 +26,9 @@ def test_vnorm_commodity_price_ratio_is_identity_at_year_to_self() -> None:
     ), f"Expected ratio == 1.0 at year=year, got max abs deviation {max_abs_dev:.2e}"
 
 
-def test_v_inflation_uses_industry_row_axis() -> None:
+def test_v_inflation_uses_industry_row_axis(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Regression guard: V inflation in
     ``derive_cornerstone_Vnorm_scrap_corrected(apply_inflation=True)`` must
     scale industry rows of V by their own price ratio (axis=0), not commodity
@@ -43,6 +48,12 @@ def test_v_inflation_uses_industry_row_axis() -> None:
       ratio reduces to a row-wise scrap-correction factor — *constant* across
       commodity columns within each row → row std = 0.
     """
+    # apply_inflation=True is the new BEA-derived industry-PI path; pin the
+    # flag so the price ratio is industry-indexed (matching V's industry
+    # rows). Under update_inflation_factors=False the helper returns
+    # commodity-indexed values for the legacy A-matrix flow.
+    monkeypatch.setattr(get_usa_config(), 'update_inflation_factors', True)
+
     Vnorm_True = derive_cornerstone_Vnorm_scrap_corrected(
         apply_inflation=True, target_year=2024
     )

--- a/bedrock/utils/economic/inflation_helpers_cornerstone.py
+++ b/bedrock/utils/economic/inflation_helpers_cornerstone.py
@@ -16,6 +16,10 @@ import numpy as np
 import pandas as pd
 
 from bedrock.transform.iot.derived_price_index import derive_industry_price_index
+from bedrock.utils.config.usa_config import get_usa_config
+from bedrock.utils.economic.inflation_helpers_ceda import (
+    obtain_inflation_factors_from_reference_data,
+)
 from bedrock.utils.taxonomy.cornerstone.commodities import COMMODITIES
 from bedrock.utils.taxonomy.cornerstone.industries import INDUSTRIES
 from bedrock.utils.taxonomy.mappings.bea_v2017_commodity__cornerstone_commodity import (
@@ -53,11 +57,21 @@ def get_cornerstone_industry_price_ratio(
     Cornerstone-only child codes (e.g. waste subsectors) inherit their CEDA v7
     parent's price ratio so that inflation is applied consistently.
     """
-    price_index = derive_industry_price_index()
+    cfg = get_usa_config()
+    if cfg.update_inflation_factors:
+        price_index = derive_industry_price_index()
+        target_codes = CORNERSTONE_INDUSTRIES
+    else:
+        # Reindex to commodities so downstream `diag(p) @ A @ diag(1/p)`
+        # aligns positionally against a commodity-indexed A. INDUSTRIES and
+        # COMMODITIES order diverges at 351/405 positions, so the target
+        # list is load-bearing despite the function's name.
+        price_index = obtain_inflation_factors_from_reference_data()
+        target_codes = CORNERSTONE_COMMODITIES
     pi_ratio: pd.Series[float] = price_index[target_year] / price_index[original_year]
 
     # Start with direct reindex (codes shared with CEDA v7 get their own ratio)
-    ratio = pi_ratio.reindex(CORNERSTONE_INDUSTRIES, fill_value=np.nan)
+    ratio = pi_ratio.reindex(target_codes, fill_value=np.nan)
 
     # Fill cornerstone-only children with their CEDA v7 parent's ratio
     parent_map = _cornerstone_to_ceda_v7_parent()


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

Add `update_inflation_factors: bool = False` to `USAConfig` and gate `get_cornerstone_industry_price_ratio` on it:

- `False` (default): parquet source (`obtain_inflation_factors_from_reference_data`) + reindex to `CORNERSTONE_COMMODITIES`.
- `True`: BEA-derived source (`derive_industry_price_index`) + reindex to `CORNERSTONE_INDUSTRIES`.

The reindex target is load-bearing. `inflate_cornerstone_A_matrix_with_industry_pi` does `diag(p) @ A @ diag(1/p)` positionally against a commodity-indexed A, and `CORNERSTONE_INDUSTRIES`/`CORNERSTONE_COMMODITIES` order diverges at 351/405 positions. Without this gate, the scheduled `test_integration` run on `main` mis-scaled `Adom_USA`, `Aimp_USA`, `scaled_q_USA`, `y_nab_USA`, `ytot_USA`, and `exports_USA`.

Pin `test_v_inflation_uses_industry_row_axis` to flag=True via `monkeypatch.setattr` since `apply_inflation=True` exercises the new path.

## Testing

- 6 previously-failing integration snapshot tests pass locally.
- 2 unit tests in `test_inflation_helpers_cornerstone.py` pass.
- `black --check .`, `ruff check .`, `mypy bedrock` (379 files) all clean.
- GH Actions integration test passed: https://github.com/cornerstone-data/bedrock/actions/runs/25352787437