### PR TITLE
Snapshots release documentation

### DIFF
--- a/.github/workflows/generate_diagnostics.yml
+++ b/.github/workflows/generate_diagnostics.yml
@@ -7,7 +7,7 @@ on:
         description: "USA config name (without .yaml extension)"
         required: true
         type: string
-        default: "v8_ceda_2025_usa"
+        default: "2025_usa_cornerstone_full_model"
       sheet_id:
         description: "Google Sheets ID for EF diagnostics"
         required: true

--- a/.github/workflows/generate_snapshots.yml
+++ b/.github/workflows/generate_snapshots.yml
@@ -7,7 +7,7 @@ on:
         description: "USA config name (without .yaml extension)"
         required: true
         type: string
-        default: "v8_ceda_2025_usa"
+        default: "2025_usa_cornerstone_full_model"
       snapshot_prefix_override:
         description: "Override snapshot prefix (optional)"
         required: false
@@ -42,7 +42,7 @@ jobs:
       - name: Generate snapshots
         id: generate
         run: |
-          CONFIG_NAME="${{ github.event.inputs.config_name || 'v8_ceda_2025_usa' }}"
+          CONFIG_NAME="${{ github.event.inputs.config_name || '2025_usa_cornerstone_full_model' }}"
           PREFIX="${{ github.event.inputs.snapshot_prefix_override }}"
           uv run python bedrock/utils/snapshots/generate_snapshots.py \
             --config_name "$CONFIG_NAME" \

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Snapshots are stored in GCS, one folder per git SHA, and [`bedrock/utils/snapsho
 When methodology changes, snapshots are regenerated and uploaded under the new SHA, and the pin is bumped.
 Old snapshots are retained, so every prior release remains independently reproducible.
 
+See [`bedrock/utils/snapshots/README.md`](bedrock/utils/snapshots/README.md) for the team-wide workflow for cutting a new snapshot, bumping the pin, and tagging a release (`v0.X.Y`).
+
 ### Diagnostics of model results compared to USEEIO and CEDA-US baselines
 
 A work-in-progress diagnostics report comparing `bedrock` outputs against USEEIO and CEDA-US can be found in [here](https://github.com/cornerstone-data/papers/blob/internal-review-diagnostics-report/diagnostics_report/bedrock_diagnostics.md) in Cornerstone's papers repository.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ See [`USAConfig`](bedrock/utils/config/usa_config.py) for the full list.
 
 All configuration files are in [`bedrock/utils/config/configs/`](bedrock/utils/config/configs/), where:
 - A single *full-model* config represents a full set of methodology choices made for a data release. For example, [`2025_usa_cornerstone_full_model.yaml`](bedrock/utils/config/configs/2025_usa_cornerstone_full_model.yaml) is now the default config in `get_usa_config()`.
-- Several *per-flag ablation* configs each isolate a single methodological change from the baseline so the impact of each choice can be measured independently. For example, [`2025_usa_cornerstone_taxonomy.yaml`](bedrock/utils/config/configs/2025_usa_cornerstone_taxonomy.yaml) is the config for a specific choice to use Cornerstone taxonomy.
+- Several *atomic configs* each isolate a single methodological change from the baseline so the impact of each choice can be measured independently. For example, [`2025_usa_cornerstone_taxonomy.yaml`](bedrock/utils/config/configs/2025_usa_cornerstone_taxonomy.yaml) is the config for a specific choice to use Cornerstone taxonomy.
 
 A separate `snapshot_version_or_git_sha` field specifies the baseline SHA, so diagnostic runs can compare current output against any released baseline.
 

--- a/bedrock/utils/config/usa_config.py
+++ b/bedrock/utils/config/usa_config.py
@@ -159,8 +159,9 @@ class USAConfig(BaseModel):
     snapshot_version_or_git_sha: ta.Literal[
         'v0',
         '1bda811e0169436ae90fd356fbef512ce7518ccb',  # v0.1
-        '2ebb51f7190c3a62b5d8b2420bff9b20f57282fc',  # v0.2
-        '9fe22d9afdfdb6806397b2356eb3cf4c4c346744',  # v0.2 2025_usa_cornerstone_fbs_schema
+        '2ebb51f7190c3a62b5d8b2420bff9b20f57282fc',  # test
+        '9fe22d9afdfdb6806397b2356eb3cf4c4c346744',  # test: snapshot from 2025_usa_cornerstone_fbs_schema
+        '7372464249c434c9bebb172c065a4d0e3702176e',  # v0.2 (current .SNAPSHOT_KEY)
     ] = 'v0'
 
     @property

--- a/bedrock/utils/snapshots/README.md
+++ b/bedrock/utils/snapshots/README.md
@@ -1,1 +1,246 @@
-Management and loading of dataset snapshots for consistent transformation results.
+# Snapshots & releases
+
+Snapshots are the source of truth for what the bedrock pipeline produced at a specific commit.
+They are:
+
+- The fixtures behind the snapshot integration tests in `bedrock/transform/__tests__/test_usa.py` (run twice every weekday on `main` via `test_integration.yml`)
+- The baseline that diagnostics runs compare against (`USAConfig.snapshot_version_or_git_sha`)
+- A reproducibility guarantee: every prior release remains independently reproducible because old snapshots are never deleted
+
+When the pipeline changes in a way that legitimately changes its outputs, the integration tests will diff against the previous snapshot and fail. That signal is intentional, and the fix is to regenerate the snapshot and bump `.SNAPSHOT_KEY`. Tagging a release is a separate event that may bundle the snapshot bump together with non-output-changing work (docs, polish, bug fixes). This document is the team-wide playbook for both flows.
+
+## Snapshot SHA vs. release tag SHA
+
+These are **independent** concepts and frequently point at different commits:
+
+- **Snapshot SHA** = the commit on `main` whose pipeline outputs were captured into `gs://cornerstone-default/snapshots/<sha>/`. Stored in `.SNAPSHOT_KEY`. Immutable per release.
+- **Release tag SHA** = the commit on `main` that the `vX.Y.Z` tag points at. Marks "what users get when they check out this release." May include the snapshot bump *plus* any docs / polish / non-output-changing PRs that landed before the tag.
+
+**Invariant**: at any tagged commit, the value of `.SNAPSHOT_KEY` is already the snapshot SHA for that release (i.e. the snapshot bump PR is an ancestor of the tagged commit). `git log <snapshot_sha>..<tag_sha>` gives you the docs/polish included in the release.
+
+## Concepts
+
+| Thing | Where | What it is |
+|---|---|---|
+| Snapshot artifacts | `gs://cornerstone-default/snapshots/<git_sha>/*.parquet` | The 10 parquet outputs of the canonical pipeline run at `<git_sha>`. See [`SNAPSHOT_NAMES`](names.py). |
+| Snapshot key | [`.SNAPSHOT_KEY`](.SNAPSHOT_KEY) | The single SHA that integration tests load via `load_current_snapshot(...)`. Bumping this is what "uses the new snapshot" means. |
+| Release tag | annotated git tag `v0.X.Y` | Marks a snapshot/release boundary so methodology evolution is easy to read in history. |
+| Named release | [`releases.py`](releases.py) | Python constants (e.g. `v0_2 = "<sha>"`) for use in code and diagnostics scripts. |
+| Diagnostic baseline pin | `USAConfig.snapshot_version_or_git_sha` | `Literal[...]` of SHAs that any config may point at as its diagnostic baseline. Every released snapshot SHA must be added here. |
+| Canonical config | [`2025_usa_cornerstone_full_model.yaml`](../config/configs/2025_usa_cornerstone_full_model.yaml) | The single config used to generate the snapshots that back `.SNAPSHOT_KEY`. Ablation/per-flag configs are not snapshotted here; see "Adhoc snapshots" below. |
+
+## Versioning
+
+Tags follow `v<major>.<minor>.<patch>`. The choice between patch and minor is **mechanical**: it depends only on whether `.SNAPSHOT_KEY` changed since the previous tag, not on a judgment call about methodology.
+
+| Bump | When | Examples |
+|---|---|---|
+| **patch** (`v0.2.0` → `v0.2.1`) | `.SNAPSHOT_KEY` is unchanged from the previous tag. Used for docs, polish, refactors, bug fixes, and any other work that does not change pipeline outputs. | Docs update; CI tweak; comment cleanup; non-output-affecting refactor |
+| **minor** (`v0.2.x` → `v0.3.0`) | `.SNAPSHOT_KEY` changed since the previous tag. Any cause — methodology choice flipped, upstream data refresh, dependency bump that perturbs floating-point arithmetic, etc. | Enabling waste disaggregation; switching GHG attribution method; FBA data refresh |
+| **major** (`v0.x.y` → `v1.0.0`) | Reserved for the first official Cornerstone U.S. release. After that, breaking changes to the artifact contract (schema/shape changes that downstream consumers must adapt to). | First public release; output schema redesign |
+
+A reviewer can verify the patch-vs-minor decision by inspecting the diff between tags: `git diff <prev_tag>..<new_tag> -- bedrock/utils/snapshots/.SNAPSHOT_KEY`.
+
+## When to cut a new snapshot (Phase A trigger)
+
+A snapshot bump is **always initiated by a human** — never automatically — because an integration-test failure can be either an intended methodology change or an accidental regression. The trigger is usually one of:
+
+1. **Integration tests start failing on `main`** after a PR merges. A Slack alert in `#alerts-bedrock` fires.
+2. **A methodology PR is about to merge** and the author knows it will change outputs.
+3. **An upstream data or dependency change** lands that perturbs outputs.
+
+In every case, follow the decision flow:
+
+```text
+integration tests red?
+        │
+        ▼
+   investigate: is the diff EXPECTED and CORRECT?
+        │
+   ┌────┴────┐
+   no        yes
+   │         │
+revert     proceed to "Phase A" below
+or fix
+```
+
+Do not bump `.SNAPSHOT_KEY` to silence a failure you have not diagnosed.
+
+## When to cut a release (Phase B trigger)
+
+Phase B is **scheduled**, not reactive. Cut a release when any of these is true and `main` is green:
+
+- A methodology change has landed and its snapshot bump has merged — ship a **minor** release.
+- A meaningful body of docs / polish / fixes has accumulated on `main` since the previous tag — ship a **patch** release.
+- Downstream consumers need a stable reference point (e.g., a paper draft, an external review).
+
+There is no requirement to tag every snapshot bump; small bumps can wait and be batched with docs into a single release.
+
+## Release workflow
+
+The release is split into two **independent** phases:
+
+- **Phase A — Snapshot regeneration.** Runs whenever pipeline outputs change. May fire multiple times during a release cycle, or never. Produces a bump to `.SNAPSHOT_KEY`. **Does not tag.**
+- **Phase B — Cutting the release.** Runs whenever the team decides to ship. Tags the current head of `main` with `vX.Y.Z`. Bundles whatever has landed (snapshot bump, docs, polish) into a release.
+
+A patch release (`v0.2.0` → `v0.2.1`) skips Phase A entirely — only Phase B runs. A minor release (`v0.2.x` → `v0.3.0`) runs both.
+
+### Roles
+
+- **Release driver** — either the author of the pipeline-changing PR (for Phase A) or a designated release manager (for Phase B). Owns end-to-end execution.
+- **Reviewer** — any team member with merge rights on the snapshot bump PR and on the release tag.
+
+### Phase A — Snapshot regeneration
+
+**A1. Land the change on `main`.**
+Merge the methodology / pipeline-change PR. Note the merge commit SHA on `main`; this is what the snapshots will be generated against and what `.SNAPSHOT_KEY` will pin.
+
+**A2. Generate snapshots in CI.**
+Trigger the `generate_snapshots` workflow manually:
+
+- GitHub → Actions → **generate_snapshots** → Run workflow
+- Branch: `main` (or the specific SHA from step A1 if newer commits have landed)
+- `config_name`: leave as the default `2025_usa_cornerstone_full_model` (the canonical config)
+- Leave `snapshot_prefix_override` blank so the prefix is the commit SHA
+
+Wait for the success notification in `#alerts-bedrock`. Artifacts will be at `gs://cornerstone-default/snapshots/<sha>/`.
+
+**A3. Open the snapshot bump PR.**
+On a new branch, make exactly these changes (and nothing else — keep the bump PR mechanical and reviewable in under a minute):
+
+- [ ] [`bedrock/utils/snapshots/.SNAPSHOT_KEY`](.SNAPSHOT_KEY) — replace the file's only line with the new SHA.
+- [ ] [`bedrock/utils/snapshots/releases.py`](releases.py) — add `vX_Y_Z = "<sha>"` underneath the previous entry. Use underscores in the Python identifier (e.g. `v0_3_0`); the git tag uses dots.
+- [ ] [`bedrock/utils/config/usa_config.py`](../config/usa_config.py) — extend the `snapshot_version_or_git_sha: Literal[...]` to include the new SHA, with a trailing comment noting the anticipated tag and config (e.g. `# v0.3.0 2025_usa_cornerstone_full_model`). Do **not** remove old SHAs — diagnostics may still reference them.
+- [ ] Title: `release: snapshot bump (anticipated v0.X.Y)`
+- [ ] Description: short summary of the output delta vs. the previous snapshot, plus the GCS URL `gs://cornerstone-default/snapshots/<new_sha>/`.
+
+**A4. Verify before merging.**
+On the bump PR's branch, the integration tests should pass against the new snapshot:
+
+```bash
+uv run pytest bedrock/transform/__tests__/test_usa.py -m eeio_integration
+```
+
+Re-run locally if CI runners hit transient flakes. The bump PR is the only safe place to verify because once `.SNAPSHOT_KEY` changes, the test pass/fail signal is what guards the release.
+
+**A5. Merge the bump PR.**
+At this point `main` carries the new snapshot. No tag yet. Other PRs (docs, polish, fixes) can continue to merge until you're ready for Phase B.
+
+### Phase B — Cutting the release
+
+**B1. Decide patch vs. minor.**
+From a fresh `main`:
+
+```bash
+git fetch --tags
+git diff <latest_tag>..main -- bedrock/utils/snapshots/.SNAPSHOT_KEY
+```
+
+- Diff is empty → **patch** bump (`v0.X.<Y+1>`).
+- Diff is non-empty → **minor** bump (`v0.<X+1>.0`).
+
+If you're cutting `v1.0.0` or a later major release, that's a deliberate methodology + comms decision separate from this flow.
+
+**B2. Confirm `main` is shippable.**
+Integration tests green on the most recent scheduled run. CI on `main` is green. Any docs PRs intended for this release have already merged.
+
+**B3. Tag `main`.**
+
+```bash
+git checkout main && git pull
+SNAP=$(cat bedrock/utils/snapshots/.SNAPSHOT_KEY)
+git tag -a v0.X.Y -m "Bedrock release v0.X.Y
+
+Snapshot SHA:  $SNAP
+GCS prefix:    gs://cornerstone-default/snapshots/$SNAP/
+Canonical config: 2025_usa_cornerstone_full_model
+
+Highlights since previous tag:
+- <bullet>
+- <bullet>
+"
+git push origin v0.X.Y
+```
+
+The tag is annotated (not lightweight) so the release notes show up in `git log` and `git tag -n`.
+
+**B4. Create a GitHub Release.**
+
+- GitHub → Releases → Draft new release → pick tag `v0.X.Y`
+- Title: `v0.X.Y`
+- Body: paste the tag message, plus a generated "what changed" section. The easiest way is `git log <prev_tag>..v0.X.Y --oneline` and group entries into Methodology / Docs / Fixes / Other.
+
+**B5. Announce in Slack.**
+Post in `#alerts-bedrock` (and any other relevant channel):
+
+> :package: **Bedrock release `v0.X.Y`**
+> Tag SHA: `<short_tag_sha>` ([compare](https://github.com/cornerstone-data/bedrock/compare/v0.X.<prev>...v0.X.Y))
+> Snapshot SHA: `<short_snapshot_sha>` (unchanged from previous release / new since `v0.X.<prev>`)
+> Canonical config: `2025_usa_cornerstone_full_model`
+> Highlights: <one or two lines>
+> Downstream impact: <e.g. diagnostics baselines should bump to this SHA when ready>
+
+**B6. (Optional) Update downstream `snapshot_version_or_git_sha` defaults.**
+If you want existing configs to compare against the new baseline by default, follow up with a PR that flips their `snapshot_version_or_git_sha`. This is intentionally a separate PR so diagnostic baseline moves are explicit.
+
+## Anatomy of the Phase A snapshot bump PR
+
+A clean bump PR diff looks roughly like this (anticipating release `v0.3.0`):
+
+```diff
+--- a/bedrock/utils/snapshots/.SNAPSHOT_KEY
++++ b/bedrock/utils/snapshots/.SNAPSHOT_KEY
+-7372464249c434c9bebb172c065a4d0e3702176e
++<new_sha>
+
+--- a/bedrock/utils/snapshots/releases.py
++++ b/bedrock/utils/snapshots/releases.py
+ v0 = "v0_sha_1234567890"
+ v0_1 = "1bda811e0169436ae90fd356fbef512ce7518ccb"
+ v0_2 = "2ebb51f7190c3a62b5d8b2420bff9b20f57282fc"
++v0_3_0 = "<new_sha>"
+
+--- a/bedrock/utils/config/usa_config.py
++++ b/bedrock/utils/config/usa_config.py
+     snapshot_version_or_git_sha: ta.Literal[
+         'v0',
+         '1bda811e0169436ae90fd356fbef512ce7518ccb',  # v0.1
+         '2ebb51f7190c3a62b5d8b2420bff9b20f57282fc',  # v0.2
+         '9fe22d9afdfdb6806397b2356eb3cf4c4c346744',  # v0.2 2025_usa_cornerstone_fbs_schema
++        '<new_sha>',                                  # v0.3.0 2025_usa_cornerstone_full_model
+     ] = 'v0'
+```
+
+Three files, no other code touched. If anything else needs to change, it belongs in a separate PR.
+
+## Rolling back
+
+The two phases roll back independently.
+
+**Rolling back a snapshot bump (Phase A).** Snapshots are immutable in GCS, so a rollback is just a revert of the bump PR — that restores the previous `.SNAPSHOT_KEY` value. Old SHAs in `USAConfig.snapshot_version_or_git_sha` and `releases.py` are kept around precisely so historical baselines remain queryable. If a tag has already been cut on top of the bump PR, see "rolling back a release" below.
+
+**Rolling back a release (Phase B).** Delete the tag locally and on origin (`git tag -d v0.X.Y && git push origin :refs/tags/v0.X.Y`) and delete the corresponding GitHub Release. The commits on `main` stay. This is safe because the tag is just a label; downstream consumers who already pulled it should be notified explicitly. Prefer cutting a new tag with the fix rather than deleting and re-creating the same tag.
+
+If a bad snapshot accidentally got uploaded under a SHA you want to keep, you can regenerate by running the workflow again with `--snapshot_prefix_override` set to the same SHA; existing files in the GCS prefix will be overwritten on re-upload. Prefer not to do this — cut a new release instead so the audit trail stays clean.
+
+## Adhoc snapshots
+
+The `generate_snapshots.py` script supports `--adhoc`, which uploads to `gs://cornerstone-default/snapshots/<sha>/adhoc/` instead of the top-level SHA folder. Use this for:
+
+- Snapshotting an ablation/per-flag config (anything other than `2025_usa_cornerstone_full_model`)
+- Local experimentation where you don't want to pollute the canonical snapshot prefix
+
+Adhoc snapshots are never wired into `.SNAPSHOT_KEY` or `releases.py`. They exist for ad-hoc diagnostic comparisons only.
+
+## File map
+
+| File | Role |
+|---|---|
+| [`.SNAPSHOT_KEY`](.SNAPSHOT_KEY) | The pinned SHA that integration tests load |
+| [`generate_snapshots.py`](generate_snapshots.py) | CLI that builds the 10 parquet snapshots and uploads to GCS |
+| [`loader.py`](loader.py) | `load_current_snapshot`, `load_configured_snapshot`, GCS download helpers |
+| [`names.py`](names.py) | `SnapshotName` literal type and `SNAPSHOT_NAMES` list |
+| [`releases.py`](releases.py) | Named constants for released snapshot SHAs |
+| [`../config/usa_config.py`](../config/usa_config.py) | `USAConfig.snapshot_version_or_git_sha` `Literal` of allowed baseline SHAs |
+| [`../../../.github/workflows/generate_snapshots.yml`](../../../.github/workflows/generate_snapshots.yml) | `workflow_dispatch` CI that runs `generate_snapshots.py` |
+| [`../../../.github/workflows/test_integration.yml`](../../../.github/workflows/test_integration.yml) | Scheduled CI that diffs current pipeline output against `.SNAPSHOT_KEY` |

--- a/bedrock/utils/snapshots/README.md
+++ b/bedrock/utils/snapshots/README.md
@@ -25,9 +25,21 @@ These are **independent** concepts and frequently point at different commits:
 | Snapshot artifacts | `gs://cornerstone-default/snapshots/<git_sha>/*.parquet` | The 10 parquet outputs of the canonical pipeline run at `<git_sha>`. See [`SNAPSHOT_NAMES`](names.py). |
 | Snapshot key | [`.SNAPSHOT_KEY`](.SNAPSHOT_KEY) | The single SHA that integration tests load via `load_current_snapshot(...)`. Bumping this is what "uses the new snapshot" means. |
 | Release tag | annotated git tag `v0.X.Y` | Marks a snapshot/release boundary so methodology evolution is easy to read in history. |
-| Named release | [`releases.py`](releases.py) | Python constants (e.g. `v0_2 = "<sha>"`) for use in code and diagnostics scripts. |
+| Named release | [`releases.py`](releases.py) | Reference-only map of release labels → snapshot SHAs. Not imported by runtime code; update in Phase A alongside `.SNAPSHOT_KEY`. |
 | Diagnostic baseline pin | `USAConfig.snapshot_version_or_git_sha` | `Literal[...]` of SHAs that any config may point at as its diagnostic baseline. Every released snapshot SHA must be added here. |
-| Canonical config | [`2025_usa_cornerstone_full_model.yaml`](../config/configs/2025_usa_cornerstone_full_model.yaml) | The single config used to generate the snapshots that back `.SNAPSHOT_KEY`. Ablation/per-flag configs are not snapshotted here; see "Adhoc snapshots" below. |
+| Canonical config | [`2025_usa_cornerstone_full_model.yaml`](../config/configs/2025_usa_cornerstone_full_model.yaml) | The single config used to generate the snapshots that back `.SNAPSHOT_KEY`. Atomic configs are not snapshotted here; see "Adhoc snapshots" below. |
+
+### Where snapshot SHAs live
+
+| Store | Releases (`v0`, `v0.1`, `v0.2`) | Test-only SHAs |
+|---|---|---|
+| [`.SNAPSHOT_KEY`](.SNAPSHOT_KEY) | `7372464249...` (v0.2) | — |
+| [`releases.py`](releases.py) | `v0`, `v0_1`, `v0_2` | `TEST_*` (intermediate bumps, not release labels) |
+| `USAConfig.snapshot_version_or_git_sha` | `'v0'`, `1bda811e...` `# v0.1`, `7372464249...` `# v0.2` | `2ebb51f7...`, `9fe22d9a...` `# test` |
+
+**Atomic config** — a YAML config that changes a single methodology flag relative to the baseline, used to measure that change in isolation.
+
+`v0.2` is the current integration baseline. `v0` and `v0.1` are earlier release snapshots. The two `TEST_*` SHAs are intermediate bumps kept in the Literal so atomic configs and test fixtures can pin them for comparison.
 
 ## Versioning
 
@@ -109,8 +121,8 @@ Wait for the success notification in `#alerts-bedrock`. Artifacts will be at `gs
 On a new branch, make exactly these changes (and nothing else — keep the bump PR mechanical and reviewable in under a minute):
 
 - [ ] [`bedrock/utils/snapshots/.SNAPSHOT_KEY`](.SNAPSHOT_KEY) — replace the file's only line with the new SHA.
-- [ ] [`bedrock/utils/snapshots/releases.py`](releases.py) — add `vX_Y_Z = "<sha>"` underneath the previous entry. Use underscores in the Python identifier (e.g. `v0_3_0`); the git tag uses dots.
-- [ ] [`bedrock/utils/config/usa_config.py`](../config/usa_config.py) — extend the `snapshot_version_or_git_sha: Literal[...]` to include the new SHA, with a trailing comment noting the anticipated tag and config (e.g. `# v0.3.0 2025_usa_cornerstone_full_model`). Do **not** remove old SHAs — diagnostics may still reference them.
+- [ ] [`bedrock/utils/snapshots/releases.py`](releases.py) — add the new release constant (e.g. `v0_3_0 = "<sha>"`) with a trailing `# config: <stem>` comment (the `generate_snapshots --config_name` value). Leave prior release entries in place. Use underscores in the Python identifier; the git tag uses dots. Do **not** add entries for patch-only releases.
+- [ ] [`bedrock/utils/config/usa_config.py`](../config/usa_config.py) — extend the `snapshot_version_or_git_sha: Literal[...]` to include the new SHA, with a trailing comment noting the release label (e.g. `# v0.3.0`). Do **not** remove old SHAs — atomic configs and test fixtures may still reference them.
 - [ ] Title: `release: snapshot bump (anticipated v0.X.Y)`
 - [ ] Description: short summary of the output delta vs. the previous snapshot, plus the GCS URL `gs://cornerstone-default/snapshots/<new_sha>/`.
 
@@ -195,19 +207,18 @@ A clean bump PR diff looks roughly like this (anticipating release `v0.3.0`):
 
 --- a/bedrock/utils/snapshots/releases.py
 +++ b/bedrock/utils/snapshots/releases.py
- v0 = "v0_sha_1234567890"
- v0_1 = "1bda811e0169436ae90fd356fbef512ce7518ccb"
- v0_2 = "2ebb51f7190c3a62b5d8b2420bff9b20f57282fc"
-+v0_3_0 = "<new_sha>"
+ v0_2 = "7372464249c434c9bebb172c065a4d0e3702176e"  # config: 2025_usa_cornerstone_full_model
++v0_3_0 = "<new_sha>"  # config: 2025_usa_cornerstone_full_model
 
 --- a/bedrock/utils/config/usa_config.py
 +++ b/bedrock/utils/config/usa_config.py
      snapshot_version_or_git_sha: ta.Literal[
          'v0',
          '1bda811e0169436ae90fd356fbef512ce7518ccb',  # v0.1
-         '2ebb51f7190c3a62b5d8b2420bff9b20f57282fc',  # v0.2
-         '9fe22d9afdfdb6806397b2356eb3cf4c4c346744',  # v0.2 2025_usa_cornerstone_fbs_schema
-+        '<new_sha>',                                  # v0.3.0 2025_usa_cornerstone_full_model
+         '2ebb51f7190c3a62b5d8b2420bff9b20f57282fc',  # test
+         '9fe22d9afdfdb6806397b2356eb3cf4c4c346744',  # test: snapshot from 2025_usa_cornerstone_fbs_schema
+         '7372464249c434c9bebb172c065a4d0e3702176e',  # v0.2 (current .SNAPSHOT_KEY)
++        '<new_sha>',                                  # v0.3.0
      ] = 'v0'
 ```
 
@@ -227,7 +238,7 @@ If a bad snapshot accidentally got uploaded under a SHA you want to keep, you ca
 
 The `generate_snapshots.py` script supports `--adhoc`, which uploads to `gs://cornerstone-default/snapshots/<sha>/adhoc/` instead of the top-level SHA folder. Use this for:
 
-- Snapshotting an ablation/per-flag config (anything other than `2025_usa_cornerstone_full_model`)
+- Snapshotting an atomic config (anything other than `2025_usa_cornerstone_full_model`)
 - Local experimentation where you don't want to pollute the canonical snapshot prefix
 
 Adhoc snapshots are never wired into `.SNAPSHOT_KEY` or `releases.py`. They exist for ad-hoc diagnostic comparisons only.
@@ -240,7 +251,7 @@ Adhoc snapshots are never wired into `.SNAPSHOT_KEY` or `releases.py`. They exis
 | [`generate_snapshots.py`](generate_snapshots.py) | CLI that builds the 10 parquet snapshots and uploads to GCS |
 | [`loader.py`](loader.py) | `load_current_snapshot`, `load_configured_snapshot`, GCS download helpers |
 | [`names.py`](names.py) | `SnapshotName` literal type and `SNAPSHOT_NAMES` list |
-| [`releases.py`](releases.py) | Named constants for released snapshot SHAs |
+| [`releases.py`](releases.py) | Reference-only release label → snapshot SHA map (not imported by code) |
 | [`../config/usa_config.py`](../config/usa_config.py) | `USAConfig.snapshot_version_or_git_sha` `Literal` of allowed baseline SHAs |
 | [`../../../.github/workflows/generate_snapshots.yml`](../../../.github/workflows/generate_snapshots.yml) | `workflow_dispatch` CI that runs `generate_snapshots.py` |
 | [`../../../.github/workflows/test_integration.yml`](../../../.github/workflows/test_integration.yml) | Scheduled CI that diffs current pipeline output against `.SNAPSHOT_KEY` |

--- a/bedrock/utils/snapshots/generate_snapshots.py
+++ b/bedrock/utils/snapshots/generate_snapshots.py
@@ -126,7 +126,9 @@ def upload_snapshots(
 
 
 @click.command(help='Generate snapshots for bedrock EEIO model')
-@click.option('--config_name', required=True, type=str, default='v8_ceda_2025_usa')
+@click.option(
+    '--config_name', required=True, type=str, default='2025_usa_cornerstone_full_model'
+)
 @click.option('--adhoc', is_flag=True, help='Upload to adhoc directory')
 @click.option(
     '--snapshot_prefix_override',

--- a/bedrock/utils/snapshots/releases.py
+++ b/bedrock/utils/snapshots/releases.py
@@ -1,3 +1,22 @@
-v0 = "v0_sha_1234567890"
-v0_1 = "1bda811e0169436ae90fd356fbef512ce7518ccb"
-v0_2 = "2ebb51f7190c3a62b5d8b2420bff9b20f57282fc"
+"""Reference-only map of release labels to snapshot SHAs.
+
+Not imported by runtime code. Integration tests use ``.SNAPSHOT_KEY``;
+diagnostics resolve baselines via ``USAConfig.snapshot_version_or_git_sha``.
+
+Each entry's ``# config:`` comment is the stem passed to
+``generate_snapshots --config_name`` when that snapshot was built. Confirm
+via the `generate_snapshots workflow
+<https://github.com/cornerstone-data/bedrock/actions/workflows/generate_snapshots.yml>`_.
+
+Update the current release entry in Phase A when ``.SNAPSHOT_KEY`` changes.
+Patch releases that leave ``.SNAPSHOT_KEY`` unchanged do not add entries here.
+"""
+
+# Release snapshots (GCS prefix or git SHA)
+v0 = "v0"  # config: legacy GCS prefix (pre git-SHA snapshots)
+v0_1 = "1bda811e0169436ae90fd356fbef512ce7518ccb"  # config: 2025_usa_cornerstone_full_model
+v0_2 = "7372464249c434c9bebb172c065a4d0e3702176e"  # config: 2025_usa_cornerstone_full_model; matches .SNAPSHOT_KEY
+
+# Intermediate snapshot SHAs (atomic configs, test fixtures — not release labels)
+TEST_config_default = "2ebb51f7190c3a62b5d8b2420bff9b20f57282fc"  # config: 2025_usa_cornerstone_full_model
+TEST_fbs_schema = "9fe22d9afdfdb6806397b2356eb3cf4c4c346744"  # config: 2025_usa_cornerstone_fbs_schema

--- a/bedrock/utils/validation/generate_diagnostics.py
+++ b/bedrock/utils/validation/generate_diagnostics.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
     '--config_name',
     required=True,
     type=str,
-    default='v8_ceda_2025_usa',
+    default='2025_usa_cornerstone_full_model',
 )
 @click.option('--git_branch', default=None, type=str, help='Override git branch name')
 @click.option('--pr_url', default=None, type=str, help='Override PR URL')


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

Adds a README for cutting snapshots and releases so we have a consistent process when pipeline outputs change.

**New doc:** [`bedrock/utils/snapshots/README.md`](https://github.com/cornerstone-data/bedrock/blob/by_cleanup_snapshots/bedrock/utils/snapshots/README.md) (rendered on this branch). Replaces the previous one-line stub and is linked from the root README.

Key proposals captured in the doc:

- **Snapshot SHA vs. release tag SHA are independent.** `.SNAPSHOT_KEY` pins the SHA where the pipeline produced its outputs; the `vX.Y.Z` git tag points at whatever head of `main` we decide to ship (may include the snapshot bump *plus* docs / polish / non-output PRs).
- **Two-phase workflow.** *Phase A* (snapshot regeneration: methodology PR → generate_snapshots CI → bump PR for `.SNAPSHOT_KEY` + `USAConfig` Literal) is decoupled from *Phase B* (cutting the release: choose patch vs. minor based on whether `.SNAPSHOT_KEY` changed, tag `main`, create a GitHub Release, Slack announce).
- **Mechanical semver.** `patch` = `.SNAPSHOT_KEY` unchanged from previous tag; `minor` = `.SNAPSHOT_KEY` changed (any cause). Reviewers can verify the bump category with `git diff <prev_tag>..<new_tag> -- bedrock/utils/snapshots/.SNAPSHOT_KEY`. This means you can cut a release that contains only docs/polish, no snapshot regeneration needed, and the patch/minor distinction handles it cleanly.
- **Phase A always human-initiated.** Integration test failures aren't auto-resolved by bumping `.SNAPSHOT_KEY`; the doc has an explicit "investigate before bumping" decision flow.
- `releases.py` converted to a reference only manifest of snapshots with human readable labels.

**Incidental changes** noticed while writing the doc:

- CI workflow `config_name` defaults updated from the stale `v8_ceda_2025_usa` → `2025_usa_cornerstone_full_model` (the canonical config per the project README) in:
  - `.github/workflows/generate_snapshots.yml` (input default + bash fallback)
  - `.github/workflows/generate_diagnostics.yml` (input default)
- Matching CLI defaults flipped in `bedrock/utils/snapshots/generate_snapshots.py` and `bedrock/utils/validation/generate_diagnostics.py` so local invocations match CI.

<!-- follow-ups planned? -->

Follow-ups (not in this PR; tracked separately):

- Reconcile the existing `v0.1` / `v0.2` git tags with the SHAs actually used by the system (the `v0.2` tag points at a non-snapshot commit `26136e7`, while production configs and tests use `9fe22d9a` and `2ebb51f7`).

## Testing

Not applicable.