### PR TITLE
refactor(analysis): centralize a_matrix_time_series shared setup

### DIFF
--- a/bedrock/analysis/a_matrix_time_series/ViewVnormandPriceRatios.py
+++ b/bedrock/analysis/a_matrix_time_series/ViewVnormandPriceRatios.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
-from pathlib import Path
-
+from bedrock.analysis.a_matrix_time_series.constants import (
+    LATEST_TARGET_YEAR,
+    ORIGINAL_YEAR,
+    RESULTS_DIR,
+)
 from bedrock.transform.eeio.derived_cornerstone import (
     derive_cornerstone_V,
     derive_cornerstone_Vnorm_scrap_corrected,
@@ -12,11 +15,9 @@ from bedrock.utils.economic.inflation_helpers_cornerstone import (
 )
 
 INFLATE_V = True
-OUTPUT_DIR = Path(__file__).parent / "output"
-RESULTS_DIR = OUTPUT_DIR / "results"
 
-original_year = 2017
-target_year = 2023
+original_year = ORIGINAL_YEAR
+target_year = LATEST_TARGET_YEAR
 
 
 def main() -> None:
@@ -44,13 +45,16 @@ def main() -> None:
         original_year, target_year
     ).rename("commodity_ratio")
 
-    Vnorm.to_csv(RESULTS_DIR / "Vnorm2023.csv")
-    industry.to_csv(RESULTS_DIR / "industry_price_ratio_2023.csv")
-    commodity.to_csv(RESULTS_DIR / "commodity_price_ratio_2023.csv")
+    vnorm_path = RESULTS_DIR / f"Vnorm{target_year}.csv"
+    industry_path = RESULTS_DIR / f"industry_price_ratio_{target_year}.csv"
+    commodity_path = RESULTS_DIR / f"commodity_price_ratio_{target_year}.csv"
+    Vnorm.to_csv(vnorm_path)
+    industry.to_csv(industry_path)
+    commodity.to_csv(commodity_path)
     print(
-        "Vnorm written to VNorm2023.csv."
-        "Industry ratios written to industry_price_ratio_2023.csv"
-        "Commodity ratios written to commodity_price_ratio_2023.csv "
+        f"Vnorm written to {vnorm_path.name}. "
+        f"Industry ratios written to {industry_path.name}. "
+        f"Commodity ratios written to {commodity_path.name}."
     )
     return None
 

--- a/bedrock/analysis/a_matrix_time_series/__init__.py
+++ b/bedrock/analysis/a_matrix_time_series/__init__.py
@@ -1,0 +1,21 @@
+"""Force BEA-derived industry price index for every script in this package.
+
+The `update_inflation_factors=False` default in `USAConfig` preserves
+pre-#369 production behavior on the Cornerstone A-matrix path. This
+analysis package universally assumes the new BEA-derived path, so the
+flag is flipped once on first import.
+
+`get_cornerstone_industry_price_ratio` and
+`get_vnorm_adjusted_commodity_price_ratio` are `@functools.cache`'d on
+`(original_year, target_year)` only, so the flag must be set before any
+helper call or the False-branch result becomes the cached answer for the
+rest of the process. Putting the flip here guarantees ordering.
+
+Scripts that swap the global config mid-run (e.g. `derive_A_time_series`
+iterating over approach YAMLs) must re-set the flag inside their swap
+helper — the toggle here only covers the initial config.
+"""
+
+from bedrock.utils.config.usa_config import get_usa_config
+
+get_usa_config().update_inflation_factors = True

--- a/bedrock/analysis/a_matrix_time_series/compare_approaches.py
+++ b/bedrock/analysis/a_matrix_time_series/compare_approaches.py
@@ -37,16 +37,17 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
+from bedrock.analysis.a_matrix_time_series.constants import (
+    LAST_RUN_SHEET_ID_PATH,
+    LATEST_TARGET_YEAR,
+    PLOTS_DIR,
+    RESULTS_DIR,
+)
 from bedrock.utils.io.gcp import update_sheet_tab
 
 logger = logging.getLogger(__name__)
 
-OUTPUT_DIR = Path(__file__).parent / "output"
-RESULTS_DIR = OUTPUT_DIR / "results"
-PLOTS_DIR = OUTPUT_DIR / "plots"
-LAST_RUN_SHEET_ID_PATH = RESULTS_DIR / "last_run_sheet_id.txt"
-
-TARGET_YEAR = 2024
+TARGET_YEAR = LATEST_TARGET_YEAR
 
 ALTERNATIVE_APPROACHES: tuple[str, ...] = (
     "summary_tables",

--- a/bedrock/analysis/a_matrix_time_series/compare_price_ratios.py
+++ b/bedrock/analysis/a_matrix_time_series/compare_price_ratios.py
@@ -25,6 +25,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
+from bedrock.analysis.a_matrix_time_series.constants import (
+    LATEST_TARGET_YEAR,
+    ORIGINAL_YEAR,
+    PLOTS_DIR,
+    RESULTS_DIR,
+)
 from bedrock.transform.eeio.derived_cornerstone import (
     derive_cornerstone_Vnorm_scrap_corrected,
 )
@@ -35,11 +41,8 @@ from bedrock.utils.economic.inflation_helpers_cornerstone import (
 
 logger = logging.getLogger(__name__)
 
-ORIGINAL_YEAR = 2017
-TARGET_YEARS: list[int] = [2018, 2019, 2020, 2021, 2022, 2023, 2024]
-OUTPUT_DIR = Path(__file__).parent / "output"
-RESULTS_DIR = OUTPUT_DIR / "results"
-PLOTS_DIR = OUTPUT_DIR / "plots"
+# Skip ORIGINAL_YEAR (year-to-self ratio is trivially 1.0).
+TARGET_YEARS: list[int] = list(range(ORIGINAL_YEAR + 1, LATEST_TARGET_YEAR + 1))
 INFLATE_V = True  # inflates V to prepare Vnorm for use in commodity ratios
 
 

--- a/bedrock/analysis/a_matrix_time_series/constants.py
+++ b/bedrock/analysis/a_matrix_time_series/constants.py
@@ -1,0 +1,25 @@
+"""Shared constants for the a_matrix_time_series analysis package.
+
+Centralizes paths, the BEA detail base year, the latest target year all
+approaches have data for, and the Drive folder for run-report Sheets.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from bedrock.utils.config.usa_config import get_usa_config
+
+OUTPUT_DIR = Path(__file__).parent / "output"
+RESULTS_DIR = OUTPUT_DIR / "results"
+PLOTS_DIR = OUTPUT_DIR / "plots"
+LAST_RUN_SHEET_ID_PATH = RESULTS_DIR / "last_run_sheet_id.txt"
+
+ANALYSIS_DRIVE_FOLDER_ID = "1UcPmwLnL6MwTq9pMYJw5d43FJQOFQVO_"
+
+# BEA detail IO base year — the inflation `original_year` for every script.
+ORIGINAL_YEAR: int = get_usa_config().usa_base_io_data_year
+
+# Latest year for which all approaches have data (USEEIO, industry_pi,
+# commodity_pi at 2024; summary_tables falls back to 2023 internally).
+LATEST_TARGET_YEAR: int = 2024

--- a/bedrock/analysis/a_matrix_time_series/derive_A_cells_long.py
+++ b/bedrock/analysis/a_matrix_time_series/derive_A_cells_long.py
@@ -54,14 +54,15 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
+from bedrock.analysis.a_matrix_time_series.constants import (
+    LAST_RUN_SHEET_ID_PATH,
+    PLOTS_DIR,
+    RESULTS_DIR,
+)
 from bedrock.utils.io.gcp import update_sheet_tab
 
 logger = logging.getLogger(__name__)
 
-OUTPUT_DIR = Path(__file__).parent / "output"
-RESULTS_DIR = OUTPUT_DIR / "results"
-PLOTS_DIR = OUTPUT_DIR / "plots"
-LAST_RUN_SHEET_ID_PATH = RESULTS_DIR / "last_run_sheet_id.txt"
 A_CELLS_LONG_PATH = RESULTS_DIR / "A_cells_long.parquet"
 
 SCATTER_APPROACHES = ("commodity_price_index", "industry_price_index", "summary_tables")

--- a/bedrock/analysis/a_matrix_time_series/derive_A_cells_stability.py
+++ b/bedrock/analysis/a_matrix_time_series/derive_A_cells_stability.py
@@ -48,14 +48,15 @@ import pandas as pd
 from matplotlib.axes import Axes
 from matplotlib.ticker import PercentFormatter
 
+from bedrock.analysis.a_matrix_time_series.constants import (
+    LAST_RUN_SHEET_ID_PATH,
+    PLOTS_DIR,
+    RESULTS_DIR,
+)
 from bedrock.utils.io.gcp import update_sheet_tab
 
 logger = logging.getLogger(__name__)
 
-OUTPUT_DIR = Path(__file__).parent / "output"
-RESULTS_DIR = OUTPUT_DIR / "results"
-PLOTS_DIR = OUTPUT_DIR / "plots"
-LAST_RUN_SHEET_ID_PATH = RESULTS_DIR / "last_run_sheet_id.txt"
 A_CELLS_LONG_PATH = RESULTS_DIR / "A_cells_long.parquet"
 
 # Approaches we plot (rows). Excludes baselines (useeio, ceda_default) which

--- a/bedrock/analysis/a_matrix_time_series/derive_A_time_series.py
+++ b/bedrock/analysis/a_matrix_time_series/derive_A_time_series.py
@@ -33,12 +33,18 @@ import pandas as pd
 import yaml
 
 import bedrock.utils.config.usa_config as cfg_module
+from bedrock.analysis.a_matrix_time_series.constants import (
+    ANALYSIS_DRIVE_FOLDER_ID,
+    LAST_RUN_SHEET_ID_PATH,
+    LATEST_TARGET_YEAR,
+    ORIGINAL_YEAR,
+    PLOTS_DIR,
+    RESULTS_DIR,
+)
 from bedrock.utils.config.usa_config import USAConfig
 from bedrock.utils.io.gcp import create_spreadsheet_in_folder, update_sheet_tab
 
 logger = logging.getLogger(__name__)
-
-ANALYSIS_DRIVE_FOLDER_ID = "1UcPmwLnL6MwTq9pMYJw5d43FJQOFQVO_"
 
 APPROACH_YAMLS: dict[str, str] = {
     "useeio": "2025_usa_cornerstone_A_useeio.yaml",
@@ -48,12 +54,9 @@ APPROACH_YAMLS: dict[str, str] = {
     "ceda_default": "2025_usa_cornerstone_taxonomy.yaml",  # CEDA baseline with Cornerstone schema
 }
 APPROACHES: list[str] = list(APPROACH_YAMLS.keys())
-TARGET_YEARS: list[int] = [2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024]
-
-OUTPUT_DIR = Path(__file__).parent / "output"
-RESULTS_DIR = OUTPUT_DIR / "results"
-PLOTS_DIR = OUTPUT_DIR / "plots"
-LAST_RUN_SHEET_ID_PATH = RESULTS_DIR / "last_run_sheet_id.txt"
+# Includes ORIGINAL_YEAR (the BEA detail base year) for the 2017-identity
+# sanity check tab.
+TARGET_YEARS: list[int] = list(range(ORIGINAL_YEAR, LATEST_TARGET_YEAR + 1))
 
 # Modules whose @functools.cache outputs are config-dependent and must be
 # invalidated between (approach, year) iterations.
@@ -89,6 +92,9 @@ def _set_config(approach: str, year: int) -> None:
     with open(yaml_path) as f:
         data = yaml.safe_load(f) or {}
     data["model_base_year"] = year
+    # The package `__init__.py` flips this on the initial config; replacing
+    # `_usa_config` here would otherwise drop it back to the field default.
+    data["update_inflation_factors"] = True
 
     cfg_module._usa_config = USAConfig.model_construct(**data)
     os.environ[cfg_module.USA_CONFIG_ENV_VAR] = APPROACH_YAMLS[approach]

--- a/bedrock/analysis/a_matrix_time_series/key_sector_deep_dive.py
+++ b/bedrock/analysis/a_matrix_time_series/key_sector_deep_dive.py
@@ -57,6 +57,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
+from bedrock.analysis.a_matrix_time_series.constants import (
+    LAST_RUN_SHEET_ID_PATH,
+    LATEST_TARGET_YEAR,
+    PLOTS_DIR,
+    RESULTS_DIR,
+)
 from bedrock.utils.io.gcp import update_sheet_tab
 from bedrock.utils.taxonomy.bea.v2017_commodity_summary import (
     USA_2017_SUMMARY_COMMODITY_DESC,
@@ -68,13 +74,9 @@ from bedrock.utils.taxonomy.cornerstone.commodities import COMMODITY_DESC
 
 logger = logging.getLogger(__name__)
 
-OUTPUT_DIR = Path(__file__).parent / "output"
-RESULTS_DIR = OUTPUT_DIR / "results"
-PLOTS_DIR = OUTPUT_DIR / "plots"
-LAST_RUN_SHEET_ID_PATH = RESULTS_DIR / "last_run_sheet_id.txt"
 A_CELLS_LONG_PATH = RESULTS_DIR / "A_cells_long.parquet"
 
-RANK_TARGET_YEAR = 2024
+RANK_TARGET_YEAR = LATEST_TARGET_YEAR
 ALTERNATIVE_APPROACHES: tuple[str, ...] = (
     "summary_tables",
     "industry_price_index",

--- a/bedrock/utils/config/usa_config.py
+++ b/bedrock/utils/config/usa_config.py
@@ -81,6 +81,8 @@ class USAConfig(BaseModel):
     )
     update_liming_and_fertilizer_ghg_method: bool = False  # DRI: mo.li
     update_other_gases_ghg_method: bool = False  # DRI: catherine.birney
+    ### Inflation factors
+    update_inflation_factors: bool = False  # mo.li
 
     #####
     # Diagnostics baseline (parquet snapshots vs USEEIO Excel on GCS)

--- a/bedrock/utils/economic/__tests__/test_inflation_helpers_cornerstone.py
+++ b/bedrock/utils/economic/__tests__/test_inflation_helpers_cornerstone.py
@@ -1,6 +1,9 @@
+import pytest
+
 from bedrock.transform.eeio.derived_cornerstone import (
     derive_cornerstone_Vnorm_scrap_corrected,
 )
+from bedrock.utils.config.usa_config import get_usa_config
 from bedrock.utils.economic.inflation_helpers_cornerstone import (
     get_vnorm_adjusted_commodity_price_ratio,
 )
@@ -23,7 +26,9 @@ def test_vnorm_commodity_price_ratio_is_identity_at_year_to_self() -> None:
     ), f"Expected ratio == 1.0 at year=year, got max abs deviation {max_abs_dev:.2e}"
 
 
-def test_v_inflation_uses_industry_row_axis() -> None:
+def test_v_inflation_uses_industry_row_axis(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Regression guard: V inflation in
     ``derive_cornerstone_Vnorm_scrap_corrected(apply_inflation=True)`` must
     scale industry rows of V by their own price ratio (axis=0), not commodity
@@ -43,6 +48,12 @@ def test_v_inflation_uses_industry_row_axis() -> None:
       ratio reduces to a row-wise scrap-correction factor — *constant* across
       commodity columns within each row → row std = 0.
     """
+    # apply_inflation=True is the new BEA-derived industry-PI path; pin the
+    # flag so the price ratio is industry-indexed (matching V's industry
+    # rows). Under update_inflation_factors=False the helper returns
+    # commodity-indexed values for the legacy A-matrix flow.
+    monkeypatch.setattr(get_usa_config(), 'update_inflation_factors', True)
+
     Vnorm_True = derive_cornerstone_Vnorm_scrap_corrected(
         apply_inflation=True, target_year=2024
     )

--- a/bedrock/utils/economic/inflation_helpers_cornerstone.py
+++ b/bedrock/utils/economic/inflation_helpers_cornerstone.py
@@ -16,6 +16,10 @@ import numpy as np
 import pandas as pd
 
 from bedrock.transform.iot.derived_price_index import derive_industry_price_index
+from bedrock.utils.config.usa_config import get_usa_config
+from bedrock.utils.economic.inflation_helpers_ceda import (
+    obtain_inflation_factors_from_reference_data,
+)
 from bedrock.utils.taxonomy.cornerstone.commodities import COMMODITIES
 from bedrock.utils.taxonomy.cornerstone.industries import INDUSTRIES
 from bedrock.utils.taxonomy.mappings.bea_v2017_commodity__cornerstone_commodity import (
@@ -53,11 +57,21 @@ def get_cornerstone_industry_price_ratio(
     Cornerstone-only child codes (e.g. waste subsectors) inherit their CEDA v7
     parent's price ratio so that inflation is applied consistently.
     """
-    price_index = derive_industry_price_index()
+    cfg = get_usa_config()
+    if cfg.update_inflation_factors:
+        price_index = derive_industry_price_index()
+        target_codes = CORNERSTONE_INDUSTRIES
+    else:
+        # Reindex to commodities so downstream `diag(p) @ A @ diag(1/p)`
+        # aligns positionally against a commodity-indexed A. INDUSTRIES and
+        # COMMODITIES order diverges at 351/405 positions, so the target
+        # list is load-bearing despite the function's name.
+        price_index = obtain_inflation_factors_from_reference_data()
+        target_codes = CORNERSTONE_COMMODITIES
     pi_ratio: pd.Series[float] = price_index[target_year] / price_index[original_year]
 
     # Start with direct reindex (codes shared with CEDA v7 get their own ratio)
-    ratio = pi_ratio.reindex(CORNERSTONE_INDUSTRIES, fill_value=np.nan)
+    ratio = pi_ratio.reindex(target_codes, fill_value=np.nan)
 
     # Fill cornerstone-only children with their CEDA v7 parent's ratio
     parent_map = _cornerstone_to_ceda_v7_parent()


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

Centralize repeated definitions across `bedrock/analysis/a_matrix_time_series/` into two shared files, and pin every script in this package to the BEA-derived industry-PI path:

- `__init__.py` — flips `update_inflation_factors=True` once on first import. The gate added in #373 defaults to `False` so production keeps the parquet flow; this analysis universally assumes the new BEA-derived path. Setting it in `__init__.py` runs before any `@functools.cache`'d helper call. `derive_A_time_series._set_config` re-pins the flag inside its YAML-swap loop so per-approach configs don't drop it back.
- `constants.py` — `OUTPUT_DIR`, `RESULTS_DIR`, `PLOTS_DIR`, `LAST_RUN_SHEET_ID_PATH`, `ANALYSIS_DRIVE_FOLDER_ID`, `ORIGINAL_YEAR` (read from `get_usa_config().usa_base_io_data_year`), and `LATEST_TARGET_YEAR = 2024`.

Each script drops its local copies and imports from `constants`. Range-using scripts derive their target-year list from `LATEST_TARGET_YEAR`:

- `derive_A_time_series.TARGET_YEARS` = `range(ORIGINAL_YEAR, LATEST_TARGET_YEAR + 1)` (includes base for the 2017-identity sanity check).
- `compare_price_ratios.TARGET_YEARS` = `range(ORIGINAL_YEAR + 1, LATEST_TARGET_YEAR + 1)` (skips year-to-self).

Bumps `ViewVnormandPriceRatios.target_year` from 2023 → 2024 (now `LATEST_TARGET_YEAR`) and parametrizes its CSV filenames.

## Testing

- All 7 scripts smoke-import cleanly. Package import flips the flag from `False` to `True` as expected.
- 6 snapshot tests in `bedrock/transform/__tests__/test_usa.py` still pass — production behavior unchanged because the package isn't imported on that path.
- 61 tests in `bedrock/utils/economic` + `bedrock/transform/eeio` pass.
- `black --check`, `ruff check .`, `mypy bedrock` (381 files) all clean.