### PR TITLE
update USEEIO style excel writer with more matrices

### DIFF
--- a/bedrock/publish/README.md
+++ b/bedrock/publish/README.md
@@ -7,9 +7,11 @@ shareable file formats, mirroring the shape of `useeior`'s
 ## Status
 
 - **XLSX**: implemented for
-  - Matrices: `V`, `U`, `U_d`, `A`, `A_d`, `B`, `C` (trivial row-summer;
-    see divergence note below), `D` (`= C @ B`), `L`, `L_d`, `M`, `M_d`,
-    `N`, `N_d`, and the output vectors `q`, `x`.
+  - Matrices: `V`, `U` (extended with VA rows + FD cols), `U_d`
+    (extended with VA rows; FD cols truncated -- see divergence note),
+    `A`, `A_d`, `B`, `C` (trivial row-summer; see divergence note
+    below), `D` (`= C @ B`), `L`, `L_d`, `M`, `M_d`, `N`, `N_d`, and the
+    output vectors `q`, `x`.
   - Metadata: `flows`, `indicators`, `commodities_meta`,
     `industries_meta`, `final_demand_meta`, `value_added_meta`,
     `config_summary`, `model_info`.
@@ -63,6 +65,21 @@ Resolution paths (TODO):
 
 Until one of those lands, `useeior_D[Greenhouse Gases]` is the
 like-for-like comparable quantity for `bedrock_B.sum(axis=0)`.
+
+## Known divergence from useeior (U_d FD truncation)
+
+Useeior's `U` and `U_d` are the same shape `(n_commod + n_VA) x
+(n_ind + n_FD)`. Bedrock matches this for `U` but **truncates `U_d`**
+to `(n_commod + n_VA) x n_ind` -- no FD columns. Reason: bedrock has
+no `Ydom` matrix at FD-category resolution today, only the `ydom`
+vector via
+[`derive_cornerstone_ydom_and_yimp`](../transform/eeio/derived_cornerstone.py).
+The `model_info` sheet's `u_d_extended` field records this.
+
+Resolution path (TODO): add a `derive_cornerstone_Ydom_matrix()` that
+disaggregates the summary-year `Yimp_matrix` to cornerstone schema and
+computes `Ydom_matrix = Ytot_matrix - Yimp_matrix`. Then re-extend
+`U_d` to match `U`'s shape.
 
 ## Recommended publish workflow
 

--- a/bedrock/publish/README.md
+++ b/bedrock/publish/README.md
@@ -6,21 +6,25 @@ shareable file formats, mirroring the shape of `useeior`'s
 
 ## Status
 
-- **XLSX**: implemented for `B`, `C` (trivial row-summer; see divergence
-  note below), `D` (`= C @ B`), `q`, plus metadata sheets
-  (`commodities_meta`, `industries_meta`, `final_demand_meta`,
-  `value_added_meta`, `config_summary`, `model_info`).
+- **XLSX**: implemented for
+  - Matrices: `V`, `U`, `U_d`, `A`, `A_d`, `B`, `C` (trivial row-summer;
+    see divergence note below), `D` (`= C @ B`), `L`, `L_d`, `M`, `M_d`,
+    `N`, `N_d`, and the output vectors `q`, `x`.
+  - Metadata: `flows`, `indicators`, `commodities_meta`,
+    `industries_meta`, `final_demand_meta`, `value_added_meta`,
+    `config_summary`, `model_info`.
 - **Supply-chain factors**: not implemented. Upstream R
   counterpart:
   [cornerstone-data/supply-chain-factors](https://github.com/cornerstone-data/supply-chain-factors).
-- **Additional matrices** (`V`, `U`, `U_d`, `A`, `A_d`, `L`, `L_d`,
-  `M`, `M_d`, `N`, `N_d`, `Rho`, `Phi`, `Tau`, `x`): registered as
-  placeholders in `excel/writer.py` (`getter = lambda: None`), so their
-  sheets are simply omitted. Each entry carries an inline `TODO`
-  pointing at the missing derivation.
 - **Import-emissions matrices** (`A_m`, `M_m`, `N_m`): require real
   import emission factors (`B_imp`), which bedrock does not yet
-  produce. Blocked on `B_imp`.
+  produce. Registered in `excel/writer.py` as `lambda: None`
+  placeholders; sheets are omitted via the "skip if NULL" rule until
+  `B_imp` lands.
+- **Useeior-only valuation matrices** (`Rho`, `Phi`, `Tau`) and
+  long-form metadata (`demands`, `SectorCrosswalk`): registered as
+  placeholders. Each carries an inline `TODO` pointing at the design
+  call or missing derivation.
 
 ## Known divergence from useeior (B units)
 
@@ -35,14 +39,16 @@ groups (`CO2`, `CH4`, `N2O`, `HFCs`, `PFCs`, `SF6`, `NF3`).
 
 Consequences for the published workbook:
 
-1. **`B` sheets are not numerically comparable** between bedrock and
-   useeior. Row dimensions differ (7 vs ~2000), and bedrock values are
-   per-row GWP-weighted CO2e while useeior values are physical mass.
-2. **The bedrock `C` and `D` sheets are emitted for useeior-shape
-   parity only.** `C` is a trivial `(1, 7)` row-summer (single
-   `Greenhouse Gases` indicator, all ones); `D = C @ B` reduces to
-   `B.sum(axis=0)`. They do *not* carry GWP characterization
-   information.
+1. **`B`, `M`, and `M_d` are not numerically comparable** between
+   bedrock and useeior. `B` carries kgCO2e/USD, and since `M = B @ L`
+   and `M_d = B @ L_d`, those matrices inherit the same kgCO2e/USD
+   units. Useeior's `B/M/M_d` are physical mass per dollar.
+2. **The bedrock `C`, `D`, `N`, `N_d` sheets are emitted for
+   useeior-shape parity only.** `C` is a trivial `(1, 7)` row-summer
+   (single `Greenhouse Gases` indicator, all ones), so `D = C @ B`,
+   `N = C @ M`, and `N_d = C @ M_d` reduce to per-sector sums of `B`,
+   `M`, and `M_d` respectively. They do *not* carry GWP
+   characterization information.
 3. The `model_info` sheet documents this with `b_units`,
    `b_characterized`, `gwp_set`, `c_kind`, and
    `divergence_from_useeior` fields so downstream consumers cannot

--- a/bedrock/publish/__tests__/_helpers.py
+++ b/bedrock/publish/__tests__/_helpers.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from typing import Callable
 
 import bedrock.utils.config.common as common
+from bedrock.publish.excel.writer import clear_publish_caches
 from bedrock.transform.eeio.derived import (
     derive_Aq_usa,
     derive_B_usa_non_finetuned,
@@ -42,6 +43,9 @@ from bedrock.utils.config.usa_config import (
     set_global_usa_config,
 )
 
+# Upstream derive_* caches that the writer's getters compose. The writer's
+# own publish-side getter caches are cleared via `clear_publish_caches()`
+# below.
 CACHED_FUNCTIONS: list[Callable[..., object]] = [
     derive_B_usa_non_finetuned,
     derive_C_usa,
@@ -67,6 +71,7 @@ def clear_all_caches() -> None:
     for fn in CACHED_FUNCTIONS:
         if hasattr(fn, 'cache_clear'):
             fn.cache_clear()
+    clear_publish_caches()
 
 
 def setup_config(config_name: str) -> None:

--- a/bedrock/publish/__tests__/test_excel_writer.py
+++ b/bedrock/publish/__tests__/test_excel_writer.py
@@ -132,3 +132,59 @@ def test_round_trip_values_preserved(
     q = book['q']
     assert q.shape == (2, 1)
     assert q.loc['100000/US', 'q'] == pytest.approx(100.0)
+
+
+def test_assemble_extended_U_block_placement() -> None:
+    """Block placement and VA x FD zero corner for `_assemble_extended_U`.
+
+    Validates the structural invariant: useeior-style extended-U has
+    intermediate top-left, FD top-right, VA bottom-left, zeros at VA x FD.
+    Bugs this catches: swapped axes on concat, missing zero padding,
+    accidental NaN broadcast.
+    """
+    industries = pd.Index(['ind1', 'ind2'], name='sector')
+    commodities = pd.Index(['c1', 'c2', 'c3'], name='sector')
+    fd_codes = pd.Index(['F01', 'F02'], name='sector')
+    va_codes = pd.Index(['V001', 'V002'], name='sector')
+
+    intermediate = pd.DataFrame(
+        [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]],
+        index=commodities,
+        columns=industries,
+    )
+    fd = pd.DataFrame(
+        [[7.0, 8.0], [9.0, 10.0], [11.0, 12.0]],
+        index=commodities,
+        columns=fd_codes,
+    )
+    va = pd.DataFrame(
+        [[13.0, 14.0], [15.0, 16.0]],
+        index=va_codes,
+        columns=industries,
+    )
+
+    extended = writer_module._assemble_extended_U(
+        intermediate=intermediate, fd=fd, va=va
+    )
+
+    assert extended.shape == (5, 4), f'expected (5, 4); got {extended.shape}'
+    assert extended.index.name == 'sector'
+    assert extended.columns.name == 'sector'
+    pd.testing.assert_frame_equal(
+        extended.loc[commodities, industries], intermediate, check_names=False
+    )
+    pd.testing.assert_frame_equal(
+        extended.loc[commodities, fd_codes], fd, check_names=False
+    )
+    pd.testing.assert_frame_equal(
+        extended.loc[va_codes, industries], va, check_names=False
+    )
+    va_fd_corner = extended.loc[va_codes, fd_codes]
+    assert (va_fd_corner == 0).all().all(), f'VA x FD corner must be zero; got {va_fd_corner.values.tolist()}'
+
+    truncated = writer_module._assemble_extended_U(
+        intermediate=intermediate, fd=None, va=va
+    )
+    assert truncated.shape == (5, 2)
+    assert list(truncated.index) == ['c1', 'c2', 'c3', 'V001', 'V002']
+    assert list(truncated.columns) == ['ind1', 'ind2']

--- a/bedrock/publish/__tests__/test_excel_writer.py
+++ b/bedrock/publish/__tests__/test_excel_writer.py
@@ -2,8 +2,8 @@
 
 These tests monkeypatch the registry-building function with small
 synthetic getters so we can exercise the writer's behavior (skip-if-None,
-empty-data-sheets guard, location-suffix application, metadata content,
-round-trip correctness) without standing up the real EEIO pipeline.
+location-suffix application, metadata content, round-trip correctness)
+without standing up the real EEIO pipeline.
 """
 
 from __future__ import annotations
@@ -15,18 +15,6 @@ import pandas as pd
 import pytest
 
 from bedrock.publish.excel import writer as writer_module
-
-
-def _empty_registry(config_name: str) -> list[writer_module.SheetSpec]:
-    """All sheets resolve to None -- exercises the empty-data-sheets guard."""
-    return [
-        writer_module.SheetSpec('B', lambda: None),
-        writer_module.SheetSpec('C', lambda: None),
-        writer_module.SheetSpec(
-            'model_info',
-            lambda: pd.DataFrame([{'field': 'config_name', 'value': config_name}]),
-        ),
-    ]
 
 
 def _synthetic_registry(config_name: str) -> list[writer_module.SheetSpec]:
@@ -58,18 +46,6 @@ def _synthetic_registry(config_name: str) -> list[writer_module.SheetSpec]:
             ),
         ),
     ]
-
-
-def test_raises_when_no_data_sheets(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    out = os.fspath(tmp_path / 'empty.xlsx')
-    monkeypatch.setattr(writer_module, '_build_matrix_registry', _empty_registry)
-    with pytest.raises(RuntimeError, match='no data sheets'):
-        writer_module.write_model_to_xlsx(out, config_name='dummy')
-    assert not os.path.exists(
-        out
-    ), 'workbook should not be written when no data sheets materialize'
 
 
 def test_writes_only_materialized_sheets(

--- a/bedrock/publish/__tests__/test_excel_writer.py
+++ b/bedrock/publish/__tests__/test_excel_writer.py
@@ -67,9 +67,9 @@ def test_raises_when_no_data_sheets(
     monkeypatch.setattr(writer_module, '_build_matrix_registry', _empty_registry)
     with pytest.raises(RuntimeError, match='no data sheets'):
         writer_module.write_model_to_xlsx(out, config_name='dummy')
-    assert not os.path.exists(
-        out
-    ), 'workbook should not be written when no data sheets materialize'
+    assert not os.path.exists(out), (
+        'workbook should not be written when no data sheets materialize'
+    )
 
 
 def test_writes_only_materialized_sheets(
@@ -180,7 +180,9 @@ def test_assemble_extended_U_block_placement() -> None:
         extended.loc[va_codes, industries], va, check_names=False
     )
     va_fd_corner = extended.loc[va_codes, fd_codes]
-    assert (va_fd_corner == 0).all().all(), f'VA x FD corner must be zero; got {va_fd_corner.values.tolist()}'
+    assert (va_fd_corner == 0).all().all(), (
+        f'VA x FD corner must be zero; got {va_fd_corner.values.tolist()}'
+    )
 
     truncated = writer_module._assemble_extended_U(
         intermediate=intermediate, fd=None, va=va

--- a/bedrock/publish/__tests__/test_excel_writer.py
+++ b/bedrock/publish/__tests__/test_excel_writer.py
@@ -67,9 +67,9 @@ def test_raises_when_no_data_sheets(
     monkeypatch.setattr(writer_module, '_build_matrix_registry', _empty_registry)
     with pytest.raises(RuntimeError, match='no data sheets'):
         writer_module.write_model_to_xlsx(out, config_name='dummy')
-    assert not os.path.exists(out), (
-        'workbook should not be written when no data sheets materialize'
-    )
+    assert not os.path.exists(
+        out
+    ), 'workbook should not be written when no data sheets materialize'
 
 
 def test_writes_only_materialized_sheets(
@@ -180,9 +180,9 @@ def test_assemble_extended_U_block_placement() -> None:
         extended.loc[va_codes, industries], va, check_names=False
     )
     va_fd_corner = extended.loc[va_codes, fd_codes]
-    assert (va_fd_corner == 0).all().all(), (
-        f'VA x FD corner must be zero; got {va_fd_corner.values.tolist()}'
-    )
+    assert (
+        (va_fd_corner == 0).all().all()
+    ), f'VA x FD corner must be zero; got {va_fd_corner.values.tolist()}'
 
     truncated = writer_module._assemble_extended_U(
         intermediate=intermediate, fd=None, va=va

--- a/bedrock/publish/excel/writer.py
+++ b/bedrock/publish/excel/writer.py
@@ -613,37 +613,6 @@ def _build_matrix_registry(config_name: str) -> list[SheetSpec]:
     ]
 
 
-# Sheet names treated as model "data" (matrices/vectors). At least one of
-# these must be non-None or `write_model_to_xlsx` raises -- otherwise we'd
-# silently publish a metadata-only workbook.
-_DATA_SHEETS: frozenset[str] = frozenset(
-    {
-        'V',
-        'U',
-        'U_d',
-        'A',
-        'A_d',
-        'A_m',
-        'B',
-        'C',
-        'D',
-        'L',
-        'L_d',
-        'M',
-        'M_d',
-        'M_m',
-        'N',
-        'N_d',
-        'N_m',
-        'Rho',
-        'Phi',
-        'Tau',
-        'q',
-        'x',
-    }
-)
-
-
 def _materialize(
     registry: Iterable[SheetSpec],
 ) -> list[tuple[str, pd.DataFrame | pd.Series]]:
@@ -677,9 +646,7 @@ def write_model_to_xlsx(out_path: str, *, config_name: str) -> None:
 
     Sheets are produced from `_build_matrix_registry(config_name)`. Any
     registry entry whose getter returns `None` is omitted from the
-    workbook (useeior-style "skip if NULL"). If zero data sheets
-    materialize, raises `RuntimeError` -- a metadata-only workbook is
-    treated as a silent failure, not a valid state.
+    workbook (useeior-style "skip if NULL").
 
     Raises `NotImplementedError` on legacy (non-cornerstone) configs --
     publish is wired only for cornerstone-schema configs today.
@@ -687,20 +654,10 @@ def write_model_to_xlsx(out_path: str, *, config_name: str) -> None:
     _require_cornerstone()
     registry = _build_matrix_registry(config_name)
     materialized = _materialize(registry)
-    data_count = sum(1 for name, _ in materialized if name in _DATA_SHEETS)
-    if data_count == 0:
-        raise RuntimeError(
-            'publish: no data sheets materialized; refusing to write a '
-            'metadata-only workbook. Check that derive_* getters in '
-            'MATRIX_REGISTRY are wired and that the requested config '
-            'supports them.'
-        )
     os.makedirs(os.path.dirname(out_path) or '.', exist_ok=True)
     logger.info(
-        'publish: writing %d sheets (%d data, %d metadata) to %s',
+        'publish: writing %d sheets to %s',
         len(materialized),
-        data_count,
-        len(materialized) - data_count,
         out_path,
     )
     with pd.ExcelWriter(out_path, engine='openpyxl') as writer:

--- a/bedrock/publish/excel/writer.py
+++ b/bedrock/publish/excel/writer.py
@@ -17,10 +17,14 @@ Practical consequences:
   * The bedrock `B` sheet is NOT numerically comparable to the useeior
     `B` sheet -- they have different row dimensions AND different
     per-row units.
-  * The bedrock `C` and `D` sheets are emitted for sheet-name parity
-    only. `C` is a trivial row-summer (single "Greenhouse Gases"
-    indicator over the 7 GHGs, all values = 1.0) and `D = C @ B`
-    reduces to `B.sum(axis=0)`. See
+  * `M` and `M_d` are `B @ L` / `B @ L_d`, so they inherit B's
+    `kgCO2e / USD` units. They are NOT numerically comparable to
+    useeior's physical-mass `M` / `M_d` either.
+  * The bedrock `C`, `D`, `N`, `N_d` sheets are emitted for sheet-name
+    parity only. `C` is a trivial row-summer (single "Greenhouse Gases"
+    indicator over the 7 GHGs, all values = 1.0), so `D = C @ B`
+    reduces to `B.sum(axis=0)`, `N = C @ M` to `M.sum(axis=0)`, and
+    `N_d = C @ M_d` to `M_d.sum(axis=0)`. See
     `bedrock/utils/emissions/characterization.py` for resolution paths.
 
 The `model_info` sheet carries `b_units`, `b_characterized`, `gwp_set`,
@@ -40,6 +44,7 @@ to integers (and so the codes are unambiguous in MRIO settings).
 from __future__ import annotations
 
 import datetime
+import functools
 import logging
 import os
 from collections.abc import Callable, Iterable
@@ -49,6 +54,7 @@ import pandas as pd
 
 from bedrock.utils.config.settings import GIT_HASH_LONG
 from bedrock.utils.config.usa_config import get_usa_config
+from bedrock.utils.math.formulas import compute_L_matrix, compute_M_matrix
 
 logger = logging.getLogger(__name__)
 
@@ -121,8 +127,13 @@ def _build_model_info_df(config_name: str) -> pd.DataFrame:
             'field': 'divergence_from_useeior',
             'value': (
                 'B is in CO2e (pre-characterized); useeior B is in physical '
-                'kg of gas. Resolve before treating bedrock XLSX as a useeior '
-                'drop-in. See bedrock/utils/emissions/characterization.py.'
+                'kg of gas. M and M_d inherit those kgCO2e/USD units '
+                '(M = B @ L). C is a trivial row-summer so D, N, N_d collapse '
+                'to a single "Greenhouse Gases" indicator equal to '
+                'B.sum(axis=0) / M.sum(axis=0) / M_d.sum(axis=0) '
+                'respectively. Resolve before treating bedrock XLSX as a '
+                'useeior drop-in. See '
+                'bedrock/utils/emissions/characterization.py.'
             ),
         },
     ]
@@ -189,6 +200,50 @@ def _build_value_added_meta_df() -> pd.DataFrame:
     )
 
 
+def _build_flows_df() -> pd.DataFrame:
+    """useeior-style `flows` table -- bedrock-aggregated GHGs (7 rows).
+
+    Useeior emits ~2000 rows of elementary flows. Bedrock B is already
+    aggregated to the 7 IPCC AR6 GHGs upstream, so this sheet lists those
+    7 (NOT directly comparable to a useeior flows sheet). See the
+    workbook docstring on `bedrock.publish.excel.writer` for the units
+    divergence.
+    """
+    from bedrock.utils.emissions.ghg import GHG
+
+    return pd.DataFrame(
+        [
+            {
+                'Flowable': name,
+                'Context': 'emission/air',
+                'Unit': 'kg CO2e',
+            }
+            for name in GHG
+        ]
+    )
+
+
+def _build_indicators_df() -> pd.DataFrame:
+    """useeior-style `indicators` table -- one row for `Greenhouse Gases`.
+
+    Mirrors the single-indicator C matrix returned by `derive_C_usa()`.
+    """
+    from bedrock.utils.emissions.characterization import GREENHOUSE_GASES_INDICATOR
+
+    return pd.DataFrame(
+        [
+            {
+                'Name': GREENHOUSE_GASES_INDICATOR,
+                'Code': 'GHG',
+                'Group': 'Impact Potential',
+                'Unit': 'kg CO2e',
+                'SimpleName': GREENHOUSE_GASES_INDICATOR,
+                'SimpleUnit': 'kg CO2e',
+            }
+        ]
+    )
+
+
 # ---------------------------------------------------------------------------
 # Matrix registry
 # ---------------------------------------------------------------------------
@@ -208,81 +263,222 @@ def _build_value_added_meta_df() -> pd.DataFrame:
 # on `CommodityorIndustryType`. Bedrock has both taxonomies and writes
 # both. config_summary and model_info are bedrock-only.
 #
-# Real getters: B, C, D, q, and metadata sheets noted below. Other
-# entries are `lambda: None` placeholders; their sheets are omitted from
-# the workbook ("skip if NULL", matching useeior `WriteModel.R`).
-# Resolving each placeholder requires either a config-aware
-# `derive_*_usa()` wrapper or, for the `*_m` family, a real `B_imp`
-# (import emission factors) which bedrock does not yet produce.
-# Concrete TODOs are inlined next to each placeholder.
+# The getters below are consumed only by the registry. If a second
+# non-publish caller appears, promote to a config-aware `derive_*_usa()`
+# in `bedrock/transform/eeio/derived.py`.
+#
+# Math for derived matrices (Leontief inverse, B @ L, etc.) is sourced
+# from `bedrock.utils.math.formulas` -- don't inline `np.linalg.inv` or
+# similar here.
+#
+# Lazy imports of `bedrock.transform.eeio.derived(_cornerstone)` inside
+# each getter keep `import bedrock.publish.excel.writer` cheap;
+# `formulas` is imported at module top because it's just math primitives.
+#
+# `@functools.cache` on each getter lets `clear_publish_caches()` reset
+# all of them in one call between integration-test configs.
 
 
-def _get_B() -> pd.DataFrame | None:
+def _require_cornerstone() -> None:
+    if not get_usa_config().use_cornerstone_2026_model_schema:
+        raise NotImplementedError(
+            'bedrock.publish.excel only supports cornerstone-schema configs '
+            '(use_cornerstone_2026_model_schema=True). Wiring legacy paths '
+            'into the publish pipeline is a separate task.'
+        )
+
+
+@functools.cache
+def _get_V() -> pd.DataFrame:
+    from bedrock.transform.eeio.derived_cornerstone import derive_cornerstone_V
+
+    return derive_cornerstone_V()
+
+
+@functools.cache
+def _get_U() -> pd.DataFrame:
+    from bedrock.transform.eeio.derived_cornerstone import derive_cornerstone_U_set
+
+    uset = derive_cornerstone_U_set()
+    U = uset.Udom + uset.Uimp
+    U.index.name = 'sector'
+    U.columns.name = 'sector'
+    return U
+
+
+@functools.cache
+def _get_Udom() -> pd.DataFrame:
+    from bedrock.transform.eeio.derived_cornerstone import derive_cornerstone_U_set
+
+    return derive_cornerstone_U_set().Udom
+
+
+@functools.cache
+def _get_x() -> pd.Series:
+    from bedrock.transform.eeio.derived_cornerstone import derive_cornerstone_x
+
+    return pd.Series(derive_cornerstone_x(), name='x')
+
+
+@functools.cache
+def _get_A() -> pd.DataFrame:
+    from bedrock.transform.eeio.derived import derive_Aq_usa
+
+    aq = derive_Aq_usa()
+    A = aq.Adom + aq.Aimp
+    A.index.name = 'sector'
+    A.columns.name = 'sector'
+    return A
+
+
+@functools.cache
+def _get_Adom() -> pd.DataFrame:
+    from bedrock.transform.eeio.derived import derive_Aq_usa
+
+    return derive_Aq_usa().Adom
+
+
+@functools.cache
+def _get_L() -> pd.DataFrame:
+    return compute_L_matrix(A=_get_A())
+
+
+@functools.cache
+def _get_Ldom() -> pd.DataFrame:
+    return compute_L_matrix(A=_get_Adom())
+
+
+@functools.cache
+def _get_B() -> pd.DataFrame:
     from bedrock.transform.eeio.derived import derive_B_usa_non_finetuned
 
     return derive_B_usa_non_finetuned()
 
 
-def _get_C() -> pd.DataFrame | None:
+@functools.cache
+def _get_C() -> pd.DataFrame:
     from bedrock.transform.eeio.derived import derive_C_usa
 
     return derive_C_usa()
 
 
-def _get_D() -> pd.DataFrame | None:
+@functools.cache
+def _get_D() -> pd.DataFrame:
     from bedrock.transform.eeio.derived import derive_D_usa
 
     return derive_D_usa()
 
 
-def _get_q() -> pd.Series | None:
+# Emission multipliers M = B @ L, M_d = B @ L_d. Both inherit B's
+# kgCO2e/USD units -- see the module docstring's divergence-from-useeior
+# callout.
+@functools.cache
+def _get_M() -> pd.DataFrame:
+    M = compute_M_matrix(B=_get_B(), L=_get_L())
+    M.columns.name = 'sector'
+    return M
+
+
+@functools.cache
+def _get_Mdom() -> pd.DataFrame:
+    M_d = compute_M_matrix(B=_get_B(), L=_get_Ldom())
+    M_d.columns.name = 'sector'
+    return M_d
+
+
+# Impact multipliers N = C @ M, N_d = C @ M_d. In bedrock semantics
+# these collapse to per-sector sums of M/M_d because C is the trivial
+# row-summer (see `bedrock.utils.emissions.characterization`).
+@functools.cache
+def _get_N() -> pd.DataFrame:
+    N = _get_C() @ _get_M()
+    N.columns.name = 'sector'
+    return N
+
+
+@functools.cache
+def _get_Ndom() -> pd.DataFrame:
+    N_d = _get_C() @ _get_Mdom()
+    N_d.columns.name = 'sector'
+    return N_d
+
+
+@functools.cache
+def _get_q() -> pd.Series:
     from bedrock.transform.eeio.derived import derive_Aq_usa
 
-    q = derive_Aq_usa().scaled_q
-    return pd.Series(q, name='q')
+    return pd.Series(derive_Aq_usa().scaled_q, name='q')
+
+
+_CACHED_GETTERS: tuple[Callable[[], pd.DataFrame | pd.Series], ...] = (
+    _get_V,
+    _get_U,
+    _get_Udom,
+    _get_x,
+    _get_A,
+    _get_Adom,
+    _get_L,
+    _get_Ldom,
+    _get_B,
+    _get_C,
+    _get_D,
+    _get_M,
+    _get_Mdom,
+    _get_N,
+    _get_Ndom,
+    _get_q,
+)
+
+
+def clear_publish_caches() -> None:
+    """Clear all `@functools.cache`-d getters in this module.
+
+    Upstream `derive_*` caches in `bedrock.transform.eeio.derived(_cornerstone)`
+    must also be cleared between configs -- see
+    `bedrock/publish/__tests__/_helpers.py`.
+    """
+    for fn in _CACHED_GETTERS:
+        fn.cache_clear()  # type: ignore[attr-defined]
 
 
 def _build_matrix_registry(config_name: str) -> list[SheetSpec]:
     return [
         # --- useeior matrices (order matches `matrices` in WriteModel.R) ---
-        # TODO: derive_V_usa() wrapping derive_cornerstone_V().
-        SheetSpec('V', lambda: None),
-        # TODO: derive_U_usa() wrapping derive_cornerstone_U_set().Udom + Uimp.
-        SheetSpec('U', lambda: None),
-        SheetSpec('U_d', lambda: None),
-        # TODO: derive_A_usa() wrapping derive_Aq_usa().Adom + Aimp.
-        SheetSpec('A', lambda: None),
-        SheetSpec('A_d', lambda: None),
+        SheetSpec('V', _get_V),
+        SheetSpec('U', _get_U),
+        SheetSpec('U_d', _get_Udom),
+        SheetSpec('A', _get_A),
+        SheetSpec('A_d', _get_Adom),
         # A_m requires real import emission factors (B_imp); not yet in bedrock.
         SheetSpec('A_m', lambda: None),
         SheetSpec('B', _get_B),
         SheetSpec('C', _get_C),
         SheetSpec('D', _get_D),
-        # TODO: derive_L_usa() = (I - A)^-1; cheap once derive_A_usa() exists.
-        SheetSpec('L', lambda: None),
-        SheetSpec('L_d', lambda: None),
-        # TODO: derive_M_usa() = B @ L; cheap once L exists.
-        SheetSpec('M', lambda: None),
-        SheetSpec('M_d', lambda: None),
+        SheetSpec('L', _get_L),
+        SheetSpec('L_d', _get_Ldom),
+        SheetSpec('M', _get_M),
+        SheetSpec('M_d', _get_Mdom),
         SheetSpec('M_m', lambda: None),  # requires B_imp
-        # TODO: derive_N_usa() = C @ M = M.sum(axis=0) given bedrock semantics.
-        SheetSpec('N', lambda: None),
-        SheetSpec('N_d', lambda: None),
+        SheetSpec('N', _get_N),
+        SheetSpec('N_d', _get_Ndom),
         SheetSpec('N_m', lambda: None),  # requires B_imp
+        # Rho, Phi, Tau are useeior valuation-adjustment matrices with no
+        # direct bedrock analogue. Leave as TODO until a design call is made.
         SheetSpec('Rho', lambda: None),
         SheetSpec('Phi', lambda: None),
         SheetSpec('Tau', lambda: None),
         # --- outputs (useeior writes these after the matrices block) ---
         SheetSpec('q', _get_q),
-        SheetSpec('x', lambda: None),  # TODO: derive_x_usa()
+        SheetSpec('x', _get_x),
         # --- metadata block (useeior order: demands, flows, indicators,
         #     <sectors>_meta, final_demand_meta, value_added_meta,
         #     SectorCrosswalk) ---
-        # TODO: demands, flows, indicators, SectorCrosswalk getters once
-        # we have config-aware accessors for those tables.
+        # TODO: `demands` -- needs a design call about which named demand
+        # vectors to emit (y_nab? y_dom? y_imp?) and how to encode the long
+        # form expected by useeior.
         SheetSpec('demands', lambda: None),
-        SheetSpec('flows', lambda: None),
-        SheetSpec('indicators', lambda: None),
+        SheetSpec('flows', lambda: _build_flows_df()),
+        SheetSpec('indicators', lambda: _build_indicators_df()),
         SheetSpec('commodities_meta', lambda: _build_commodities_meta_df()),
         SheetSpec('industries_meta', lambda: _build_industries_meta_df()),
         SheetSpec(
@@ -293,6 +489,8 @@ def _build_matrix_registry(config_name: str) -> list[SheetSpec]:
             'value_added_meta',
             lambda: _build_value_added_meta_df(),
         ),
+        # TODO: SectorCrosswalk getter once we settle on which crosswalk
+        # to expose (BEA summary <-> CEDA <-> NAICS?).
         SheetSpec('SectorCrosswalk', lambda: None),
         # --- bedrock-only extensions ---
         SheetSpec(
@@ -373,7 +571,11 @@ def write_model_to_xlsx(out_path: str, *, config_name: str) -> None:
     workbook (useeior-style "skip if NULL"). If zero data sheets
     materialize, raises `RuntimeError` -- a metadata-only workbook is
     treated as a silent failure, not a valid state.
+
+    Raises `NotImplementedError` on legacy (non-cornerstone) configs --
+    publish is wired only for cornerstone-schema configs today.
     """
+    _require_cornerstone()
     registry = _build_matrix_registry(config_name)
     materialized = _materialize(registry)
     data_count = sum(1 for name, _ in materialized if name in _DATA_SHEETS)

--- a/bedrock/publish/excel/writer.py
+++ b/bedrock/publish/excel/writer.py
@@ -37,7 +37,25 @@ Following useeior's convention, BEA-style numeric codes (e.g. `211000`)
 are emitted with a `/US` location suffix so Excel does not coerce them
 to integers (and so the codes are unambiguous in MRIO settings).
 `_with_loc_suffix` is applied automatically to any axis whose
-`Index.name == 'sector'`.
+`Index.name == 'sector'`. The extended-U axes carry mixed
+sector/VA/final-demand codes; we tag them as `'sector'` anyway so the
+suffix applies uniformly (matches useeior's effective behavior).
+
+Extended U / U_d block layout
+-----------------------------
+`U` mirrors useeior's extended use matrix -- value-added rows
+(`V00100..V00300`) below the commodity-by-industry intermediate block,
+and final-demand columns (`F01000..F10S00`) to the right of it. The
+VA x FD corner is zero (structural padding). The VA block is identical
+between U and U_d since value added is intrinsically domestic.
+
+`U_d`'s FD block is currently truncated: bedrock has no `Ydom` matrix
+at FD-category resolution (only the `ydom` vector via
+`derive_cornerstone_ydom_and_yimp`), so we emit `U_d` as
+`(commodity + VA) x industry` only -- VA rows but no FD columns. The
+`model_info` sheet carries a `u_d_extended` field so consumers see
+this. Future work: add a `derive_cornerstone_Ydom_matrix()` and
+re-extend `U_d` to match `U`'s shape.
 """
 
 # ruff: noqa: PLC0415
@@ -134,6 +152,24 @@ def _build_model_info_df(config_name: str) -> pd.DataFrame:
                 'respectively. Resolve before treating bedrock XLSX as a '
                 'useeior drop-in. See '
                 'bedrock/utils/emissions/characterization.py.'
+            ),
+        },
+        {
+            'field': 'u_extended',
+            'value': (
+                'full: VA rows (V001/V002/V003) and FD cols (F01000..F10S00) '
+                'attached to commodity-by-industry intermediate. VA x FD '
+                'corner is zero (structural padding). Matches useeior `U`.'
+            ),
+        },
+        {
+            'field': 'u_d_extended',
+            'value': (
+                'partial: VA rows included, FD cols truncated. Bedrock has '
+                'no Ydom matrix at FD-category resolution today (only the '
+                'ydom vector via derive_cornerstone_ydom_and_yimp). U_d '
+                'shape diverges from useeior U_d until a derive_cornerstone'
+                '_Ydom_matrix exists. See writer module docstring.'
             ),
         },
     ]
@@ -288,6 +324,56 @@ def _require_cornerstone() -> None:
         )
 
 
+def _assemble_extended_U(
+    intermediate: pd.DataFrame,
+    fd: pd.DataFrame | None,
+    va: pd.DataFrame,
+) -> pd.DataFrame:
+    """Stack intermediate / FD / VA blocks into a useeior-style extended U.
+
+    Layout when `fd` is provided:
+
+        +-----------------+-----------+
+        |  intermediate   |    fd     |
+        +-----------------+-----------+
+        |       va        |  zeros    |
+        +-----------------+-----------+
+
+    With `fd=None`, the right-hand column block (FD + VA x FD zeros) is
+    omitted -- used for `U_d` until a domestic Y matrix at FD-category
+    granularity exists in bedrock (see
+    `derive_cornerstone_ydom_and_yimp`).
+
+    Both axes of the returned frame are tagged `Index.name = 'sector'`
+    so `_apply_loc_suffix` adds `/US` to every label.
+
+    Inputs must be aligned: `intermediate.columns == va.columns` and
+    (when present) `intermediate.index == fd.index`.
+    """
+    if not intermediate.columns.equals(va.columns):
+        raise ValueError(
+            '_assemble_extended_U: intermediate.columns and va.columns must match '
+            f'(got {len(intermediate.columns)} vs {len(va.columns)} labels)'
+        )
+    if fd is not None and not intermediate.index.equals(fd.index):
+        raise ValueError(
+            '_assemble_extended_U: intermediate.index and fd.index must match '
+            f'(got {len(intermediate.index)} vs {len(fd.index)} labels)'
+        )
+
+    if fd is None:
+        out = pd.concat([intermediate, va], axis=0)
+    else:
+        top = pd.concat([intermediate, fd], axis=1)
+        va_zeros = pd.DataFrame(0.0, index=va.index, columns=fd.columns)
+        bottom = pd.concat([va, va_zeros], axis=1)
+        out = pd.concat([top, bottom], axis=0)
+
+    out.index.name = 'sector'
+    out.columns.name = 'sector'
+    return out
+
+
 @functools.cache
 def _get_V() -> pd.DataFrame:
     from bedrock.transform.eeio.derived_cornerstone import derive_cornerstone_V
@@ -297,20 +383,43 @@ def _get_V() -> pd.DataFrame:
 
 @functools.cache
 def _get_U() -> pd.DataFrame:
-    from bedrock.transform.eeio.derived_cornerstone import derive_cornerstone_U_set
+    # TODO: `_derive_cornerstone_Ytot_with_trade` is single-underscore private.
+    # Promote to a public `derive_cornerstone_Y_matrix()` once another
+    # non-publish caller appears -- see option A in the writer module
+    # docstring discussion.
+    from bedrock.transform.eeio.derived_cornerstone import (
+        _derive_cornerstone_Ytot_with_trade,
+        derive_cornerstone_U_set,
+        derive_cornerstone_VA,
+    )
+    from bedrock.utils.taxonomy.cornerstone.final_demand import FINAL_DEMANDS
 
     uset = derive_cornerstone_U_set()
-    U = uset.Udom + uset.Uimp
-    U.index.name = 'sector'
-    U.columns.name = 'sector'
-    return U
+    intermediate = uset.Udom + uset.Uimp
+    # Reindex by canonical FINAL_DEMANDS order so column layout matches
+    # useeior's `U` regardless of source column ordering.
+    fd_block = _derive_cornerstone_Ytot_with_trade()[list(FINAL_DEMANDS)]
+    return _assemble_extended_U(
+        intermediate=intermediate,
+        fd=fd_block,
+        va=derive_cornerstone_VA(),
+    )
 
 
 @functools.cache
 def _get_Udom() -> pd.DataFrame:
-    from bedrock.transform.eeio.derived_cornerstone import derive_cornerstone_U_set
+    # FD block intentionally truncated; bedrock has no Ydom matrix at
+    # FD-category resolution today. See writer module docstring.
+    from bedrock.transform.eeio.derived_cornerstone import (
+        derive_cornerstone_U_set,
+        derive_cornerstone_VA,
+    )
 
-    return derive_cornerstone_U_set().Udom
+    return _assemble_extended_U(
+        intermediate=derive_cornerstone_U_set().Udom,
+        fd=None,
+        va=derive_cornerstone_VA(),
+    )
 
 
 @functools.cache


### PR DESCRIPTION
cc: #401 
Closes:

## What changed? Why?

Follows #404. Wires up the bulk of the useeior-style matrix and metadata set so the published workbook contains a usable EEIO model.

### 1. Matrix getters in `bedrock/publish/excel/writer.py`

Cached `_get_*` getters for V, U, U_d, A, A_d, B, C, D, L, L_d, M, M_d, N, N_d, q, x. Direct accessors wrap existing cornerstone derivations; L/M math comes from `bedrock.utils.math.formulas` (`compute_L_matrix`, `compute_M_matrix`); N is inline `C @ M`. U/U_d route through `_assemble_extended_U` -- see section 2.

Getters live in `writer.py` rather than `bedrock.transform.eeio.derived` because each has a single caller (the registry); promotion is appropriate if a second non-publish caller appears.

Supporting infrastructure:

- `_require_cornerstone()` -- single gate at the top of `write_model_to_xlsx`; raises `NotImplementedError` on legacy configs.
- `clear_publish_caches()` -- clears all `@functools.cache`-d getters in one call; invoked from `_helpers.py::clear_all_caches` for test isolation.
- Lazy imports of `bedrock.transform.eeio.derived(_cornerstone)` inside each getter to keep `import bedrock.publish.excel.writer` cheap.

### 2. Extended `U` matrix; truncated `U_d`

Useeior's `U` and `U_d` are four-block extended matrices:

```text
                 industries        FD codes
              +---------------+---------------+
commodities   | intermediate  |      Y        |
              +---------------+---------------+
VA codes      |     VA        |     0         |
              +---------------+---------------+
```

`_assemble_extended_U(intermediate, fd, va)` builds this layout. Both axes are tagged `Index.name = 'sector'` so `_apply_loc_suffix` adds `/US` to every label.

- **`U`** fully extended: intermediate = `Udom + Uimp`, FD = `_derive_cornerstone_Ytot_with_trade()[FINAL_DEMANDS]`, VA = `derive_cornerstone_VA()`, zero VA × FD corner.
- **`U_d`** has the VA rows but no FD columns. Bedrock has no `Ydom` matrix at FD-category resolution (only the `ydom` vector via `derive_cornerstone_ydom_and_yimp`), so the FD block is deferred. Shape: `(n_commod + n_VA) × n_ind`. Recorded in `model_info.u_d_extended` and `bedrock/publish/README.md`.

`_derive_cornerstone_Ytot_with_trade` is private; called from `writer.py` with an inline TODO to promote if a second non-publish caller appears.

### 3. Metadata sheets

- `flows` -- 7-row table over `bedrock.utils.emissions.ghg.GHG` (CO2, CH4, N2O, HFCs, PFCs, SF6, NF3). NOT comparable to useeior's ~2000-row elementary-flow list -- bedrock aggregates upstream at FBS aggregation.
- `indicators` -- 1-row table for `Greenhouse Gases`, matching `derive_C_usa()`.

### 4. Divergence-from-useeior callout (B, C, D, M, M_d, N, N_d)

- `B` is `kgCO2e / USD`; useeior `B` is physical `kg gas / USD`.
- `M = B @ L` and `M_d = B @ L_d` inherit B's units. NOT numerically comparable to useeior's M/M_d.
- `C` is a trivial `(1, 7)` row-summer. `D = C @ B`, `N = C @ M`, `N_d = C @ M_d` collapse to per-sector sums of B/M/M_d. Single `Greenhouse Gases` indicator; no GWP characterization.

Recorded in the writer module docstring, `model_info` (`divergence_from_useeior`, `u_extended`, `u_d_extended`), and `bedrock/publish/README.md`.

### 5. Sheet inventory

- **Matrices**: V, U, U_d, A, A_d, B, C, D, L, L_d, M, M_d, N, N_d, q, x.
- **Metadata**: flows, indicators, commodities_meta, industries_meta, final_demand_meta, value_added_meta, config_summary, model_info.
- **Omitted via "skip if NULL"** (each carries an inline TODO):
  - `A_m`, `M_m`, `N_m` -- blocked on real `B_imp`.
  - `Rho`, `Phi`, `Tau` -- no direct bedrock analogue.
  - `demands`, `SectorCrosswalk` -- pending schema design call.

### 6. Follow-ups

- `derive_cornerstone_Ydom_matrix()` -- closes the U_d FD-truncation divergence.
- Real `B_imp` -- unlocks A_m, M_m, N_m.
- Bedrock analogues for Rho, Phi, Tau.
- `demands` / `SectorCrosswalk` schema design.
- Resolve B-units divergence (paths in `bedrock/publish/README.md`).
- Promote `_derive_cornerstone_Ytot_with_trade` to public if another non-publish caller appears.

## Testing

- **Unit tests** (`bedrock/publish/__tests__/test_excel_writer.py`, 5 tests):
  - `test_assemble_extended_U_block_placement` -- four-block layout, zero VA × FD corner, `fd=None` branch.
  - Four registry-monkeypatching tests -- skip-if-None, empty-data-sheets guard, location suffix, round-trip.

  ```
  uv run pytest bedrock/publish/__tests__/test_excel_writer.py -v
  ```

- **End-to-end smoke** for `useeio_phoebe_23`: 24 sheets (16 data + 8 metadata) at `bedrock/publish/output/<git_sha>/useeio_phoebe_23.xlsx`. Wall time ~74s.

  ```
  uv run python -m bedrock.publish.excel.cli --config_name useeio_phoebe_23
  ```

- **Structural verification of U / U_d**:
  - U `(408, 425)` = `(405 commod + 3 VA) × (405 ind + 20 FD)`; U_d `(408, 405)`.
  - VA × FD corner zero; VA blocks byte-identical between U and U_d.
  - Intermediate `U - U_d >= 0` everywhere; ~19k cells differ.
  - VA codes (`V00100..V00300`) and FD codes (`F01000..F10S00`) match canonical phoebe-23 byte-for-byte.
  - Absolute counts diverge from canonical `(411, 428)` because bedrock cornerstone is 405-sector vs useeior 408 -- tracked separately.
