### PR TITLE
Add 2017 and 2018 GHG FBS

### DIFF
--- a/bedrock/transform/ghg/GHG_national_Cornerstone_2017.yaml
+++ b/bedrock/transform/ghg/GHG_national_Cornerstone_2017.yaml
@@ -1,0 +1,906 @@
+# This is the 2017 method file for the Cornerstone GHG model (v2025)
+# Note that this FBS (along with 2018) can only be generated using the
+# Flow-By-Activity files stored on GCS - these files are labeled v2.0.3.
+# This method cannot be generated with raw GHGI data, as the latest
+# release of GHGI goes back to 2019.
+# Therefore, when running generateFlowBySector(), must set "download_sources_ok=True"
+
+!include:Cornerstone_2025_target.yaml
+year: &ghgi_year 2017
+target_naics_year: 2017
+geoscale: national
+
+mecs_year: &mecs_year 2018
+coa_year: &coa_year 2017
+
+_attribution_sources:
+  EIA_MECS_Energy_Allocation_CEDA: &mecs_energy_alloc
+    activity_to_sector_mapping: CEDA_2025
+    year: *mecs_year
+
+  BEA: &bea # 2017 Make and Use tables
+    year: 2017
+    activity_to_sector_mapping: Cornerstone_2025
+    exclusion_fields:
+      # Drop irrelevant final demand and total sectors
+      ActivityConsumedBy: ['F03000', 'F04000', 'F05000', 'F02E00',
+                           'F06E00', 'F07E00', 'F10E00', 'F02R00',
+                           'T001', 'T004', 'T007', 'T019']
+      ActivityProducedBy: ['T007', 'T013', 'T015', 'T016', 'TOP',
+                           'MCIF']
+    attribution_method: equal
+
+  _cropland_allocation: &cropland_allocation
+    USDA_CoA_Cropland:
+      year: *coa_year
+      selection_fields:
+        Class: Land
+        FlowName:
+          - AREA HARVESTED
+          - AREA BEARING & NON-BEARING # Orchards
+          - AREA GROWN # Berry totals
+      attribution_method: proportional
+      attribution_source:
+        USDA_CoA_Cropland_NAICS:
+          year: *coa_year
+          selection_fields:
+            Class: Land
+            FlowName: AG LAND, CROPLAND, HARVESTED
+          estimate_suppressed: !clean_function:flowbyclean estimate_suppressed_sectors_equal_attribution
+
+  _animal_land_allocation: &animal_land_allocation
+    USDA_CoA_Cropland_NAICS:
+      year: *coa_year
+      selection_fields:
+        Class: Land
+        FlowName: FARM OPERATIONS
+      estimate_suppressed: !clean_function:flowbyclean estimate_suppressed_sectors_equal_attribution
+
+
+source_names:
+  EPA_GHGI_T_2_1: #U.S. GHG emissions
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    fedefl_mapping: GHGI_AR5_100
+    activity_sets:
+      direct:
+        selection_fields:
+          PrimaryActivity:
+            - Abandoned Oil and Gas Wells #CH4
+            - Abandoned Underground Coal Mines #CH4
+            - Adipic Acid Production #N2O
+            - Aluminum Production #CO2
+            - Ammonia Production #CO2
+            - Anaerobic Digestion at Biogas Facilities #CH4
+            - Caprolactam, Glyoxal, and Glyoxylic Acid Production #N2O
+            - Carbide Production and Consumption #CO2
+            - Cement Production #CO2
+            - Coal Mining #CH4, CO2
+            - Composting #CH4, N2O
+            - Ferroalloy Production #CO2, CH4
+            - Glass Production #CO2
+            - Landfills #CH4
+            - Lead Production #CO2
+            - Incineration of Waste #N2O and CO2
+            - Lime Production #CO2
+            - Iron and Steel Production & Metallurgical Coke Production #CO2, CH4
+            - Nitric Acid Production #N2O
+            - Phosphoric Acid Production #CO2
+            - Rice Cultivation #CH4
+            - Soda Ash Production #CO2
+            - Titanium Dioxide Production #CO2
+            - Wastewater Treatment #CH4, N2O
+            - Zinc Production #CO2
+          FlowName: ["CO2", "CH4", "N2O"] # HFCs and other flows are pulled elsewhere
+        attribution_method: direct
+      electricity_transmission:
+        selection_fields:
+          PrimaryActivity:
+            - Electrical Transmission and Distribution  # SF6
+            - Electrical Equipment  # SF6
+          FlowName: SF6
+        attribution_method: direct
+
+      electric_power:
+        selection_fields:
+          PrimaryActivity:
+            Electric Power Sector: Electric Power # CO2
+        attribution_method: direct
+
+      liming: # liming of agricultural soils
+        selection_fields:
+          PrimaryActivity: Liming #CO2
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'327400': ''} # Lime and Gypsum Products
+
+      urea:
+        selection_fields:
+          PrimaryActivity:
+            - Urea Consumption for Non-Agricultural Purposes # CO2
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'325310': ''} # Fertilizers
+
+      urea_fertilizer:
+        selection_fields:
+          PrimaryActivity: Urea Fertilization # CO2
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'325310': ''} # Fertilizers
+
+      carbonate_use:
+        selection_fields:
+          PrimaryActivity: Other Process Uses of Carbonates # CO2
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'325180': ''} # Other Basic Inorganic Chemicals
+
+      nitrous_oxide_use:
+        selection_fields:
+          PrimaryActivity: N2O from Product Uses # N2O
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'325120': ''} # Industrial gases
+
+      field_burning_n2O:
+        selection_fields:
+          PrimaryActivity:
+            - Field Burning of Agricultural Residues
+          FlowName: ["N2O"]
+        attribution_method: proportional
+        attribution_source:
+          EPA_GHGI_T_5_28: &field_burning
+            year: *ghgi_year
+            activity_to_sector_mapping: EPA_GHGI_Cornerstone
+            selection_fields:
+              PrimaryActivity:
+                - Chickpeas
+                - Cotton
+                - Maize
+                - Rice
+                - Soybeans
+                - Wheat
+                - Lentils
+                - Sugarcane
+              FlowName:
+                CH4: N2O # replacing flow name
+            attribution_method: direct
+
+      field_burning_ch4:
+        selection_fields:
+          PrimaryActivity:
+            - Field Burning of Agricultural Residues
+          FlowName: ["CH4"]
+        attribution_method: proportional
+        attribution_source:
+          EPA_GHGI_T_5_28:
+            <<: *field_burning
+            selection_fields:
+              PrimaryActivity:
+                - Chickpeas
+                - Cotton
+                - Maize
+                - Rice
+                - Soybeans
+                - Wheat
+                - Lentils
+                - Sugarcane
+              FlowName: ["CH4"]
+
+
+## Fossil Fuels
+  EPA_GHGI_T_3_73: &natgas #CH4 from Natural Gas Systems
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    fedefl_mapping: GHGI_AR5_100
+    selection_fields:
+      PrimaryActivity:
+        - Distribution
+        - Post-Meter
+        - Exploration
+        - Processing
+        - Production
+        - Transmission and Storage
+    attribution_method: direct
+  EPA_GHGI_T_3_75: *natgas # CO2 from Natural Gas Systems mimics CH4
+  EPA_GHGI_T_3_77: *natgas # N2O from Natural Gas Systems mimics CH4
+
+  EPA_GHGI_T_3_44: &petroleum #CH4 from Petroleum Systems
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    fedefl_mapping: GHGI_AR5_100
+    selection_fields:
+      PrimaryActivity:
+        - Crude Oil Transportation
+        - Transportation
+        - Exploration
+        - Production
+        - Refining
+        - Crude Refining
+    attribution_method: direct
+  EPA_GHGI_T_3_46: *petroleum # CO2 from Petroleum Systems mimics CH4
+  EPA_GHGI_T_3_48: *petroleum # N2O from Petroleum Systems mimics CH4
+
+## Agriculture
+  EPA_GHGI_T_5_3:  &animals #CH4 from Enteric Fermentation
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    fedefl_mapping: GHGI_AR5_100
+    selection_fields:
+      PrimaryActivity:
+        - American Bison
+        - Beef Cattle
+        - Dairy Cattle
+        - Goats
+        - Horses
+        - Mules and Asses
+        - Sheep
+        - Swine
+        - Poultry
+    attribution_method: direct
+  EPA_GHGI_T_5_6:  *animals # CH4 and N2O from manure management
+
+  EPA_GHGI_T_5_17: #Direct N2O emissions from agricultural soils
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    fedefl_mapping: GHGI_AR5_100
+    activity_sets:
+      fertilizer_use:
+        selection_fields:
+          PrimaryActivity:
+            - Organic Amendment Cropland
+            - Residue N Cropland
+            - Synthetic Fertilizer Cropland
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'325310': ''} # fertilizer sectors
+
+      cropland:
+        selection_fields:
+          PrimaryActivity:
+            - Mineralization and Asymbiotic Fixation Cropland
+            - Drained Organic Soils Cropland
+        attribution_method: proportional
+        attribution_source: *cropland_allocation
+
+      pasture:
+        selection_fields:
+          PrimaryActivity:
+            - All activities Grassland
+        attribution_method: proportional
+        attribution_source: *animal_land_allocation
+
+
+  EPA_GHGI_T_5_18: #Indirect N2O emissions from agricultural soils
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    fedefl_mapping: GHGI_AR5_100
+    activity_sets:
+      fertilizer_use:
+        selection_fields:
+          PrimaryActivity:
+            - Volatilization & Atm. Deposition Cropland
+            - Surface Leaching & Run-Off Cropland
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'325310': ''} # fertilizer sectors
+      pasture:
+        selection_fields:
+          PrimaryActivity:
+            - All activities Grassland
+        attribution_method: proportional
+        attribution_source: *animal_land_allocation
+
+
+### Mobile Sources
+  EPA_GHGI_T_3_13: #CO2 from mobile combustion
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    fedefl_mapping: GHGI_AR5_100
+    activity_sets:
+      direct_residual_fuel_oil:
+        selection_fields:
+          PrimaryActivity:
+            Ships and Non-Recreational Boats Residual Fuel Oil: Ships and Non-Recreational Boats
+        attribution_method: direct
+
+      direct_lpg:
+        selection_fields:
+          PrimaryActivity:
+            Buses LPG: Buses
+            Medium- and Heavy-Duty Trucks LPG: Medium- and Heavy-Duty Trucks
+            Light-Duty Trucks LPG: Light-Duty Trucks - Households
+            Passenger Cars LPG: Passenger Cars - Households
+        attribution_method: direct
+
+      direct_jet:
+        selection_fields:
+          PrimaryActivity:
+            General Aviation Aircraft Aviation Gasoline: General Aviation Aircraft
+            General Aviation Aircraft Jet Fuel: General Aviation Aircraft
+            Commercial Aircraft Jet Fuel: Commercial Aircraft
+            Military Aircraft Jet Fuel: Military Aircraft
+        attribution_method: direct
+
+      direct_ng:
+        selection_fields:
+          PrimaryActivity:
+            Buses Natural Gas: Buses
+            Pipeline Natural Gas: Pipeline Natural Gas
+            Medium- and Heavy-Duty Trucks Natural Gas: Medium- and Heavy-Duty Trucks
+        attribution_method: direct
+
+      direct_diesel:
+        selection_fields:
+          PrimaryActivity:
+            Rail Distillate Fuel Oil: Rail
+            Recreational Boats Distillate Fuel Oil: Recreational Boats
+            Ships and Non-Recreational Boats Distillate Fuel Oil: Ships and Non-Recreational Boats
+        attribution_method: direct
+
+      direct_gasoline:
+        selection_fields:
+          PrimaryActivity:
+            Medium- and Heavy-Duty Trucks Gasoline: Medium- and Heavy-Duty Trucks
+            Buses Gasoline: Buses
+            Motorcycles Gasoline: Motorcycles
+            Recreational Boats Gasoline: Recreational Boats
+        attribution_method: direct
+
+      petroleum_fuels_diesel:
+        selection_fields:
+          PrimaryActivity:
+            Medium- and Heavy-Duty Trucks Distillate Fuel Oil: Medium- and Heavy-Duty Trucks - Distillate Fuel Oil
+            Buses Distillate Fuel Oil: Buses - Distillate Fuel Oil
+            Passenger Cars Distillate Fuel Oil: Passenger Cars
+            Light-Duty Trucks Distillate Fuel Oil: Light-Duty Trucks
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'324110': ''}  # purchases of refinery products
+
+      petroleum_fuels_gasoline:
+        selection_fields:
+          PrimaryActivity:
+            Passenger Cars Gasoline: Passenger Cars
+            Light-Duty Trucks Gasoline: Light-Duty Trucks
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'324110': ''}  # purchases of refinery products
+
+  EPA_GHGI_T_3_14: &mobile #CH4 from mobile combustion
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    fedefl_mapping: GHGI_AR5_100
+    activity_sets:
+      direct_gasoline: # empty in some years (<0.05 MMT CO2eq)
+        selection_fields:
+          PrimaryActivity:
+            Motorcycles Gasoline On-Road: Motorcycles
+            Medium- and Heavy-Duty Trucks and Buses Gasoline On-Road: Medium- and Heavy-Duty Trucks and Buses
+        attribution_method: direct
+
+      direct_diesel:
+        selection_fields:
+          PrimaryActivity:
+            Passenger Cars Diesel On-Road: Passenger Cars - Households
+            Light-Duty Trucks Diesel On-Road: Light-Duty Trucks - Households
+            Medium- and Heavy-Duty Buses Diesel On-Road: Medium- and Heavy-Duty Buses
+        attribution_method: direct
+
+      direct_non_road:
+        selection_fields:
+          PrimaryActivity:
+            Rail Non-Road: Rail
+            Ships and Boats Non-Road: Ships and Boats
+            Aircraft Non-Road: General Aviation Aircraft
+        attribution_method: direct
+
+      petroleum_fuels_diesel:
+        selection_fields:
+          PrimaryActivity:
+            Medium- and Heavy-Duty Trucks Diesel On-Road: Medium- and Heavy-Duty Trucks - Distillate Fuel Oil
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'324110': ''}  # purchases of refinery products
+
+      petroleum_fuels_gasoline:
+        selection_fields:
+          PrimaryActivity:
+            Passenger Cars Gasoline On-Road: Passenger Cars - Households
+            Light-Duty Trucks Gasoline On-Road: Light-Duty Trucks - Households
+        attribution_method: direct
+
+      construction_and_mining: #this set is allocated by purchases of construction equipment
+        selection_fields:
+          PrimaryActivity: Construction/Mining Equipment Non-Road
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'333120': ''} # purchases of construction/mining equipment
+
+      farm_non_road: #this set is allocated by purchases of farm machinery
+        selection_fields:
+          PrimaryActivity: Agricultural Equipment Non-Road
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'333111': ''} # purchases of farm machinery
+
+      other_non_road: #this set is allocated by purchases of petroleum refining
+        selection_fields:
+          PrimaryActivity: Other Non-Road
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'324110': ''} # purchases of refinery products
+
+      alt_fuel_on_road: #this set is allocated by purchases of natural gas
+        selection_fields: # empty in some years (<0.05 MMT CO2eq)
+          PrimaryActivity:
+            All activities Alternative Fuel On-Road: Alternative Fuel On-Road
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'221200': ''} # purchases of natural gas
+
+  EPA_GHGI_T_3_15:  *mobile #N2O from mobile combustion duplicates method for CH4
+
+## Stationary Combustion
+  "EPA_GHGI_T_A_10": # CO2 emissions from stationary combustion
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    fedefl_mapping: GHGI_AR5_100
+    year: *ghgi_year
+    clean_fba_before_activity_sets: !script_function:EPA_GHGI allocate_industrial_combustion
+    clean_parameter: # Override each year for use in allocate_industrial_combustion
+        energy_fba: 'EIA_MECS_Energy'
+        year: *mecs_year
+        ghgi_year: *ghgi_year # CEDA uses the GHGI year not the MECS year
+        ghg_fba: 'EPA_GHGI_T_A_10'
+    activity_sets:
+      direct_attribution: #direct allocation
+        selection_fields:
+          PrimaryActivity: Total (All Fuels) Residential
+        attribution_method: direct
+
+      non_manufacturing_coal:
+        selection_fields:
+          PrimaryActivity:
+            Commercial Coal Commercial: Coal Commercial
+            Industrial Other Coal Industrial: Coal Industrial
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'212100': ''} # purchases of coal
+
+      non_manufacturing_natural_gas: # Applies to non-manufacturing sectors like ag and mining
+        selection_fields:
+          PrimaryActivity:
+            - Natural Gas Commercial
+            - Natural Gas Industrial
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'221200': ''} # purchases of natural gas
+
+
+      coal_manufacturing_co2: # Industrial Coal for Manufacturing
+        selection_fields:
+          PrimaryActivity:
+            Industrial Other Coal Industrial - Manufacturing: Coal Industrial - Manufacturing
+        attribution_method: proportional
+        attribution_source:
+          EIA_MECS_Energy_Allocation_CEDA:
+            <<: *mecs_energy_alloc
+            selection_fields:
+              FlowName: Coal
+              Description: 'energy'
+
+
+      natural_gas_manufacturing: # Industrial Natural Gas for manufacturing
+        selection_fields:
+          PrimaryActivity:
+            - Natural Gas Industrial - Manufacturing
+        attribution_method: proportional
+        attribution_source:
+          EIA_MECS_Energy_Allocation_CEDA:
+            <<: *mecs_energy_alloc
+            selection_fields:
+              FlowName: Natural Gas
+              Description: 'energy'
+
+      petroleum_industrial: # Petroleum
+        selection_fields:
+          PrimaryActivity:
+            - Total Petroleum Industrial
+        attribution_method: proportional
+        attribution_source:
+          EIA_MECS_Energy_Allocation_CEDA:
+            <<: *mecs_energy_alloc
+            selection_fields:
+              FlowName: Petroleum
+              Description: 'energy'
+
+      petroleum_commercial: # Petroleum
+        selection_fields:
+          PrimaryActivity:
+            - Total Petroleum Commercial
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'324110': ''} # purchases of refinery products
+
+  EPA_GHGI_T_3_8:  &stationary_combustion # CH4 emissions from stationary combustion
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    # note - below clean function splits ghgi data into manufacturing and non manufacturing
+    # while ceda does not originally use this terminology/append "manufacturing" to activity names, ceda
+    # accomplishes the same methods through
+    # _allocate_industrial_coal_to_industries_energy_allocation() + _allocate_remaining_industrial_coal_usage()
+    clean_fba_before_activity_sets: !script_function:EPA_GHGI allocate_industrial_combustion
+    clean_parameter: # Override each year for use in allocate_industrial_combustion
+        energy_fba: 'EIA_MECS_Energy'
+        year: *mecs_year
+        ghgi_year: *ghgi_year # CEDA uses the GHGI year not the MECS year
+        ghg_fba: 'EPA_GHGI_T_A_10'
+    fedefl_mapping: GHGI_AR5_100
+    activity_sets:
+      residential:
+        selection_fields:
+          PrimaryActivity:
+            - Fuel Oil Residential
+            - Coal Residential
+            - Natural Gas Residential
+            - Wood Residential
+        attribution_method: direct
+
+      electric_power:
+        selection_fields:
+          PrimaryActivity:
+            Coal Electric Power: Coal Electric Power
+            Natural Gas Electric Power: Natural Gas Electric Power
+            Natural gas Electric Power: Natural Gas Electric Power # fix capitalization
+            Fuel Oil Electric Power: Fuel Oil Electric Power
+            Wood Electric Power: Wood Electric Power
+        attribution_method: direct
+
+      # updated from flowsa, only includes commercial
+      fuel_oil_commercial:
+        selection_fields:
+          PrimaryActivity:
+            - Fuel Oil Commercial
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'324110': ''}  # purchases of refinery products
+
+      # new code for industrial
+      fuel_oil_industrial:
+        selection_fields:
+          PrimaryActivity:
+            - Fuel Oil Industrial
+        attribution_method: proportional
+        attribution_source:
+          EIA_MECS_Energy_Allocation_CEDA:
+            <<: *mecs_energy_alloc
+            selection_fields:
+              FlowName: Petroleum
+              Description: 'energy'
+
+      natural_gas_nonmanufacturing:  # Commercial Natural gas
+        selection_fields:
+          PrimaryActivity:
+            Natural gas Commercial: Natural Gas Commercial # fix capitalization
+            Natural gas Industrial: Natural Gas Industrial # fix capitalization
+            Natural Gas Commercial: Natural Gas Commercial
+            Natural Gas Industrial: Natural Gas Industrial
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'221200': ''}  # purchases of natural gas
+
+      # note - this replicates _allocate_remaining_industrial_coal_usage()
+      coal_nonmanufacturing: # empty in some years (i.e., all coal consumption for manufacturing)
+        selection_fields:
+          PrimaryActivity: Coal Industrial
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'212100': ''}  # purchases of coal
+
+      # ceda splits coal into manufacturing/non manufacturing, but did not update the activity names, same method
+      coal_manufacturing:
+        selection_fields:
+          PrimaryActivity: Coal Industrial - Manufacturing
+        attribution_method: proportional
+        attribution_source:
+          EIA_MECS_Energy_Allocation_CEDA:
+            <<: *mecs_energy_alloc
+            selection_fields:
+              FlowName: Coal
+              Description: 'energy'
+
+      # ceda accomplishes similar through
+      # _allocate_industrial_nat_gas_to_industries_energy_allocation() + _allocate_remaining_industrial_nat_gas_usage()
+      ng_manufacturing:
+        selection_fields:
+          PrimaryActivity:
+            - Natural gas Industrial - Manufacturing
+            - Natural Gas Industrial - Manufacturing  # only in flowsa, CEDA does not call on manufacturing
+        attribution_method: proportional
+        attribution_source:
+          EIA_MECS_Energy_Allocation_CEDA:
+            <<: *mecs_energy_alloc
+            selection_fields:
+              FlowName: Natural Gas
+              Description: "energy"
+
+    #Intentionally left out 'Wood Commercial' and 'Wood Industrial'  # flowsa note, but ceda also does not include
+
+  EPA_GHGI_T_3_9: *stationary_combustion # N2O emissions from stationary combustion
+
+
+## Other sources
+  EPA_GHGI_T_4_55: #CO2 for selected petrochemicals
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    fedefl_mapping: GHGI_AR5_100
+    selection_fields:
+      PrimaryActivity:
+        - Acrylonitrile
+        - Carbon Black
+        - Ethylene
+        - Ethylene Dichloride
+        - Ethylene Oxide
+        - Methanol
+    attribution_method: direct
+
+  EPA_GHGI_T_3_24b: # Fossil fuel for non-energy uses
+    year: *ghgi_year
+    fedefl_mapping: GHGI_AR5_100
+    activity_sets:
+      coal:
+        selection_fields:
+          PrimaryActivity:
+            - Industry Industrial Coking Coal
+            - Industry Industrial Other Coal
+        attribution_method: direct
+
+      petroleum_neu: # consumed petroleum products
+        selection_fields:
+          PrimaryActivity:
+            'Industry Asphalt & Road Oil': Industry Petroleum Products Non-energy
+            Industry Distillate Fuel Oil: Industry Petroleum Products Non-energy
+            # Industry LPG: Industry Petroleum Products Non-energy  #not in 2023 ghg, this is the same as HGL in 2018
+            Industry Lubricants: Industry Petroleum Products Non-energy
+            Industry Miscellaneous Products: Industry Petroleum Products Non-energy
+            'Industry Naphtha (<401 F)': Industry Petroleum Products Non-energy
+            'Industry Other Oil (>401 F)': Industry Petroleum Products Non-energy
+            # Industry Pentanes Plus: Industry Petroleum Products Non-energy #not in 2023 ghg, this is the same as HGL in 2018
+            Industry Petroleum Coke: Industry Petroleum Products Non-energy
+            Industry Special Naphtha: Industry Petroleum Products Non-energy
+            Industry Still Gas: Industry Petroleum Products Non-energy
+            Industry Waxes: Industry Petroleum Products Non-energy
+            Industry Natural Gasoline: Industry Petroleum Products Non-energy #T_3_22. Also produced by nat gas plants
+            Industry HGL: Industry Petroleum Products Non-energy #T_3_22. Also produced by nat gas plants
+        attribution_method: proportional
+        attribution_source:
+          EIA_MECS_Energy_Allocation_CEDA:
+            <<: *mecs_energy_alloc
+            selection_fields:
+              FlowName: Petroleum
+              Description: "non energy"
+
+      natural_gas_neu: # consumed nat gas to chemical plants
+        selection_fields:
+          PrimaryActivity: Industry Natural Gas to Chemical Plants
+        attribution_method: proportional
+        attribution_source:
+          EIA_MECS_Energy_Allocation_CEDA:
+            <<: *mecs_energy_alloc
+            selection_fields:
+              FlowName: Natural Gas
+              Description: "non energy"
+
+      transportation_lubricants:
+        selection_fields:
+          PrimaryActivity: Transportation Lubricants
+        attribution_method: proportional
+        attribution_source:
+          EIA_MECS_Energy_Allocation_CEDA:
+            <<: *mecs_energy_alloc
+            selection_fields:
+              FlowName: Transport
+              Description: "non energy"
+
+## Other Emissions
+  EPA_GHGI_T_4_59: # HFCs from HCFC-22 production
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    fedefl_mapping: GHGI_AR5_100
+    selection_fields:
+      PrimaryActivity: HCFC-22 Production
+    attribution_method: direct
+
+  EPA_GHGI_T_4_63: # Fluorochemical production (in CO2e)
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    fedefl_mapping: GHGI_AR5_100
+    selection_fields:
+      PrimaryActivity: Fluorochemical Production
+      FlowName: ["Other PFCs", "Other HFCs"]
+    attribution_method: direct
+
+  EPA_GHGI_T_4_64: # Fluorochemical production (in MT)
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    fedefl_mapping: GHGI_AR5_100
+    selection_fields:
+      PrimaryActivity: Fluorochemical Production
+    exclusion_fields:
+      FlowName: ["Other PFCs", "Other HFCs"]
+    attribution_method: direct
+
+  EPA_GHGI_T_4_109: # HFCs, SF6, CO2 from magnesium production
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    fedefl_mapping: GHGI_AR5_100
+    selection_fields:
+      PrimaryActivity: Magnesium Production and Processing
+    attribution_method: proportional
+    attribution_source:
+      BEA_Detail_GrossOutput_IO:
+        year: *ghgi_year
+        geoscale: national
+        activity_to_sector_mapping: BEA_2017_Detail
+        attribution_method: equal
+
+  EPA_GHGI_T_4_121: # HFCs and other emissions from electronics manufacture
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    fedefl_mapping: GHGI_AR5_100
+    selection_fields:
+      PrimaryActivity:
+        - Electronics Industry
+        - Semiconductors
+        - PV
+        - MEMS
+    attribution_method: direct
+
+  EPA_GHGI_T_4_135: # SF6 and PFCs from Other Product Use
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    fedefl_mapping: GHGI_AR5_100
+    attribution_method: direct
+
+  EPA_GHGI_T_4_127: # HFCs and PFCs from ODS Substitutes
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    clean_fba_before_activity_sets: !script_function:EPA_GHGI split_HFCs_by_type
+    clean_parameter:
+        flow_fba: EPA_GHGI_T_4_125
+    year: *ghgi_year
+    fedefl_mapping: GHGI_AR5_100
+    activity_sets:
+      households:
+        selection_fields:
+          PrimaryActivity:
+            - Domestic Refrigeration
+            - Residential Stationary Air Conditioning
+        attribution_method: direct
+
+      refrigerants:
+        selection_fields:
+          PrimaryActivity:
+            - Commercial Refrigeration
+            - Industrial Process Refrigeration
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'333415': ''} # Air conditioning equipment
+
+      air_conditioning:
+        selection_fields:
+          PrimaryActivity:
+            - Commercial Stationary Air Conditioning
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'333415': ''} # Air conditioning equipment
+
+      foams:
+        selection_fields:
+          PrimaryActivity:
+            - Foams
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy:
+                '326140': '' # Polystyrene foam
+                '326150': '' # Urethane and other foam
+
+
+  EPA_GHGI_T_A_89: # HFCs from Transportation
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    clean_fba_before_mapping: !script_function:EPA_GHGI split_HFCs_by_type
+    clean_parameter:
+        # Proportions of specific HFCs are assigned based on national total
+        flow_fba: EPA_GHGI_T_4_125
+    fedefl_mapping: GHGI_AR5_100
+    selection_fields:
+      PrimaryActivity:
+        Mobile AC - Passenger Cars: Passenger Cars - Households
+        Mobile AC - Light-Duty Trucks: Light-Duty Trucks - Households
+        Mobile AC - Heavy-Duty Vehicles: Heavy-Duty Vehicles
+        Comfort Cooling for Trains and Buses - School and Tour Buses: School and Tour Buses
+        Comfort Cooling for Trains and Buses - Transit Buses: Transit Buses
+        Comfort Cooling for Trains and Buses - Rail: Rail
+        Refrigerated Transport - Medium- and Heavy-Duty Trucks: Medium- and Heavy-Duty Trucks
+        Refrigerated Transport - Rail: Rail
+        Refrigerated Transport - Ships and Boats: Ships and Boats
+    attribution_method: direct
+
+
+  EPA_GHGI_T_4_103: # PFCs from aluminum production
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    fedefl_mapping: GHGI_AR5_100
+    selection_fields:
+      PrimaryActivity: Aluminum Production
+    attribution_method: direct

--- a/bedrock/transform/ghg/GHG_national_Cornerstone_2018.yaml
+++ b/bedrock/transform/ghg/GHG_national_Cornerstone_2018.yaml
@@ -1,0 +1,906 @@
+# This is the 2018 method file for the Cornerstone GHG model (v2025)
+# Note that this FBS (along with 2017) can only be generated using the
+# Flow-By-Activity files stored on GCS - these files are labeled v2.0.3.
+# This method cannot be generated with raw GHGI data, as the latest
+# release of GHGI goes back to 2019.
+# Therefore, when running generateFlowBySector(), must set "download_sources_ok=True"
+
+!include:Cornerstone_2025_target.yaml
+year: &ghgi_year 2018
+target_naics_year: 2017
+geoscale: national
+
+mecs_year: &mecs_year 2018
+coa_year: &coa_year 2017
+
+_attribution_sources:
+  EIA_MECS_Energy_Allocation_CEDA: &mecs_energy_alloc
+    activity_to_sector_mapping: CEDA_2025
+    year: *mecs_year
+
+  BEA: &bea # 2017 Make and Use tables
+    year: 2017
+    activity_to_sector_mapping: Cornerstone_2025
+    exclusion_fields:
+      # Drop irrelevant final demand and total sectors
+      ActivityConsumedBy: ['F03000', 'F04000', 'F05000', 'F02E00',
+                           'F06E00', 'F07E00', 'F10E00', 'F02R00',
+                           'T001', 'T004', 'T007', 'T019']
+      ActivityProducedBy: ['T007', 'T013', 'T015', 'T016', 'TOP',
+                           'MCIF']
+    attribution_method: equal
+
+  _cropland_allocation: &cropland_allocation
+    USDA_CoA_Cropland:
+      year: *coa_year
+      selection_fields:
+        Class: Land
+        FlowName:
+          - AREA HARVESTED
+          - AREA BEARING & NON-BEARING # Orchards
+          - AREA GROWN # Berry totals
+      attribution_method: proportional
+      attribution_source:
+        USDA_CoA_Cropland_NAICS:
+          year: *coa_year
+          selection_fields:
+            Class: Land
+            FlowName: AG LAND, CROPLAND, HARVESTED
+          estimate_suppressed: !clean_function:flowbyclean estimate_suppressed_sectors_equal_attribution
+
+  _animal_land_allocation: &animal_land_allocation
+    USDA_CoA_Cropland_NAICS:
+      year: *coa_year
+      selection_fields:
+        Class: Land
+        FlowName: FARM OPERATIONS
+      estimate_suppressed: !clean_function:flowbyclean estimate_suppressed_sectors_equal_attribution
+
+
+source_names:
+  EPA_GHGI_T_2_1: #U.S. GHG emissions
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    fedefl_mapping: GHGI_AR5_100
+    activity_sets:
+      direct:
+        selection_fields:
+          PrimaryActivity:
+            - Abandoned Oil and Gas Wells #CH4
+            - Abandoned Underground Coal Mines #CH4
+            - Adipic Acid Production #N2O
+            - Aluminum Production #CO2
+            - Ammonia Production #CO2
+            - Anaerobic Digestion at Biogas Facilities #CH4
+            - Caprolactam, Glyoxal, and Glyoxylic Acid Production #N2O
+            - Carbide Production and Consumption #CO2
+            - Cement Production #CO2
+            - Coal Mining #CH4, CO2
+            - Composting #CH4, N2O
+            - Ferroalloy Production #CO2, CH4
+            - Glass Production #CO2
+            - Landfills #CH4
+            - Lead Production #CO2
+            - Incineration of Waste #N2O and CO2
+            - Lime Production #CO2
+            - Iron and Steel Production & Metallurgical Coke Production #CO2, CH4
+            - Nitric Acid Production #N2O
+            - Phosphoric Acid Production #CO2
+            - Rice Cultivation #CH4
+            - Soda Ash Production #CO2
+            - Titanium Dioxide Production #CO2
+            - Wastewater Treatment #CH4, N2O
+            - Zinc Production #CO2
+          FlowName: ["CO2", "CH4", "N2O"] # HFCs and other flows are pulled elsewhere
+        attribution_method: direct
+      electricity_transmission:
+        selection_fields:
+          PrimaryActivity:
+            - Electrical Transmission and Distribution  # SF6
+            - Electrical Equipment  # SF6
+          FlowName: SF6
+        attribution_method: direct
+
+      electric_power:
+        selection_fields:
+          PrimaryActivity:
+            Electric Power Sector: Electric Power # CO2
+        attribution_method: direct
+
+      liming: # liming of agricultural soils
+        selection_fields:
+          PrimaryActivity: Liming #CO2
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'327400': ''} # Lime and Gypsum Products
+
+      urea:
+        selection_fields:
+          PrimaryActivity:
+            - Urea Consumption for Non-Agricultural Purposes # CO2
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'325310': ''} # Fertilizers
+
+      urea_fertilizer:
+        selection_fields:
+          PrimaryActivity: Urea Fertilization # CO2
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'325310': ''} # Fertilizers
+
+      carbonate_use:
+        selection_fields:
+          PrimaryActivity: Other Process Uses of Carbonates # CO2
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'325180': ''} # Other Basic Inorganic Chemicals
+
+      nitrous_oxide_use:
+        selection_fields:
+          PrimaryActivity: N2O from Product Uses # N2O
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'325120': ''} # Industrial gases
+
+      field_burning_n2O:
+        selection_fields:
+          PrimaryActivity:
+            - Field Burning of Agricultural Residues
+          FlowName: ["N2O"]
+        attribution_method: proportional
+        attribution_source:
+          EPA_GHGI_T_5_28: &field_burning
+            year: *ghgi_year
+            activity_to_sector_mapping: EPA_GHGI_Cornerstone
+            selection_fields:
+              PrimaryActivity:
+                - Chickpeas
+                - Cotton
+                - Maize
+                - Rice
+                - Soybeans
+                - Wheat
+                - Lentils
+                - Sugarcane
+              FlowName:
+                CH4: N2O # replacing flow name
+            attribution_method: direct
+
+      field_burning_ch4:
+        selection_fields:
+          PrimaryActivity:
+            - Field Burning of Agricultural Residues
+          FlowName: ["CH4"]
+        attribution_method: proportional
+        attribution_source:
+          EPA_GHGI_T_5_28:
+            <<: *field_burning
+            selection_fields:
+              PrimaryActivity:
+                - Chickpeas
+                - Cotton
+                - Maize
+                - Rice
+                - Soybeans
+                - Wheat
+                - Lentils
+                - Sugarcane
+              FlowName: ["CH4"]
+
+
+## Fossil Fuels
+  EPA_GHGI_T_3_73: &natgas #CH4 from Natural Gas Systems
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    fedefl_mapping: GHGI_AR5_100
+    selection_fields:
+      PrimaryActivity:
+        - Distribution
+        - Post-Meter
+        - Exploration
+        - Processing
+        - Production
+        - Transmission and Storage
+    attribution_method: direct
+  EPA_GHGI_T_3_75: *natgas # CO2 from Natural Gas Systems mimics CH4
+  EPA_GHGI_T_3_77: *natgas # N2O from Natural Gas Systems mimics CH4
+
+  EPA_GHGI_T_3_44: &petroleum #CH4 from Petroleum Systems
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    fedefl_mapping: GHGI_AR5_100
+    selection_fields:
+      PrimaryActivity:
+        - Crude Oil Transportation
+        - Transportation
+        - Exploration
+        - Production
+        - Refining
+        - Crude Refining
+    attribution_method: direct
+  EPA_GHGI_T_3_46: *petroleum # CO2 from Petroleum Systems mimics CH4
+  EPA_GHGI_T_3_48: *petroleum # N2O from Petroleum Systems mimics CH4
+
+## Agriculture
+  EPA_GHGI_T_5_3:  &animals #CH4 from Enteric Fermentation
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    fedefl_mapping: GHGI_AR5_100
+    selection_fields:
+      PrimaryActivity:
+        - American Bison
+        - Beef Cattle
+        - Dairy Cattle
+        - Goats
+        - Horses
+        - Mules and Asses
+        - Sheep
+        - Swine
+        - Poultry
+    attribution_method: direct
+  EPA_GHGI_T_5_6:  *animals # CH4 and N2O from manure management
+
+  EPA_GHGI_T_5_17: #Direct N2O emissions from agricultural soils
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    fedefl_mapping: GHGI_AR5_100
+    activity_sets:
+      fertilizer_use:
+        selection_fields:
+          PrimaryActivity:
+            - Organic Amendment Cropland
+            - Residue N Cropland
+            - Synthetic Fertilizer Cropland
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'325310': ''} # fertilizer sectors
+
+      cropland:
+        selection_fields:
+          PrimaryActivity:
+            - Mineralization and Asymbiotic Fixation Cropland
+            - Drained Organic Soils Cropland
+        attribution_method: proportional
+        attribution_source: *cropland_allocation
+
+      pasture:
+        selection_fields:
+          PrimaryActivity:
+            - All activities Grassland
+        attribution_method: proportional
+        attribution_source: *animal_land_allocation
+
+
+  EPA_GHGI_T_5_18: #Indirect N2O emissions from agricultural soils
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    fedefl_mapping: GHGI_AR5_100
+    activity_sets:
+      fertilizer_use:
+        selection_fields:
+          PrimaryActivity:
+            - Volatilization & Atm. Deposition Cropland
+            - Surface Leaching & Run-Off Cropland
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'325310': ''} # fertilizer sectors
+      pasture:
+        selection_fields:
+          PrimaryActivity:
+            - All activities Grassland
+        attribution_method: proportional
+        attribution_source: *animal_land_allocation
+
+
+### Mobile Sources
+  EPA_GHGI_T_3_13: #CO2 from mobile combustion
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    fedefl_mapping: GHGI_AR5_100
+    activity_sets:
+      direct_residual_fuel_oil:
+        selection_fields:
+          PrimaryActivity:
+            Ships and Non-Recreational Boats Residual Fuel Oil: Ships and Non-Recreational Boats
+        attribution_method: direct
+
+      direct_lpg:
+        selection_fields:
+          PrimaryActivity:
+            Buses LPG: Buses
+            Medium- and Heavy-Duty Trucks LPG: Medium- and Heavy-Duty Trucks
+            Light-Duty Trucks LPG: Light-Duty Trucks - Households
+            Passenger Cars LPG: Passenger Cars - Households
+        attribution_method: direct
+
+      direct_jet:
+        selection_fields:
+          PrimaryActivity:
+            General Aviation Aircraft Aviation Gasoline: General Aviation Aircraft
+            General Aviation Aircraft Jet Fuel: General Aviation Aircraft
+            Commercial Aircraft Jet Fuel: Commercial Aircraft
+            Military Aircraft Jet Fuel: Military Aircraft
+        attribution_method: direct
+
+      direct_ng:
+        selection_fields:
+          PrimaryActivity:
+            Buses Natural Gas: Buses
+            Pipeline Natural Gas: Pipeline Natural Gas
+            Medium- and Heavy-Duty Trucks Natural Gas: Medium- and Heavy-Duty Trucks
+        attribution_method: direct
+
+      direct_diesel:
+        selection_fields:
+          PrimaryActivity:
+            Rail Distillate Fuel Oil: Rail
+            Recreational Boats Distillate Fuel Oil: Recreational Boats
+            Ships and Non-Recreational Boats Distillate Fuel Oil: Ships and Non-Recreational Boats
+        attribution_method: direct
+
+      direct_gasoline:
+        selection_fields:
+          PrimaryActivity:
+            Medium- and Heavy-Duty Trucks Gasoline: Medium- and Heavy-Duty Trucks
+            Buses Gasoline: Buses
+            Motorcycles Gasoline: Motorcycles
+            Recreational Boats Gasoline: Recreational Boats
+        attribution_method: direct
+
+      petroleum_fuels_diesel:
+        selection_fields:
+          PrimaryActivity:
+            Medium- and Heavy-Duty Trucks Distillate Fuel Oil: Medium- and Heavy-Duty Trucks - Distillate Fuel Oil
+            Buses Distillate Fuel Oil: Buses - Distillate Fuel Oil
+            Passenger Cars Distillate Fuel Oil: Passenger Cars
+            Light-Duty Trucks Distillate Fuel Oil: Light-Duty Trucks
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'324110': ''}  # purchases of refinery products
+
+      petroleum_fuels_gasoline:
+        selection_fields:
+          PrimaryActivity:
+            Passenger Cars Gasoline: Passenger Cars
+            Light-Duty Trucks Gasoline: Light-Duty Trucks
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'324110': ''}  # purchases of refinery products
+
+  EPA_GHGI_T_3_14: &mobile #CH4 from mobile combustion
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    fedefl_mapping: GHGI_AR5_100
+    activity_sets:
+      direct_gasoline: # empty in some years (<0.05 MMT CO2eq)
+        selection_fields:
+          PrimaryActivity:
+            Motorcycles Gasoline On-Road: Motorcycles
+            Medium- and Heavy-Duty Trucks and Buses Gasoline On-Road: Medium- and Heavy-Duty Trucks and Buses
+        attribution_method: direct
+
+      direct_diesel:
+        selection_fields:
+          PrimaryActivity:
+            Passenger Cars Diesel On-Road: Passenger Cars - Households
+            Light-Duty Trucks Diesel On-Road: Light-Duty Trucks - Households
+            Medium- and Heavy-Duty Buses Diesel On-Road: Medium- and Heavy-Duty Buses
+        attribution_method: direct
+
+      direct_non_road:
+        selection_fields:
+          PrimaryActivity:
+            Rail Non-Road: Rail
+            Ships and Boats Non-Road: Ships and Boats
+            Aircraft Non-Road: General Aviation Aircraft
+        attribution_method: direct
+
+      petroleum_fuels_diesel:
+        selection_fields:
+          PrimaryActivity:
+            Medium- and Heavy-Duty Trucks Diesel On-Road: Medium- and Heavy-Duty Trucks - Distillate Fuel Oil
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'324110': ''}  # purchases of refinery products
+
+      petroleum_fuels_gasoline:
+        selection_fields:
+          PrimaryActivity:
+            Passenger Cars Gasoline On-Road: Passenger Cars - Households
+            Light-Duty Trucks Gasoline On-Road: Light-Duty Trucks - Households
+        attribution_method: direct
+
+      construction_and_mining: #this set is allocated by purchases of construction equipment
+        selection_fields:
+          PrimaryActivity: Construction/Mining Equipment Non-Road
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'333120': ''} # purchases of construction/mining equipment
+
+      farm_non_road: #this set is allocated by purchases of farm machinery
+        selection_fields:
+          PrimaryActivity: Agricultural Equipment Non-Road
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'333111': ''} # purchases of farm machinery
+
+      other_non_road: #this set is allocated by purchases of petroleum refining
+        selection_fields:
+          PrimaryActivity: Other Non-Road
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'324110': ''} # purchases of refinery products
+
+      alt_fuel_on_road: #this set is allocated by purchases of natural gas
+        selection_fields: # empty in some years (<0.05 MMT CO2eq)
+          PrimaryActivity:
+            All activities Alternative Fuel On-Road: Alternative Fuel On-Road
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'221200': ''} # purchases of natural gas
+
+  EPA_GHGI_T_3_15:  *mobile #N2O from mobile combustion duplicates method for CH4
+
+## Stationary Combustion
+  "EPA_GHGI_T_A_9": # CO2 emissions from stationary combustion
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    fedefl_mapping: GHGI_AR5_100
+    year: *ghgi_year
+    clean_fba_before_activity_sets: !script_function:EPA_GHGI allocate_industrial_combustion
+    clean_parameter: # Override each year for use in allocate_industrial_combustion
+        energy_fba: 'EIA_MECS_Energy'
+        year: *mecs_year
+        ghgi_year: *ghgi_year # CEDA uses the GHGI year not the MECS year
+        ghg_fba: 'EPA_GHGI_T_A_9'
+    activity_sets:
+      direct_attribution: #direct allocation
+        selection_fields:
+          PrimaryActivity: Total (All Fuels) Residential
+        attribution_method: direct
+
+      non_manufacturing_coal:
+        selection_fields:
+          PrimaryActivity:
+            Commercial Coal Commercial: Coal Commercial
+            Industrial Other Coal Industrial: Coal Industrial
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'212100': ''} # purchases of coal
+
+      non_manufacturing_natural_gas: # Applies to non-manufacturing sectors like ag and mining
+        selection_fields:
+          PrimaryActivity:
+            - Natural Gas Commercial
+            - Natural Gas Industrial
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'221200': ''} # purchases of natural gas
+
+
+      coal_manufacturing_co2: # Industrial Coal for Manufacturing
+        selection_fields:
+          PrimaryActivity:
+            Industrial Other Coal Industrial - Manufacturing: Coal Industrial - Manufacturing
+        attribution_method: proportional
+        attribution_source:
+          EIA_MECS_Energy_Allocation_CEDA:
+            <<: *mecs_energy_alloc
+            selection_fields:
+              FlowName: Coal
+              Description: 'energy'
+
+
+      natural_gas_manufacturing: # Industrial Natural Gas for manufacturing
+        selection_fields:
+          PrimaryActivity:
+            - Natural Gas Industrial - Manufacturing
+        attribution_method: proportional
+        attribution_source:
+          EIA_MECS_Energy_Allocation_CEDA:
+            <<: *mecs_energy_alloc
+            selection_fields:
+              FlowName: Natural Gas
+              Description: 'energy'
+
+      petroleum_industrial: # Petroleum
+        selection_fields:
+          PrimaryActivity:
+            - Total Petroleum Industrial
+        attribution_method: proportional
+        attribution_source:
+          EIA_MECS_Energy_Allocation_CEDA:
+            <<: *mecs_energy_alloc
+            selection_fields:
+              FlowName: Petroleum
+              Description: 'energy'
+
+      petroleum_commercial: # Petroleum
+        selection_fields:
+          PrimaryActivity:
+            - Total Petroleum Commercial
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'324110': ''} # purchases of refinery products
+
+  EPA_GHGI_T_3_8:  &stationary_combustion # CH4 emissions from stationary combustion
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    # note - below clean function splits ghgi data into manufacturing and non manufacturing
+    # while ceda does not originally use this terminology/append "manufacturing" to activity names, ceda
+    # accomplishes the same methods through
+    # _allocate_industrial_coal_to_industries_energy_allocation() + _allocate_remaining_industrial_coal_usage()
+    clean_fba_before_activity_sets: !script_function:EPA_GHGI allocate_industrial_combustion
+    clean_parameter: # Override each year for use in allocate_industrial_combustion
+        energy_fba: 'EIA_MECS_Energy'
+        year: *mecs_year
+        ghgi_year: *ghgi_year # CEDA uses the GHGI year not the MECS year
+        ghg_fba: 'EPA_GHGI_T_A_9'
+    fedefl_mapping: GHGI_AR5_100
+    activity_sets:
+      residential:
+        selection_fields:
+          PrimaryActivity:
+            - Fuel Oil Residential
+            - Coal Residential
+            - Natural Gas Residential
+            - Wood Residential
+        attribution_method: direct
+
+      electric_power:
+        selection_fields:
+          PrimaryActivity:
+            Coal Electric Power: Coal Electric Power
+            Natural Gas Electric Power: Natural Gas Electric Power
+            Natural gas Electric Power: Natural Gas Electric Power # fix capitalization
+            Fuel Oil Electric Power: Fuel Oil Electric Power
+            Wood Electric Power: Wood Electric Power
+        attribution_method: direct
+
+      # updated from flowsa, only includes commercial
+      fuel_oil_commercial:
+        selection_fields:
+          PrimaryActivity:
+            - Fuel Oil Commercial
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'324110': ''}  # purchases of refinery products
+
+      # new code for industrial
+      fuel_oil_industrial:
+        selection_fields:
+          PrimaryActivity:
+            - Fuel Oil Industrial
+        attribution_method: proportional
+        attribution_source:
+          EIA_MECS_Energy_Allocation_CEDA:
+            <<: *mecs_energy_alloc
+            selection_fields:
+              FlowName: Petroleum
+              Description: 'energy'
+
+      natural_gas_nonmanufacturing:  # Commercial Natural gas
+        selection_fields:
+          PrimaryActivity:
+            Natural gas Commercial: Natural Gas Commercial # fix capitalization
+            Natural gas Industrial: Natural Gas Industrial # fix capitalization
+            Natural Gas Commercial: Natural Gas Commercial
+            Natural Gas Industrial: Natural Gas Industrial
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'221200': ''}  # purchases of natural gas
+
+      # note - this replicates _allocate_remaining_industrial_coal_usage()
+      coal_nonmanufacturing: # empty in some years (i.e., all coal consumption for manufacturing)
+        selection_fields:
+          PrimaryActivity: Coal Industrial
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'212100': ''}  # purchases of coal
+
+      # ceda splits coal into manufacturing/non manufacturing, but did not update the activity names, same method
+      coal_manufacturing:
+        selection_fields:
+          PrimaryActivity: Coal Industrial - Manufacturing
+        attribution_method: proportional
+        attribution_source:
+          EIA_MECS_Energy_Allocation_CEDA:
+            <<: *mecs_energy_alloc
+            selection_fields:
+              FlowName: Coal
+              Description: 'energy'
+
+      # ceda accomplishes similar through
+      # _allocate_industrial_nat_gas_to_industries_energy_allocation() + _allocate_remaining_industrial_nat_gas_usage()
+      ng_manufacturing:
+        selection_fields:
+          PrimaryActivity:
+            - Natural gas Industrial - Manufacturing
+            - Natural Gas Industrial - Manufacturing  # only in flowsa, CEDA does not call on manufacturing
+        attribution_method: proportional
+        attribution_source:
+          EIA_MECS_Energy_Allocation_CEDA:
+            <<: *mecs_energy_alloc
+            selection_fields:
+              FlowName: Natural Gas
+              Description: "energy"
+
+    #Intentionally left out 'Wood Commercial' and 'Wood Industrial'  # flowsa note, but ceda also does not include
+
+  EPA_GHGI_T_3_9: *stationary_combustion # N2O emissions from stationary combustion
+
+
+## Other sources
+  EPA_GHGI_T_4_55: #CO2 for selected petrochemicals
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    fedefl_mapping: GHGI_AR5_100
+    selection_fields:
+      PrimaryActivity:
+        - Acrylonitrile
+        - Carbon Black
+        - Ethylene
+        - Ethylene Dichloride
+        - Ethylene Oxide
+        - Methanol
+    attribution_method: direct
+
+  EPA_GHGI_T_3_24b: # Fossil fuel for non-energy uses
+    year: *ghgi_year
+    fedefl_mapping: GHGI_AR5_100
+    activity_sets:
+      coal:
+        selection_fields:
+          PrimaryActivity:
+            - Industry Industrial Coking Coal
+            - Industry Industrial Other Coal
+        attribution_method: direct
+
+      petroleum_neu: # consumed petroleum products
+        selection_fields:
+          PrimaryActivity:
+            'Industry Asphalt & Road Oil': Industry Petroleum Products Non-energy
+            Industry Distillate Fuel Oil: Industry Petroleum Products Non-energy
+            # Industry LPG: Industry Petroleum Products Non-energy  #not in 2023 ghg, this is the same as HGL in 2018
+            Industry Lubricants: Industry Petroleum Products Non-energy
+            Industry Miscellaneous Products: Industry Petroleum Products Non-energy
+            'Industry Naphtha (<401 F)': Industry Petroleum Products Non-energy
+            'Industry Other Oil (>401 F)': Industry Petroleum Products Non-energy
+            # Industry Pentanes Plus: Industry Petroleum Products Non-energy #not in 2023 ghg, this is the same as HGL in 2018
+            Industry Petroleum Coke: Industry Petroleum Products Non-energy
+            Industry Special Naphtha: Industry Petroleum Products Non-energy
+            Industry Still Gas: Industry Petroleum Products Non-energy
+            Industry Waxes: Industry Petroleum Products Non-energy
+            Industry Natural Gasoline: Industry Petroleum Products Non-energy #T_3_22. Also produced by nat gas plants
+            Industry HGL: Industry Petroleum Products Non-energy #T_3_22. Also produced by nat gas plants
+        attribution_method: proportional
+        attribution_source:
+          EIA_MECS_Energy_Allocation_CEDA:
+            <<: *mecs_energy_alloc
+            selection_fields:
+              FlowName: Petroleum
+              Description: "non energy"
+
+      natural_gas_neu: # consumed nat gas to chemical plants
+        selection_fields:
+          PrimaryActivity: Industry Natural Gas to Chemical Plants
+        attribution_method: proportional
+        attribution_source:
+          EIA_MECS_Energy_Allocation_CEDA:
+            <<: *mecs_energy_alloc
+            selection_fields:
+              FlowName: Natural Gas
+              Description: "non energy"
+
+      transportation_lubricants:
+        selection_fields:
+          PrimaryActivity: Transportation Lubricants
+        attribution_method: proportional
+        attribution_source:
+          EIA_MECS_Energy_Allocation_CEDA:
+            <<: *mecs_energy_alloc
+            selection_fields:
+              FlowName: Transport
+              Description: "non energy"
+
+## Other Emissions
+  EPA_GHGI_T_4_59: # HFCs from HCFC-22 production
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    fedefl_mapping: GHGI_AR5_100
+    selection_fields:
+      PrimaryActivity: HCFC-22 Production
+    attribution_method: direct
+
+  EPA_GHGI_T_4_63: # Fluorochemical production (in CO2e)
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    fedefl_mapping: GHGI_AR5_100
+    selection_fields:
+      PrimaryActivity: Fluorochemical Production
+      FlowName: ["Other PFCs", "Other HFCs"]
+    attribution_method: direct
+
+  EPA_GHGI_T_4_64: # Fluorochemical production (in MT)
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    fedefl_mapping: GHGI_AR5_100
+    selection_fields:
+      PrimaryActivity: Fluorochemical Production
+    exclusion_fields:
+      FlowName: ["Other PFCs", "Other HFCs"]
+    attribution_method: direct
+
+  EPA_GHGI_T_4_109: # HFCs, SF6, CO2 from magnesium production
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    fedefl_mapping: GHGI_AR5_100
+    selection_fields:
+      PrimaryActivity: Magnesium Production and Processing
+    attribution_method: proportional
+    attribution_source:
+      BEA_Detail_GrossOutput_IO:
+        year: *ghgi_year
+        geoscale: national
+        activity_to_sector_mapping: BEA_2017_Detail
+        attribution_method: equal
+
+  EPA_GHGI_T_4_121: # HFCs and other emissions from electronics manufacture
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    fedefl_mapping: GHGI_AR5_100
+    selection_fields:
+      PrimaryActivity:
+        - Electronics Industry
+        - Semiconductors
+        - PV
+        - MEMS
+    attribution_method: direct
+
+  EPA_GHGI_T_4_135: # SF6 and PFCs from Other Product Use
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    fedefl_mapping: GHGI_AR5_100
+    attribution_method: direct
+
+  EPA_GHGI_T_4_127: # HFCs and PFCs from ODS Substitutes
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    clean_fba_before_activity_sets: !script_function:EPA_GHGI split_HFCs_by_type
+    clean_parameter:
+        flow_fba: EPA_GHGI_T_4_125
+    year: *ghgi_year
+    fedefl_mapping: GHGI_AR5_100
+    activity_sets:
+      households:
+        selection_fields:
+          PrimaryActivity:
+            - Domestic Refrigeration
+            - Residential Stationary Air Conditioning
+        attribution_method: direct
+
+      refrigerants:
+        selection_fields:
+          PrimaryActivity:
+            - Commercial Refrigeration
+            - Industrial Process Refrigeration
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'333415': ''} # Air conditioning equipment
+
+      air_conditioning:
+        selection_fields:
+          PrimaryActivity:
+            - Commercial Stationary Air Conditioning
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy: {'333415': ''} # Air conditioning equipment
+
+      foams:
+        selection_fields:
+          PrimaryActivity:
+            - Foams
+        attribution_method: proportional
+        attribution_source:
+          BEA_Detail_Use_AfterRedef:
+            <<: *bea
+            selection_fields:
+              ActivityProducedBy:
+                '326140': '' # Polystyrene foam
+                '326150': '' # Urethane and other foam
+
+
+  EPA_GHGI_T_A_89: # HFCs from Transportation
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    clean_fba_before_mapping: !script_function:EPA_GHGI split_HFCs_by_type
+    clean_parameter:
+        # Proportions of specific HFCs are assigned based on national total
+        flow_fba: EPA_GHGI_T_4_125
+    fedefl_mapping: GHGI_AR5_100
+    selection_fields:
+      PrimaryActivity:
+        Mobile AC - Passenger Cars: Passenger Cars - Households
+        Mobile AC - Light-Duty Trucks: Light-Duty Trucks - Households
+        Mobile AC - Heavy-Duty Vehicles: Heavy-Duty Vehicles
+        Comfort Cooling for Trains and Buses - School and Tour Buses: School and Tour Buses
+        Comfort Cooling for Trains and Buses - Transit Buses: Transit Buses
+        Comfort Cooling for Trains and Buses - Rail: Rail
+        Refrigerated Transport - Medium- and Heavy-Duty Trucks: Medium- and Heavy-Duty Trucks
+        Refrigerated Transport - Rail: Rail
+        Refrigerated Transport - Ships and Boats: Ships and Boats
+    attribution_method: direct
+
+
+  EPA_GHGI_T_4_103: # PFCs from aluminum production
+    year: *ghgi_year
+    activity_to_sector_mapping: EPA_GHGI_Cornerstone
+    fedefl_mapping: GHGI_AR5_100
+    selection_fields:
+      PrimaryActivity: Aluminum Production
+    attribution_method: direct


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

- Add FBS yamls for 2017 and 2018 GHG
- Note that we do not generate GHGI FBAs for these methods, the GHGI tables must be downloaded from GCS (with the extension v2.0.3)
- To generate these FBS, must set `download_sources_ok=True` when running `generateFlowBySector()`

## Testing

- compared sectors in 2017 and 2018 output to those in 2023
