### PR TITLE
fix(snapshots): align GCS upload path with loader

### DIFF
--- a/bedrock/utils/io/gcp_paths.py
+++ b/bedrock/utils/io/gcp_paths.py
@@ -2,10 +2,7 @@ import posixpath
 from collections.abc import Mapping
 from typing import Any
 
-# TODO: update/drop? after files moved on GCS
-GCS_CEDA_USA_DIR = "ceda-usa"
-GCS_SNAPSHOT_DIR = posixpath.join(GCS_CEDA_USA_DIR, "snapshots")
-
+GCS_SNAPSHOT_DIR = "snapshots"
 GCS_EXTRACT_DIR = "extract"
 GCS_EXTRACT_INPUT_DIR = posixpath.join(GCS_EXTRACT_DIR, "input-data")
 GCS_EXTRACT_TAXONOMY_DIR = posixpath.join(GCS_EXTRACT_INPUT_DIR, "taxonomy")


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

Set `GCS_SNAPSHOT_DIR = "snapshots"` in `bedrock/utils/io/gcp_paths.py` (was `ceda-usa/snapshots`) and drop the now-unused `GCS_CEDA_USA_DIR` constant.

The generator (`bedrock/utils/snapshots/generate_snapshots.py`) was uploading to `gs://cornerstone-default/ceda-usa/snapshots/<sha>/`, while the loader (`bedrock/utils/snapshots/loader.py:11`) and the `generate_snapshots.yml` workflow's Slack notification both expect `gs://cornerstone-default/snapshots/<sha>/`. Snapshots from the most recent run (run 25759953688) landed at the `ceda-usa/snapshots/` path and could not be located at the advertised path. This aligns the generator with both consumers.

Verified `GCS_CEDA_USA_DIR` has no other references in the repo.

## Testing

black, ruff, mypy pass on the changed file. Will trigger `generate_snapshots` workflow after merge and verify files appear at `gs://cornerstone-default/snapshots/<sha>/`.