### PR TITLE
Store flow mapping files within bedrock

### DIFF
--- a/bedrock/extract/flowbyactivity.py
+++ b/bedrock/extract/flowbyactivity.py
@@ -177,7 +177,9 @@ class FlowByActivity(_FlowBy):
         mapping_load: pd.DataFrame | None = None
         if mapping_subset is not None:
             if isinstance(mapping_subset, str):
-                local_csv = settings.mappingpath / 'flowmapping' / f'{mapping_subset}.csv'
+                local_csv = (
+                    settings.mappingpath / 'flowmapping' / f'{mapping_subset}.csv'
+                )
                 if local_csv.is_file():
                     log.info('Loading flow mapping from %s', local_csv)
                     mapping_load = pd.read_csv(local_csv)

--- a/bedrock/extract/flowbyactivity.py
+++ b/bedrock/extract/flowbyactivity.py
@@ -163,7 +163,6 @@ class FlowByActivity(_FlowBy):
         )
 
         # Check for use of multiple mapping files
-        # TODO this was handled in esupy originally - can we go back to that fxn?
         if isinstance(mapping_subset, list):
             fba_merge_keys.append('SourceName')
             mapping_merge_keys.append('SourceListName')
@@ -173,9 +172,22 @@ class FlowByActivity(_FlowBy):
             Context=self.Compartment,
         ).drop(columns=['FlowName', 'Compartment'])
 
-        mapping = fedelemflowlist.get_flowmapping(mapping_subset)[
-            mapping_fields
-        ].assign(ConversionFactor=lambda x: x.ConversionFactor.fillna(1))
+        # first check for a flow mapping file stored locally. If it does not exist, then use the fedelemflowlist
+        # mapping file
+        mapping_load: pd.DataFrame | None = None
+        if mapping_subset is not None:
+            if isinstance(mapping_subset, str):
+                local_csv = settings.mappingpath / 'flowmapping' / f'{mapping_subset}.csv'
+                if local_csv.is_file():
+                    log.info('Loading flow mapping from %s', local_csv)
+                    mapping_load = pd.read_csv(local_csv)
+
+        if mapping_load is None:
+            mapping_load = fedelemflowlist.get_flowmapping(mapping_subset)
+
+        mapping = mapping_load[mapping_fields].assign(
+            ConversionFactor=lambda x: x.ConversionFactor.fillna(1)
+        )
         if mapping.empty:
             log.error(
                 f'Elementary flow list entries for {mapping_subset} not ' f'found'

--- a/bedrock/transform/README.md
+++ b/bedrock/transform/README.md
@@ -192,7 +192,7 @@ Some functions allow for extra named parameters.
   mapping file, if not provided will use the source name
 - _apply_urban_rural_: (bool) Assign flow quantities as urban or rural based on
   population density by FIPS.
-- _fedefl_mapping_: name of mapping file to use in FEDEFL.
+- _fedefl_mapping_: name of flow mapping file - first looks for local file, otherwise loads from FEDEFL.
 - _mfl_mapping_: name of mapping file for Material Flow List. Should not be
   used if fedefl_mapping is used
 - _keep_unmapped_rows_: (bool) default is False, if True will maintain any

--- a/bedrock/utils/mapping/flowmapping/USDA_ERS_MLU.csv
+++ b/bedrock/utils/mapping/flowmapping/USDA_ERS_MLU.csv
@@ -1,0 +1,20 @@
+SourceListName,SourceFlowName,SourceFlowUUID,SourceFlowContext,SourceUnit,MatchCondition,ConversionFactor,TargetFlowName,TargetFlowUUID,TargetFlowContext,TargetUnit,Mapper,Verifier,LastUpdated
+USDA_ERS_MLU,All special uses of land,,ground,Thousand Acres,=,4046872.61,Land use,6438548e-77ef-35c2-97d9-8471835bcd8f,resource/ground,m2*a,Hottle,Birney,8/18/2021
+USDA_ERS_MLU,Land in rural parks and wildlife areas,,ground,Thousand Acres,=,4046872.61,Land use,6438548e-77ef-35c2-97d9-8471835bcd8f,resource/ground,m2*a,Hottle,Birney,8/18/2021
+USDA_ERS_MLU,Other land,,ground,Thousand Acres,=,4046872.61,Land use,6438548e-77ef-35c2-97d9-8471835bcd8f,resource/ground,m2*a,Hottle,Birney,8/18/2021
+USDA_ERS_MLU,Miscellaneous other land,,ground,Thousand Acres,=,4046872.61,Land use,6438548e-77ef-35c2-97d9-8471835bcd8f,resource/ground,m2*a,Birney,,4/6/2026
+USDA_ERS_MLU,Total land,,ground,Thousand Acres,=,4046872.61,Land use,6438548e-77ef-35c2-97d9-8471835bcd8f,resource/ground,m2*a,Hottle,Birney,8/18/2021
+USDA_ERS_MLU,Cropland idled,,ground,Thousand Acres,=,4046872.61,Land use,46b31bbe-1c77-3a50-a31d-5378c1e47dd6,resource/ground/human-dominated/agricultural,m2*a,Hottle,Birney,8/18/2021
+USDA_ERS_MLU,Cropland used for crops,,ground,Thousand Acres,=,4046872.61,Land use,46b31bbe-1c77-3a50-a31d-5378c1e47dd6,resource/ground/human-dominated/agricultural,m2*a,Hottle,Birney,8/18/2021
+USDA_ERS_MLU,Cropland used for pasture,,ground,Thousand Acres,=,4046872.61,Land use,46b31bbe-1c77-3a50-a31d-5378c1e47dd6,resource/ground/human-dominated/agricultural,m2*a,Hottle,Birney,8/18/2021
+USDA_ERS_MLU,Total cropland,,ground,Thousand Acres,=,4046872.61,Land use,46b31bbe-1c77-3a50-a31d-5378c1e47dd6,resource/ground/human-dominated/agricultural,m2*a,Hottle,Birney,8/18/2021
+USDA_ERS_MLU,"Farmsteads, roads, and miscellaneous farmland",,ground,Thousand Acres,=,4046872.61,Land use,2ab5e22d-38c0-31ff-9843-87323cc6e89e,resource/ground/human-dominated/agricultural/rural,m2*a,Hottle,Birney,8/18/2021
+USDA_ERS_MLU,Forest-use land (all),,ground,Thousand Acres,=,4046872.61,Land use,1147e66c-db3e-303c-b7c7-89b006d98881,resource/ground/terrestrial/forest,m2*a,Hottle,Birney,8/18/2021
+USDA_ERS_MLU,Forest-use land grazed,,ground,Thousand Acres,=,4046872.61,Land use,1147e66c-db3e-303c-b7c7-89b006d98881,resource/ground/terrestrial/forest,m2*a,Hottle,Birney,8/18/2021
+USDA_ERS_MLU,Grazed forest-use land grazed,,ground,Thousand Acres,=,4046872.61,Land use,1147e66c-db3e-303c-b7c7-89b006d98881,resource/ground/terrestrial/forest,m2*a,Birney,,4/6/2026
+USDA_ERS_MLU,Forest-use land not grazed,,ground,Thousand Acres,=,4046872.61,Land use,1147e66c-db3e-303c-b7c7-89b006d98881,resource/ground/terrestrial/forest,m2*a,Hottle,Birney,8/18/2021
+USDA_ERS_MLU,Ungrazed forest-use land,,ground,Thousand Acres,=,4046872.61,Land use,1147e66c-db3e-303c-b7c7-89b006d98881,resource/ground/terrestrial/forest,m2*a,Birney,,4/6/2026
+USDA_ERS_MLU,Grassland pasture and range,,ground,Thousand Acres,=,4046872.61,Land use,69430702-b65a-3ef0-a8d4-64bc3fcae42e,resource/ground/terrestrial/grassland,m2*a,Hottle,Birney,8/18/2021
+USDA_ERS_MLU,Land in defense and industrial areas,,ground,Thousand Acres,=,4046872.61,Land use,4b92c75e-e528-3f23-bc67-e92977682eb4,resource/ground/human-dominated/industrial,m2*a,Hottle,Birney,8/18/2021
+USDA_ERS_MLU,Land in rural transportation facilities,,ground,Thousand Acres,=,4046872.61,Land use,11a47fe3-b34b-3c3c-a621-92651c169d0b,resource/ground/human-dominated/commercial/rural,m2*a,Hottle,Birney,8/18/2021
+USDA_ERS_MLU,Land in urban areas,,ground,Thousand Acres,=,4046872.61,Land use,f4acc1d3-7983-39c9-825f-53c965585dde,resource/ground/human-dominated/urban,m2*a,Hottle,Birney,8/18/2021


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

Adds ability to store a flow mapping file within bedrock. During FBS generation, the flow mapping files are looked for locally first. If the csv does not exist locally, the mapping file is loaded from [fedelemflowlist](https://github.com/FLCAC-admin/fedelemflowlist) repo.

This PR contains an updated mapping file for MLU which contains updated activity names from the newest release of USDA MLU. Required for the land_national_2012 FBS

## Testing
[integration test](https://github.com/cornerstone-data/bedrock/actions/runs/25579423277)
