### PR TITLE
prepares scaffolding for USEEIO style excel output for a model

### DIFF
--- a/bedrock/publish/README.md
+++ b/bedrock/publish/README.md
@@ -1,3 +1,105 @@
 # publish
 
-This folder contains modules and scripts for pushing datasets to downstream systems. It enables the export and publication of processed data to external destinations or services, supporting integration with broader data workflows.
+Publishing pipeline for the bedrock EEIO model. Exports the model to
+shareable file formats, mirroring the shape of `useeior`'s
+`writeModeltoXLSX` output.
+
+## Status
+
+- **XLSX**: implemented for `B`, `C` (trivial row-summer; see divergence
+  note below), `D` (`= C @ B`), `q`, plus metadata sheets
+  (`commodities_meta`, `industries_meta`, `final_demand_meta`,
+  `value_added_meta`, `config_summary`, `model_info`).
+- **Supply-chain factors**: not implemented. Upstream R
+  counterpart:
+  [cornerstone-data/supply-chain-factors](https://github.com/cornerstone-data/supply-chain-factors).
+- **Additional matrices** (`V`, `U`, `U_d`, `A`, `A_d`, `L`, `L_d`,
+  `M`, `M_d`, `N`, `N_d`, `Rho`, `Phi`, `Tau`, `x`): registered as
+  placeholders in `excel/writer.py` (`getter = lambda: None`), so their
+  sheets are simply omitted. Each entry carries an inline `TODO`
+  pointing at the missing derivation.
+- **Import-emissions matrices** (`A_m`, `M_m`, `N_m`): require real
+  import emission factors (`B_imp`), which bedrock does not yet
+  produce. Blocked on `B_imp`.
+
+## Known divergence from useeior (B units)
+
+In `useeior`, `B` is in `kg of physical gas / USD` and a real GWP
+characterization matrix `C` (indicator x flow) produces `D = C @ B` in
+`kgCO2e / USD`.
+
+In bedrock (Cornerstone), `B` is **already in `kgCO2e / USD`**: AR6 GWPs
+are applied upstream at FBS aggregation in
+`bedrock.transform.allocation.derived`. The 7 rows are aggregated GHG
+groups (`CO2`, `CH4`, `N2O`, `HFCs`, `PFCs`, `SF6`, `NF3`).
+
+Consequences for the published workbook:
+
+1. **`B` sheets are not numerically comparable** between bedrock and
+   useeior. Row dimensions differ (7 vs ~2000), and bedrock values are
+   per-row GWP-weighted CO2e while useeior values are physical mass.
+2. **The bedrock `C` and `D` sheets are emitted for useeior-shape
+   parity only.** `C` is a trivial `(1, 7)` row-summer (single
+   `Greenhouse Gases` indicator, all ones); `D = C @ B` reduces to
+   `B.sum(axis=0)`. They do *not* carry GWP characterization
+   information.
+3. The `model_info` sheet documents this with `b_units`,
+   `b_characterized`, `gwp_set`, `c_kind`, and
+   `divergence_from_useeior` fields so downstream consumers cannot
+   silently misinterpret the workbook.
+
+Resolution paths (TODO):
+
+- **A.** Switch bedrock `B` to physical-mass units and ship a real GWP
+  `C` from `bedrock.utils.emissions.gwp.GWP100_AR6_CEDA`.
+- **B.** Emit a `B_phys` companion sheet alongside the CO2e `B`, with a
+  real GWP `C` keyed to `B_phys`.
+
+Until one of those lands, `useeior_D[Greenhouse Gases]` is the
+like-for-like comparable quantity for `bedrock_B.sum(axis=0)`.
+
+## Recommended publish workflow
+
+1. Generate parquet snapshots on `main` for the target config:
+
+   ```
+   uv run python -m bedrock.utils.snapshots.generate_snapshots --config_name <cfg>
+   ```
+
+2. **(Pre-flight)** Confirm bedrock-at-HEAD reproduces the snapshot:
+
+   ```
+   uv run pytest -m eeio_integration bedrock/publish/__tests__/test_excel_vs_snapshot.py
+   ```
+
+   This step is logically independent of step 3 -- the test runs its own
+   `write_model_to_xlsx` to a tmp directory and compares against the
+   parquet snapshot.
+
+   **The test is hard-coded to `2025_usa_cornerstone_full_model`.** If
+   `<cfg>` differs, this step does NOT validate the artifact you are
+   about to publish. (TODO: parameterize the test to validate arbitrary
+   configs; tracked in
+   [bedrock/publish/__tests__/test_excel_vs_snapshot.py](__tests__/test_excel_vs_snapshot.py).)
+
+   **Skippable when** all three hold:
+   - `<cfg>` is `2025_usa_cornerstone_full_model`, AND
+   - you are publishing from a `main` SHA covered by the most recent
+     green
+     [`test_integration.yml`](../../.github/workflows/test_integration.yml)
+     run (cron: 7am/4pm PT weekdays), AND
+   - no derivation-affecting code has merged since that CI run.
+
+   On a feature branch, after a fresh merge, or for any non-default
+   `<cfg>`, run it locally.
+
+3. Run the publish CLI for the same config:
+
+   ```
+   uv run python -m bedrock.publish.excel.cli --config_name <cfg>
+   ```
+
+   This writes `bedrock/publish/output/<git_sha>/<cfg>.xlsx`.
+
+4. Inspect the workbook (especially `model_info`). Manual distribution
+   for now; GCS upload is a TODO.

--- a/bedrock/publish/__tests__/_helpers.py
+++ b/bedrock/publish/__tests__/_helpers.py
@@ -1,0 +1,87 @@
+"""Shared helpers for `bedrock/publish/__tests__/`.
+
+The publish pipeline calls into a stack of `@functools.cache`-d
+`derive_*_usa()` functions and a process-wide `USAConfig`. Integration
+tests must reset both between configs or stale state leaks between
+tests. Mirrors the pattern in
+`bedrock/transform/eeio/__tests__/test_waste_disagg_pipeline_integration.py`.
+
+`setup_config` also flips `bedrock.utils.config.common.download_fba_on_api_error`
+so eeio_integration tests work in environments without USDA FBA API
+credentials (FBA is fetched from the GCS cache instead).
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import bedrock.utils.config.common as common
+from bedrock.transform.eeio.derived import (
+    derive_Aq_usa,
+    derive_B_usa_non_finetuned,
+    derive_C_usa,
+    derive_D_usa,
+    derive_y_for_national_accounting_balance_usa,
+)
+from bedrock.transform.eeio.derived_cornerstone import (
+    derive_cornerstone_Aq,
+    derive_cornerstone_Aq_scaled,
+    derive_cornerstone_B_non_finetuned,
+    derive_cornerstone_q,
+    derive_cornerstone_U_set,
+    derive_cornerstone_U_with_negatives,
+    derive_cornerstone_V,
+    derive_cornerstone_VA,
+    derive_cornerstone_Vnorm_scrap_corrected,
+    derive_cornerstone_x,
+    derive_cornerstone_y_nab,
+    derive_cornerstone_Ytot_matrix_set,
+)
+from bedrock.utils.config.usa_config import (
+    reset_usa_config,
+    set_global_usa_config,
+)
+
+CACHED_FUNCTIONS: list[Callable[..., object]] = [
+    derive_B_usa_non_finetuned,
+    derive_C_usa,
+    derive_D_usa,
+    derive_Aq_usa,
+    derive_y_for_national_accounting_balance_usa,
+    derive_cornerstone_V,
+    derive_cornerstone_x,
+    derive_cornerstone_q,
+    derive_cornerstone_Vnorm_scrap_corrected,
+    derive_cornerstone_U_with_negatives,
+    derive_cornerstone_U_set,
+    derive_cornerstone_Ytot_matrix_set,
+    derive_cornerstone_VA,
+    derive_cornerstone_Aq,
+    derive_cornerstone_Aq_scaled,
+    derive_cornerstone_B_non_finetuned,
+    derive_cornerstone_y_nab,
+]
+
+
+def clear_all_caches() -> None:
+    for fn in CACHED_FUNCTIONS:
+        if hasattr(fn, 'cache_clear'):
+            fn.cache_clear()
+
+
+def setup_config(config_name: str) -> None:
+    """Reset config + caches, then set a fresh global config.
+
+    Also enables FBA-on-API-error fallback so derivations can pull
+    FBA from the GCS cache when USDA API credentials are absent.
+    """
+    clear_all_caches()
+    reset_usa_config(should_reset_env_var=True)
+    set_global_usa_config(config_name)
+    common.download_fba_on_api_error = True
+
+
+def teardown() -> None:
+    clear_all_caches()
+    reset_usa_config(should_reset_env_var=True)
+    common.download_fba_on_api_error = False

--- a/bedrock/publish/__tests__/test_excel_vs_snapshot.py
+++ b/bedrock/publish/__tests__/test_excel_vs_snapshot.py
@@ -1,0 +1,66 @@
+"""eeio_integration: bedrock-published XLSX `B` sheet matches the parquet snapshot.
+
+Reproducibility guard: when this test passes we know the bedrock workbook
+written at HEAD reproduces the values of the pinned
+`B_USA_non_finetuned` parquet snapshot from `.SNAPSHOT_KEY`. Divergence
+implies either (a) bedrock derivation drift, or (b) the snapshot is stale
+and needs regenerating via `bedrock.utils.snapshots.generate_snapshots`.
+
+TODO: `_DEFAULT_CONFIG` is hard-coded to `2025_usa_cornerstone_full_model`,
+so this guard only covers that config. Parameterize via env var or pytest
+parameter so arbitrary configs published via `bedrock.publish.excel.cli` can be
+validated against their corresponding snapshots before upload.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from bedrock.publish.__tests__._helpers import setup_config, teardown
+from bedrock.publish.excel.writer import _LOCATION, write_model_to_xlsx
+from bedrock.utils.snapshots.loader import load_current_snapshot
+
+_DEFAULT_CONFIG = '2025_usa_cornerstone_full_model'
+
+
+def _strip_loc_suffix(values: pd.Index) -> pd.Index:
+    suffix = f'/{_LOCATION}'
+    return pd.Index(
+        [str(v)[: -len(suffix)] if str(v).endswith(suffix) else str(v) for v in values],
+        name=values.name,
+    )
+
+
+@pytest.mark.eeio_integration
+def test_published_B_matches_snapshot(tmp_path: Path) -> None:
+    """Compare bedrock XLSX `B` sheet vs `B_USA_non_finetuned` parquet snapshot."""
+    setup_config(_DEFAULT_CONFIG)
+    try:
+        out = os.fspath(tmp_path / 'model.xlsx')
+        write_model_to_xlsx(out, config_name=_DEFAULT_CONFIG)
+
+        B_xlsx = pd.read_excel(out, sheet_name='B', index_col=0, engine='openpyxl')
+        B_xlsx.columns = _strip_loc_suffix(B_xlsx.columns)
+
+        B_snapshot = load_current_snapshot('B_USA_non_finetuned')
+    finally:
+        teardown()
+
+    assert list(B_xlsx.index) == list(B_snapshot.index), (
+        f'ghg index mismatch: xlsx={list(B_xlsx.index)} '
+        f'snapshot={list(B_snapshot.index)}'
+    )
+    assert list(B_xlsx.columns) == list(
+        B_snapshot.columns
+    ), 'sector column mismatch (after stripping /US suffix)'
+    np.testing.assert_allclose(
+        B_xlsx.values.astype(float),
+        B_snapshot.values.astype(float),
+        rtol=1e-9,
+        atol=1e-12,
+    )

--- a/bedrock/publish/__tests__/test_excel_writer.py
+++ b/bedrock/publish/__tests__/test_excel_writer.py
@@ -1,0 +1,134 @@
+"""Unit tests for `bedrock.publish.excel.writer`.
+
+These tests monkeypatch the registry-building function with small
+synthetic getters so we can exercise the writer's behavior (skip-if-None,
+empty-data-sheets guard, location-suffix application, metadata content,
+round-trip correctness) without standing up the real EEIO pipeline.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from bedrock.publish.excel import writer as writer_module
+
+
+def _empty_registry(config_name: str) -> list[writer_module.SheetSpec]:
+    """All sheets resolve to None -- exercises the empty-data-sheets guard."""
+    return [
+        writer_module.SheetSpec('B', lambda: None),
+        writer_module.SheetSpec('C', lambda: None),
+        writer_module.SheetSpec(
+            'model_info',
+            lambda: pd.DataFrame([{'field': 'config_name', 'value': config_name}]),
+        ),
+    ]
+
+
+def _synthetic_registry(config_name: str) -> list[writer_module.SheetSpec]:
+    """Two sectors and three GHGs; covers DataFrame and Series paths."""
+    sector_idx = pd.Index(['100000', '200000'], name='sector')
+    ghg_idx = pd.Index(['CO2', 'CH4', 'N2O'], name='ghg')
+    indicator_idx = pd.Index(['Greenhouse Gases'], name='indicator')
+
+    B = pd.DataFrame(
+        [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]],
+        index=ghg_idx,
+        columns=sector_idx,
+    )
+    C = pd.DataFrame([[1.0, 1.0, 1.0]], index=indicator_idx, columns=ghg_idx)
+    q = pd.Series([100.0, 200.0], index=sector_idx, name='q')
+
+    return [
+        writer_module.SheetSpec('B', lambda: B),
+        writer_module.SheetSpec('C', lambda: C),
+        writer_module.SheetSpec('q', lambda: q),
+        writer_module.SheetSpec('A', lambda: None),
+        writer_module.SheetSpec(
+            'model_info',
+            lambda: pd.DataFrame(
+                [
+                    {'field': 'config_name', 'value': config_name},
+                    {'field': 'b_units', 'value': 'kg CO2e / USD'},
+                ]
+            ),
+        ),
+    ]
+
+
+def test_raises_when_no_data_sheets(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    out = os.fspath(tmp_path / 'empty.xlsx')
+    monkeypatch.setattr(writer_module, '_build_matrix_registry', _empty_registry)
+    with pytest.raises(RuntimeError, match='no data sheets'):
+        writer_module.write_model_to_xlsx(out, config_name='dummy')
+    assert not os.path.exists(
+        out
+    ), 'workbook should not be written when no data sheets materialize'
+
+
+def test_writes_only_materialized_sheets(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    out = os.fspath(tmp_path / 'model.xlsx')
+    monkeypatch.setattr(writer_module, '_build_matrix_registry', _synthetic_registry)
+    writer_module.write_model_to_xlsx(out, config_name='dummy')
+
+    book = pd.read_excel(out, sheet_name=None, index_col=0, engine='openpyxl')
+    assert set(book) == {
+        'B',
+        'C',
+        'q',
+        'model_info',
+    }, f'expected B/C/q/model_info; got {sorted(book)}'
+
+
+def test_loc_suffix_applied_only_to_sector_axis(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    out = os.fspath(tmp_path / 'model.xlsx')
+    monkeypatch.setattr(writer_module, '_build_matrix_registry', _synthetic_registry)
+    writer_module.write_model_to_xlsx(out, config_name='dummy')
+
+    book = pd.read_excel(out, sheet_name=None, index_col=0, engine='openpyxl')
+
+    B = book['B']
+    assert list(B.index) == [
+        'CO2',
+        'CH4',
+        'N2O',
+    ], f'B ghg index should be unsuffixed; got {list(B.index)}'
+    assert list(B.columns) == [
+        '100000/US',
+        '200000/US',
+    ], f'B sector columns should carry /US suffix; got {list(B.columns)}'
+
+    C = book['C']
+    assert list(C.index) == ['Greenhouse Gases']
+    assert list(C.columns) == ['CO2', 'CH4', 'N2O']
+
+    q = book['q']
+    assert list(q.index) == ['100000/US', '200000/US']
+
+
+def test_round_trip_values_preserved(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    out = os.fspath(tmp_path / 'model.xlsx')
+    monkeypatch.setattr(writer_module, '_build_matrix_registry', _synthetic_registry)
+    writer_module.write_model_to_xlsx(out, config_name='dummy')
+
+    book = pd.read_excel(out, sheet_name=None, index_col=0, engine='openpyxl')
+    B = book['B']
+    assert B.shape == (3, 2)
+    assert B.loc['CO2', '100000/US'] == pytest.approx(1.0)
+    assert B.loc['N2O', '200000/US'] == pytest.approx(6.0)
+
+    q = book['q']
+    assert q.shape == (2, 1)
+    assert q.loc['100000/US', 'q'] == pytest.approx(100.0)

--- a/bedrock/publish/excel/__init__.py
+++ b/bedrock/publish/excel/__init__.py
@@ -1,0 +1,3 @@
+from bedrock.publish.excel.writer import write_model_to_xlsx
+
+__all__ = ['write_model_to_xlsx']

--- a/bedrock/publish/excel/cli.py
+++ b/bedrock/publish/excel/cli.py
@@ -1,0 +1,83 @@
+"""XLSX publish CLI: build the bedrock model workbook locally.
+
+Invoke as:
+
+    uv run python -m bedrock.publish.excel.cli --config_name <cfg>
+
+GCS upload is TODO. Other formats (e.g. supply-chain factors at
+https://github.com/cornerstone-data/supply-chain-factors) will have
+their own `bedrock.publish.<format>.cli` entry points.
+"""
+
+# ruff: noqa: PLC0415
+from __future__ import annotations
+
+import logging
+import os
+import time
+
+import click
+
+import bedrock.utils.config.common as common
+from bedrock.utils.config.settings import GIT_HASH_LONG
+from bedrock.utils.config.usa_config import set_global_usa_config
+
+logger = logging.getLogger(__name__)
+
+# bedrock/publish/excel/cli.py -> bedrock/publish/
+_PUBLISH_PKG_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_DEFAULT_OUTPUT_DIR = os.path.join(_PUBLISH_PKG_DIR, 'output')
+
+
+def _publish_prefix() -> str:
+    if not GIT_HASH_LONG:
+        raise RuntimeError('GIT_HASH_LONG is not set')
+    return GIT_HASH_LONG
+
+
+def _default_output_dir() -> str:
+    return os.path.join(_DEFAULT_OUTPUT_DIR, _publish_prefix())
+
+
+def _publish_xlsx(
+    config_name: str,
+    output_dir: str | None,
+) -> str:
+    from bedrock.publish.excel import write_model_to_xlsx
+
+    local_dir = output_dir or _default_output_dir()
+    os.makedirs(local_dir, exist_ok=True)
+    local_path = os.path.join(local_dir, f'{config_name}.xlsx')
+
+    logger.info('publish: building XLSX for config=%s -> %s', config_name, local_path)
+    write_model_to_xlsx(local_path, config_name=config_name)
+    return local_path
+
+
+@click.command(help='Publish the bedrock EEIO model as a local XLSX workbook.')
+@click.option('--config_name', required=True, type=str)
+@click.option(
+    '--output_dir',
+    default=None,
+    type=str,
+    help='Local directory for the workbook. The file is always named '
+    '<config_name>.xlsx. Defaults to bedrock/publish/output/<git_sha>/.',
+)
+def publish(config_name: str, output_dir: str | None) -> None:
+    """Run the XLSX publish pipeline."""
+    t0 = time.time()
+    set_global_usa_config(config_name)
+    common.download_fba_on_api_error = True
+
+    local_path = _publish_xlsx(config_name=config_name, output_dir=output_dir)
+
+    logger.info(
+        '[TIMING] publish completed in %.1fs (local=%s)',
+        time.time() - t0,
+        local_path,
+    )
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s %(name)s %(message)s')
+    publish()

--- a/bedrock/publish/excel/writer.py
+++ b/bedrock/publish/excel/writer.py
@@ -1,0 +1,400 @@
+"""Excel publisher for the bedrock EEIO model.
+
+Mirrors the shape of `useeior::writeModeltoXLSX` -- one workbook with one
+sheet per model object plus metadata sheets. Each registry entry pairs a
+sheet name with a getter callable that returns the object to write; if a
+getter returns `None`, the sheet is omitted (matches `WriteModel.R` "skip
+if NULL" behavior).
+
+KNOWN DIVERGENCE FROM USEEIOR
+-----------------------------
+Bedrock `B` is in `kgCO2e / USD` (AR6 GWPs already baked in upstream at
+FBS aggregation in `bedrock.transform.allocation.derived`). Useeior `B`
+is in physical `kg gas / USD`, with a real GWP `C` matrix applying
+characterization.
+
+Practical consequences:
+  * The bedrock `B` sheet is NOT numerically comparable to the useeior
+    `B` sheet -- they have different row dimensions AND different
+    per-row units.
+  * The bedrock `C` and `D` sheets are emitted for sheet-name parity
+    only. `C` is a trivial row-summer (single "Greenhouse Gases"
+    indicator over the 7 GHGs, all values = 1.0) and `D = C @ B`
+    reduces to `B.sum(axis=0)`. See
+    `bedrock/utils/emissions/characterization.py` for resolution paths.
+
+The `model_info` sheet carries `b_units`, `b_characterized`, `gwp_set`,
+`c_kind`, and `divergence_from_useeior` fields so downstream consumers
+cannot mistake bedrock B for useeior B.
+
+Location suffix
+---------------
+Following useeior's convention, BEA-style numeric codes (e.g. `211000`)
+are emitted with a `/US` location suffix so Excel does not coerce them
+to integers (and so the codes are unambiguous in MRIO settings).
+`_with_loc_suffix` is applied automatically to any axis whose
+`Index.name == 'sector'`.
+"""
+
+# ruff: noqa: PLC0415
+from __future__ import annotations
+
+import datetime
+import logging
+import os
+from collections.abc import Callable, Iterable
+from typing import NamedTuple
+
+import pandas as pd
+
+from bedrock.utils.config.settings import GIT_HASH_LONG
+from bedrock.utils.config.usa_config import get_usa_config
+
+logger = logging.getLogger(__name__)
+
+# Useeior-style location suffix. Keeps numeric BEA codes string-typed in
+# Excel and matches useeior workbook conventions.
+_LOCATION: str = 'US'
+
+
+class SheetSpec(NamedTuple):
+    name: str
+    getter: Callable[[], pd.DataFrame | pd.Series | None]
+
+
+def _with_loc_suffix(idx: pd.Index) -> pd.Index:
+    """Append `/US` to a sector-named axis; otherwise return unchanged.
+
+    Detection by `Index.name` keeps non-sector axes (e.g. `ghg`,
+    `indicator`) untouched.
+    """
+    if idx.name != 'sector':
+        return idx
+    out = [f'{str(v)}/{_LOCATION}' for v in idx]
+    return pd.Index(out, name=idx.name)
+
+
+def _apply_loc_suffix(obj: pd.DataFrame | pd.Series) -> pd.DataFrame | pd.Series:
+    out = obj.copy()
+    if isinstance(out, pd.DataFrame):
+        out.index = _with_loc_suffix(out.index)
+        out.columns = _with_loc_suffix(out.columns)
+    else:
+        out.index = _with_loc_suffix(out.index)
+    return out
+
+
+def _build_config_summary_df(config_name: str) -> pd.DataFrame:
+    """USAConfig -> long-form (config_field, value) DataFrame."""
+    return get_usa_config().to_dataframe(config_name=config_name)
+
+
+def _build_model_info_df(config_name: str) -> pd.DataFrame:
+    """Workbook-level metadata, including the bedrock-vs-useeior divergence flags."""
+    cfg = get_usa_config()
+    rows: list[dict[str, object]] = [
+        {'field': 'config_name', 'value': config_name},
+        {'field': 'bedrock_git_sha', 'value': GIT_HASH_LONG or 'unknown'},
+        {
+            'field': 'published_at',
+            'value': datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        },
+        {'field': 'model_base_year', 'value': cfg.model_base_year},
+        {'field': 'usa_io_data_year', 'value': cfg.usa_io_data_year},
+        {'field': 'usa_ghg_data_year', 'value': cfg.usa_ghg_data_year},
+        {'field': 'ipcc_ar_version', 'value': cfg.ipcc_ar_version},
+        {'field': 'location_suffix', 'value': _LOCATION},
+        # Divergence-from-useeior fields. DO NOT REMOVE without resolving the
+        # underlying semantics gap -- see writer module docstring and
+        # bedrock/utils/emissions/characterization.py.
+        {'field': 'b_units', 'value': 'kg CO2e / USD'},
+        {'field': 'b_characterized', 'value': True},
+        {'field': 'gwp_set', 'value': 'AR6'},
+        {
+            'field': 'c_kind',
+            'value': (
+                'trivial_row_summer (bedrock B is pre-characterized; '
+                'useeior-shape parity only)'
+            ),
+        },
+        {
+            'field': 'divergence_from_useeior',
+            'value': (
+                'B is in CO2e (pre-characterized); useeior B is in physical '
+                'kg of gas. Resolve before treating bedrock XLSX as a useeior '
+                'drop-in. See bedrock/utils/emissions/characterization.py.'
+            ),
+        },
+    ]
+    return pd.DataFrame(rows)
+
+
+def _build_commodities_meta_df() -> pd.DataFrame:
+    from bedrock.utils.taxonomy.cornerstone.commodities import (
+        COMMODITIES,
+        COMMODITY_DESC,
+    )
+
+    return pd.DataFrame(
+        [
+            {
+                'Code': code,
+                'Code_Loc': f'{code}/{_LOCATION}',
+                'Location': _LOCATION,
+                'Name': COMMODITY_DESC[code],
+            }
+            for code in COMMODITIES
+        ]
+    )
+
+
+def _build_industries_meta_df() -> pd.DataFrame:
+    from bedrock.utils.taxonomy.cornerstone.industries import (
+        INDUSTRIES,
+        INDUSTRY_DESC,
+    )
+
+    return pd.DataFrame(
+        [
+            {
+                'Code': code,
+                'Code_Loc': f'{code}/{_LOCATION}',
+                'Location': _LOCATION,
+                'Name': INDUSTRY_DESC[code],
+            }
+            for code in INDUSTRIES
+        ]
+    )
+
+
+def _build_final_demand_meta_df() -> pd.DataFrame:
+    from bedrock.utils.taxonomy.cornerstone.final_demand import (
+        FINAL_DEMAND_DESC,
+        FINAL_DEMANDS,
+    )
+
+    return pd.DataFrame(
+        [{'Code': code, 'Name': FINAL_DEMAND_DESC[code]} for code in FINAL_DEMANDS]
+    )
+
+
+def _build_value_added_meta_df() -> pd.DataFrame:
+    from bedrock.utils.taxonomy.cornerstone.value_added import (
+        VALUE_ADDED_DESC,
+        VALUE_ADDEDS,
+    )
+
+    return pd.DataFrame(
+        [{'Code': code, 'Name': VALUE_ADDED_DESC[code]} for code in VALUE_ADDEDS]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Matrix registry
+# ---------------------------------------------------------------------------
+#
+# Sheet ordering mirrors useeior's `writeModeltoXLSX` (see `WriteModel.R`):
+#
+#   1. Matrices in the order declared in useeior's `matrices` vector:
+#        V, U, U_d, A, A_d, A_m, B, C, D, L, L_d,
+#        M, M_d, M_m, N, N_d, N_m, Rho, Phi, Tau
+#   2. q, x (commodity and industry output)
+#   3. demand vectors (one sheet per named demand vector; not yet wired)
+#   4. metadata block: demands, flows, indicators, commodities_meta /
+#      industries_meta, final_demand_meta, value_added_meta, SectorCrosswalk
+#   5. bedrock-only extensions: config_summary, model_info
+#
+# Useeior writes only one of commodities_meta / industries_meta depending
+# on `CommodityorIndustryType`. Bedrock has both taxonomies and writes
+# both. config_summary and model_info are bedrock-only.
+#
+# Real getters: B, C, D, q, and metadata sheets noted below. Other
+# entries are `lambda: None` placeholders; their sheets are omitted from
+# the workbook ("skip if NULL", matching useeior `WriteModel.R`).
+# Resolving each placeholder requires either a config-aware
+# `derive_*_usa()` wrapper or, for the `*_m` family, a real `B_imp`
+# (import emission factors) which bedrock does not yet produce.
+# Concrete TODOs are inlined next to each placeholder.
+
+
+def _get_B() -> pd.DataFrame | None:
+    from bedrock.transform.eeio.derived import derive_B_usa_non_finetuned
+
+    return derive_B_usa_non_finetuned()
+
+
+def _get_C() -> pd.DataFrame | None:
+    from bedrock.transform.eeio.derived import derive_C_usa
+
+    return derive_C_usa()
+
+
+def _get_D() -> pd.DataFrame | None:
+    from bedrock.transform.eeio.derived import derive_D_usa
+
+    return derive_D_usa()
+
+
+def _get_q() -> pd.Series | None:
+    from bedrock.transform.eeio.derived import derive_Aq_usa
+
+    q = derive_Aq_usa().scaled_q
+    return pd.Series(q, name='q')
+
+
+def _build_matrix_registry(config_name: str) -> list[SheetSpec]:
+    return [
+        # --- useeior matrices (order matches `matrices` in WriteModel.R) ---
+        # TODO: derive_V_usa() wrapping derive_cornerstone_V().
+        SheetSpec('V', lambda: None),
+        # TODO: derive_U_usa() wrapping derive_cornerstone_U_set().Udom + Uimp.
+        SheetSpec('U', lambda: None),
+        SheetSpec('U_d', lambda: None),
+        # TODO: derive_A_usa() wrapping derive_Aq_usa().Adom + Aimp.
+        SheetSpec('A', lambda: None),
+        SheetSpec('A_d', lambda: None),
+        # A_m requires real import emission factors (B_imp); not yet in bedrock.
+        SheetSpec('A_m', lambda: None),
+        SheetSpec('B', _get_B),
+        SheetSpec('C', _get_C),
+        SheetSpec('D', _get_D),
+        # TODO: derive_L_usa() = (I - A)^-1; cheap once derive_A_usa() exists.
+        SheetSpec('L', lambda: None),
+        SheetSpec('L_d', lambda: None),
+        # TODO: derive_M_usa() = B @ L; cheap once L exists.
+        SheetSpec('M', lambda: None),
+        SheetSpec('M_d', lambda: None),
+        SheetSpec('M_m', lambda: None),  # requires B_imp
+        # TODO: derive_N_usa() = C @ M = M.sum(axis=0) given bedrock semantics.
+        SheetSpec('N', lambda: None),
+        SheetSpec('N_d', lambda: None),
+        SheetSpec('N_m', lambda: None),  # requires B_imp
+        SheetSpec('Rho', lambda: None),
+        SheetSpec('Phi', lambda: None),
+        SheetSpec('Tau', lambda: None),
+        # --- outputs (useeior writes these after the matrices block) ---
+        SheetSpec('q', _get_q),
+        SheetSpec('x', lambda: None),  # TODO: derive_x_usa()
+        # --- metadata block (useeior order: demands, flows, indicators,
+        #     <sectors>_meta, final_demand_meta, value_added_meta,
+        #     SectorCrosswalk) ---
+        # TODO: demands, flows, indicators, SectorCrosswalk getters once
+        # we have config-aware accessors for those tables.
+        SheetSpec('demands', lambda: None),
+        SheetSpec('flows', lambda: None),
+        SheetSpec('indicators', lambda: None),
+        SheetSpec('commodities_meta', lambda: _build_commodities_meta_df()),
+        SheetSpec('industries_meta', lambda: _build_industries_meta_df()),
+        SheetSpec(
+            'final_demand_meta',
+            lambda: _build_final_demand_meta_df(),
+        ),
+        SheetSpec(
+            'value_added_meta',
+            lambda: _build_value_added_meta_df(),
+        ),
+        SheetSpec('SectorCrosswalk', lambda: None),
+        # --- bedrock-only extensions ---
+        SheetSpec(
+            'config_summary',
+            lambda: _build_config_summary_df(config_name),
+        ),
+        SheetSpec(
+            'model_info',
+            lambda: _build_model_info_df(config_name),
+        ),
+    ]
+
+
+# Sheet names treated as model "data" (matrices/vectors). At least one of
+# these must be non-None or `write_model_to_xlsx` raises -- otherwise we'd
+# silently publish a metadata-only workbook.
+_DATA_SHEETS: frozenset[str] = frozenset(
+    {
+        'V',
+        'U',
+        'U_d',
+        'A',
+        'A_d',
+        'A_m',
+        'B',
+        'C',
+        'D',
+        'L',
+        'L_d',
+        'M',
+        'M_d',
+        'M_m',
+        'N',
+        'N_d',
+        'N_m',
+        'Rho',
+        'Phi',
+        'Tau',
+        'q',
+        'x',
+    }
+)
+
+
+def _materialize(
+    registry: Iterable[SheetSpec],
+) -> list[tuple[str, pd.DataFrame | pd.Series]]:
+    out: list[tuple[str, pd.DataFrame | pd.Series]] = []
+    seen: set[str] = set()
+    for spec in registry:
+        if spec.name in seen:
+            raise RuntimeError(
+                f'publish: duplicate sheet name {spec.name!r} in registry; '
+                'each SheetSpec.name must be unique'
+            )
+        seen.add(spec.name)
+        result = spec.getter()
+        if result is None:
+            logger.info('publish: skipping sheet %r (getter returned None)', spec.name)
+            continue
+        if isinstance(result, pd.Series):
+            out.append((spec.name, _apply_loc_suffix(result)))
+        elif isinstance(result, pd.DataFrame):
+            out.append((spec.name, _apply_loc_suffix(result)))
+        else:
+            raise TypeError(
+                f'publish: sheet {spec.name!r} getter returned unsupported type '
+                f'{type(result).__name__}; expected DataFrame, Series, or None'
+            )
+    return out
+
+
+def write_model_to_xlsx(out_path: str, *, config_name: str) -> None:
+    """Write the bedrock EEIO model workbook to `out_path`.
+
+    Sheets are produced from `_build_matrix_registry(config_name)`. Any
+    registry entry whose getter returns `None` is omitted from the
+    workbook (useeior-style "skip if NULL"). If zero data sheets
+    materialize, raises `RuntimeError` -- a metadata-only workbook is
+    treated as a silent failure, not a valid state.
+    """
+    registry = _build_matrix_registry(config_name)
+    materialized = _materialize(registry)
+    data_count = sum(1 for name, _ in materialized if name in _DATA_SHEETS)
+    if data_count == 0:
+        raise RuntimeError(
+            'publish: no data sheets materialized; refusing to write a '
+            'metadata-only workbook. Check that derive_* getters in '
+            'MATRIX_REGISTRY are wired and that the requested config '
+            'supports them.'
+        )
+    os.makedirs(os.path.dirname(out_path) or '.', exist_ok=True)
+    logger.info(
+        'publish: writing %d sheets (%d data, %d metadata) to %s',
+        len(materialized),
+        data_count,
+        len(materialized) - data_count,
+        out_path,
+    )
+    with pd.ExcelWriter(out_path, engine='openpyxl') as writer:
+        for name, obj in materialized:
+            if isinstance(obj, pd.Series):
+                obj.to_frame().to_excel(writer, sheet_name=name)
+            else:
+                obj.to_excel(writer, sheet_name=name)

--- a/bedrock/transform/eeio/derived.py
+++ b/bedrock/transform/eeio/derived.py
@@ -43,6 +43,8 @@ from bedrock.utils.economic.inflation_helpers_ceda import (
     inflate_B_matrix,
     inflate_q_or_y,
 )
+from bedrock.utils.emissions.characterization import build_ghg_characterization_matrix
+from bedrock.utils.emissions.ghg import GHG
 from bedrock.utils.math.disaggregation import disaggregate_vector
 from bedrock.utils.math.formulas import (
     compute_B_ind_matrix,
@@ -334,6 +336,30 @@ def derive_Aq_usa() -> SingleRegionAqMatrixSet:
             Aimp=pt.DataFrame[AMatrix](Aimp),
             scaled_q=QVectorSchema.validate(q),
         )
+
+
+@functools.cache
+def derive_C_usa() -> pd.DataFrame:
+    """Trivial `(1, |GHG|)` row-summer for cornerstone B (already in CO2e).
+
+    KNOWN DIVERGENCE FROM USEEIOR: bedrock B is in `kgCO2e/USD` while
+    useeior B is in physical `kg gas/USD`. See
+    `bedrock.utils.emissions.characterization` for the resolution path.
+    """
+    return build_ghg_characterization_matrix(list(GHG))
+
+
+@functools.cache
+def derive_D_usa() -> pd.DataFrame:
+    """Direct impact per commodity = `C @ B` -- here equivalent to `B.sum(axis=0)`.
+
+    KNOWN DIVERGENCE FROM USEEIOR: bedrock's D is structurally a single
+    `Greenhouse Gases` indicator over commodities because bedrock's B is
+    already CO2e. See `bedrock.utils.emissions.characterization`.
+    """
+    D = derive_C_usa() @ derive_B_usa_non_finetuned()
+    D.columns.name = 'sector'
+    return D
 
 
 def derive_B_usa_via_vnorm(*, E_usa: pd.DataFrame) -> pd.DataFrame:

--- a/bedrock/utils/emissions/characterization.py
+++ b/bedrock/utils/emissions/characterization.py
@@ -1,0 +1,60 @@
+"""GHG characterization matrix builders.
+
+KNOWN DIVERGENCE FROM USEEIOR
+-----------------------------
+In `useeior`, the `C` matrix is a real GWP characterization matrix
+(`indicator x flow`) that converts physical-mass elementary flows in
+`B [kg gas / USD]` into impact units via `D = C @ B [kgCO2e / USD]`.
+
+In bedrock (Cornerstone), `B` is already in `kgCO2e / USD` -- AR6 GWPs are
+applied upstream during FBS aggregation in
+`bedrock.transform.allocation.derived` (`fbs['CO2e'] = ... * GWP100_AR6_CEDA`).
+See also `bedrock.utils.math.formulas` (top docstring): `B (g,c) [kgco2e/USD]`.
+
+As a consequence, the bedrock-side `C` returned by
+`build_ghg_characterization_matrix` is intentionally *trivial*: a single
+`Greenhouse Gases` indicator row of ones across the GHG axis. The product
+`C @ B` then equals `B.sum(axis=0)` -- the per-commodity total `kgCO2e/USD`.
+
+This matches the *shape* of `useeior`'s `C` but not its *semantics*. It exists
+so that the bedrock published workbook carries the same `C`/`D` sheet names
+as `useeior`'s `writeModeltoXLSX` output without inventing fake GWPs.
+
+TODO(divergence-from-useeior): resolve before bedrock can be treated as a
+drop-in `useeior` replacement. Options are documented in
+`bedrock/publish/README.md`:
+
+  1. Switch bedrock `B` to physical-mass units and ship a real GWP `C` from
+     `bedrock.utils.emissions.gwp.GWP100_AR6_CEDA`.
+  2. Or, emit a `B_phys` companion sheet alongside the CO2e `B` and a real
+     GWP `C` keyed to `B_phys`.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+GREENHOUSE_GASES_INDICATOR = 'Greenhouse Gases'
+
+
+def build_ghg_characterization_matrix(ghg_index: list[str]) -> pd.DataFrame:
+    """Trivial `(1, |ghg|)` row-summer.
+
+    See module docstring for the divergence-from-useeior caveat. The
+    returned matrix has a single `Greenhouse Gases` indicator row of all
+    ones, so `C @ B == B.sum(axis=0)` for any GHG-indexed `B` already in
+    CO2e per dollar.
+    """
+    if not ghg_index:
+        raise ValueError(
+            'build_ghg_characterization_matrix requires non-empty ghg_index'
+        )
+    if len(set(ghg_index)) != len(ghg_index):
+        raise ValueError(f'ghg_index must be unique; got duplicates in {ghg_index!r}')
+    C = pd.DataFrame(
+        [[1.0] * len(ghg_index)],
+        index=pd.Index([GREENHOUSE_GASES_INDICATOR], name='indicator'),
+        columns=pd.Index(list(ghg_index), name='ghg'),
+        dtype=float,
+    )
+    return C


### PR DESCRIPTION
cc: #401 
Closes:

## What changed? Why?

Stands up `bedrock/publish/` with the first publishable XLSX export of the bedrock EEIO model, mirroring the shape of `useeior::writeModeltoXLSX`.

### 1. New package layout

- `bedrock/publish/excel/writer.py` -- the workbook builder (`write_model_to_xlsx`) plus the `_build_matrix_registry`.
- `bedrock/publish/excel/cli.py` -- per-format Click CLI. Invoked as `uv run python -m bedrock.publish.excel.cli --config_name <cfg>`. Writes to `bedrock/publish/output/<git_sha>/<config_name>.xlsx`. Local only; GCS upload is TODO.
- `bedrock/utils/emissions/characterization.py` -- pure-math `build_ghg_characterization_matrix`.
- `bedrock/transform/eeio/derived.py` -- adds `derive_C_usa()` and `derive_D_usa()` wrappers (cached).

### 2. Sheet inventory

- **Real**: `B`, `C`, `D` (`= C @ B`), `q`, plus metadata (`commodities_meta`, `industries_meta`, `final_demand_meta`, `value_added_meta`, `config_summary`, `model_info`).
- **Placeholders** (registered with `getter = lambda: None`, sheets omitted via "skip if NULL" -- mirroring `useeior::WriteModel.R`): `V`, `U`, `U_d`, `A`, `A_d`, `A_m`, `L`, `L_d`, `M`, `M_d`, `M_m`, `N`, `N_d`, `N_m`, `Rho`, `Phi`, `Tau`, `x`, plus the metadata-side `demands`, `flows`, `indicators`, `SectorCrosswalk`. Each carries an inline TODO pointing at the missing derivation.

### 3. Known divergence from useeior (B units)

Bedrock `B` is in `kg CO2e / USD` (AR6 GWPs applied upstream at FBS aggregation in `bedrock/transform/allocation/derived.py`); useeior `B` is in physical `kg gas / USD` with a real GWP `C`. Consequences baked into the workbook:

1. The bedrock `B` sheet is NOT numerically comparable to useeior's `B` sheet. Row dimensions differ AND values differ per-row by a GWP factor.
2. The bedrock `C` sheet is a trivial `(1, 7)` row-summer (single `Greenhouse Gases` indicator, all ones), and `D = C @ B` reduces to `B.sum(axis=0)`. They are emitted for useeior sheet-name parity only.
3. `model_info` carries `b_units`, `b_characterized`, `gwp_set`, `c_kind`, and `divergence_from_useeior` fields so downstream consumers cannot silently misinterpret the workbook.

Resolution paths (not in this PR):
- **A.** Switch bedrock `B` to physical-mass units and ship a real GWP `C` from `bedrock.utils.emissions.gwp.GWP100_AR6_CEDA`. See https://github.com/cornerstone-data/methods/discussions/29
- **B.** Emit a `B_phys` companion sheet alongside the CO2e `B`, with a real GWP `C` keyed to `B_phys`.

Until then, `useeior_D[Greenhouse Gases]` is the like-for-like comparable quantity for `bedrock_B.sum(axis=0)`.

### 4. Notable design choices

- **Matrix registry shape** in `bedrock/publish/excel/writer.py` (`_build_matrix_registry(config_name) -> list[SheetSpec]`): flat list of `(sheet_name, getter_callable)` pairs. Lazy + cached (getters wrap `@functools.cache`-d `derive_*_usa()`). Subsetting and additional formats are additive.
- **Sheet order** mirrors useeior's `WriteModel.R` `matrices` vector exactly, then `q`, `x`, then the metadata block (`demands, flows, indicators, commodities_meta, industries_meta, final_demand_meta, value_added_meta, SectorCrosswalk`), then bedrock-only extensions (`config_summary, model_info`).
- **`/US` location suffix** automatically appended to any axis whose `Index.name == 'sector'`. Matches useeior convention and forces Excel to keep BEA numeric codes as text (no `211000` → `211000.0`).

### 5. Potential follow-ups (not in this PR)

Required:
- **Real derivations** for `L, M, N, Rho, Phi, Tau, V, U, U_d, A, A_d, demands, flows, indicators, SectorCrosswalk, x`.
- **Resolving B-units divergence** (paths A/B above).

Optional:
- **GCS upload of published workbooks.**
- **Supply-chain factors** -- upstream R counterpart: https://github.com/cornerstone-data/supply-chain-factors.
- **Import-emission factors `B_imp`** + downstream `A_m, M_m, N_m`.
- **Parameterizing the snapshot integration test** to validate arbitrary configs (currently hard-coded to `2025_usa_cornerstone_full_model`).

## Testing

- **Unit tests** (`bedrock/publish/__tests__/test_excel_writer.py`, 4 green): RuntimeError on empty data sheets (no file produced), skip-if-None filtering, `/US` suffix scoping across DataFrame and Series axes, pandas/openpyxl round-trip preserves values.

  ```
  uv run pytest bedrock/publish/__tests__/test_excel_writer.py -v
  ```

- **Integration** (`-m eeio_integration`): `test_excel_vs_snapshot.py` rebuilds the workbook under `2025_usa_cornerstone_full_model` and asserts the `B` sheet (after stripping `/US`) equals the `B_USA_non_finetuned` parquet snapshot. Picked up by daily `test_integration.yml`.

  ```
  uv run pytest -m eeio_integration bedrock/publish/__tests__/test_excel_vs_snapshot.py -v
  ```

- **End-to-end smoke** for `useeio_phoebe_23` (10.6s on a warm FBA cache): 10-sheet workbook (4 data + 6 metadata) materialized at `bedrock/publish/output/<git_sha>/useeio_phoebe_23.xlsx`. `model_info` carries the divergence flags; `B` columns carry the `/US` suffix; 7 aggregated GHG rows on `B`'s index.

  ```
  uv run python -m bedrock.publish.excel.cli --config_name useeio_phoebe_23
  ```
