### PR TITLE
Do not call gcs unnecessarily when file to be loaded already exists locally

### DIFF
--- a/bedrock/utils/io/gcp.py
+++ b/bedrock/utils/io/gcp.py
@@ -93,23 +93,23 @@ def download_gcs_file_if_not_exists(name: str, sub_bucket: str, pth: str) -> Non
                 download_gcs_file(name, norm_bucket, pth)
             except Exception:
                 pass
-        # Download metadata from this GCS prefix when they exist
-        prefix = norm_bucket + "/"
-        gcs_bucket = __storage_client().bucket("cornerstone-default")
-        for blob in gcs_bucket.list_blobs(prefix=prefix):
-            if not blob.name.startswith(prefix):
-                continue
-            rel = blob.name[len(prefix) :]
-            if not rel or rel.endswith("/") or "metadata" not in rel.lower():
-                continue
-            dest = os.path.join(parent, *rel.split("/"))
-            if os.path.exists(dest):
-                continue
-            os.makedirs(os.path.dirname(dest), exist_ok=True)
-            try:
-                download_gcs_file(rel, norm_bucket, dest)
-            except Exception:
-                pass
+            # Download metadata from this GCS prefix when they exist
+            prefix = norm_bucket + "/"
+            gcs_bucket = __storage_client().bucket("cornerstone-default")
+            for blob in gcs_bucket.list_blobs(prefix=prefix):
+                if not blob.name.startswith(prefix):
+                    continue
+                rel = blob.name[len(prefix) :]
+                if not rel or rel.endswith("/") or "metadata" not in rel.lower():
+                    continue
+                dest = os.path.join(parent, *rel.split("/"))
+                if os.path.exists(dest):
+                    continue
+                os.makedirs(os.path.dirname(dest), exist_ok=True)
+                try:
+                    download_gcs_file(rel, norm_bucket, dest)
+                except Exception:
+                    pass
         return
 
     if os.path.exists(pth):

--- a/scripts/build_model_manual_check.py
+++ b/scripts/build_model_manual_check.py
@@ -6,12 +6,12 @@ for that model.
 
 from bedrock.utils.config.usa_config import set_global_usa_config
 
-# config = "useeio_phoebe_23"
+config = "useeio_phoebe_23"
 # config = "useeio_phoebe_23_restore_schema_and_ghg"
 # config = "useeio_phoebe_23_restore_useeio_B"
 # config = "useeio_phoebe_23_restore_iot_redefinition"
 # config = "useeio_phoebe_23_restore_ghg"
-config = 'useeio_phoebe_23_restore_scrap'
+# config = 'useeio_phoebe_23_restore_scrap'
 # config = "2025_usa_cornerstone_full_model"
 # config = "2025_usa_cornerstone_taxonomy"
 # config = "2025_usa_cornerstone_taxonomy_and_waste_disagg"


### PR DESCRIPTION
This relates to the change to gcp.py occurring with this commit:
https://github.com/cornerstone-data/bedrock/commit/26136e7d72dc0fb6b344f835d490bf99ba6f271c#diff-30b839914f0f14c8e78090f9a82d33e3415d4e427a824916e5745440583fc0d7

The problem is the google cloud storage is being called when looking for any local data file in order to scan for metadata. 
Not only does this slow down the build process, it will cause fundamental model build code like 
`derive_Aq_usa()`  to fail if the user is offline or has issues with gcs authentication management. 

The fix moves the metadata-scanning block (including the __storage_client() call) inside the if not os.path.exists(pth): guard. Now the entire GCS interaction — both the main file download and the metadata scan — is skipped when pth already exists locally.

The tradeoff: if a new metadata file is added to GCS after the main file was already downloaded, it won't be picked up on subsequent runs. Given the function is named *_if_not_exists, that's consistent behavior — callers who need fresh metadata should delete the local file or use download_gcs_file directly.

The change to `build_model_manual_check.py` is inconsequential here and accidentally committed but just changed out the model being tested so it's more trouble to remove it than leave it in.