### PR TITLE
"Export of waste-disagg matrices through excel publish functionality"

### DIFF
--- a/bedrock/extract/disaggregation/__tests__/test_electricity_disagg_cornerstone_materializer.py
+++ b/bedrock/extract/disaggregation/__tests__/test_electricity_disagg_cornerstone_materializer.py
@@ -1,0 +1,97 @@
+"""PR1.1: materializer smoke + writer parity (extract-owned; real ``derive_*``)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pandas as pd
+import pytest
+
+from bedrock.extract.disaggregation.electricity_disagg_cornerstone_materializer import (
+    intermediate_use_totals,
+    materialize_electricity_disagg_cornerstone_frames,
+)
+from bedrock.publish.__tests__._helpers import setup_config, teardown
+from bedrock.publish.excel import writer as writer_module
+from bedrock.transform.eeio.derived_cornerstone import get_waste_disagg_weights
+
+
+@pytest.fixture
+def cornerstone_full_model_config() -> Iterator[None]:
+    setup_config('2025_usa_cornerstone_full_model.yaml')
+    yield
+    teardown()
+
+
+@pytest.mark.skipif(
+    get_waste_disagg_weights() is None,
+    reason='Waste disaggregation weight CSVs not available',
+)
+def test_materialize_electricity_disagg_cornerstone_frames_smoke(
+    cornerstone_full_model_config: object,
+) -> None:
+    writer_module.clear_publish_caches()
+    frames = materialize_electricity_disagg_cornerstone_frames()
+    assert set(frames) == {'V', 'Udom', 'Uimp', 'VA', 'Y', 'E'}
+    V, Udom, Uimp, VA, Y, E = (
+        frames['V'],
+        frames['Udom'],
+        frames['Uimp'],
+        frames['VA'],
+        frames['Y'],
+        frames['E'],
+    )
+    assert Udom.shape == Uimp.shape
+    assert Udom.index.equals(Uimp.index)
+    assert Udom.columns.equals(V.index)
+    assert Udom.index.equals(V.columns)
+    assert VA.shape[1] == V.shape[0]
+    assert Y.index.equals(Udom.index)
+    assert E.shape[1] == V.shape[0]
+    assert E.columns.equals(V.index)
+
+
+@pytest.mark.skipif(
+    get_waste_disagg_weights() is None,
+    reason='Waste disaggregation weight CSVs not available',
+)
+def test_intermediate_use_totals_matches_u_dom_plus_u_imp(
+    cornerstone_full_model_config: object,
+) -> None:
+    writer_module.clear_publish_caches()
+    frames = materialize_electricity_disagg_cornerstone_frames()
+    tot = intermediate_use_totals()
+    pd.testing.assert_frame_equal(
+        tot, frames['Udom'] + frames['Uimp'], check_names=True, rtol=0.0, atol=0.0
+    )
+
+
+@pytest.mark.skipif(
+    get_waste_disagg_weights() is None,
+    reason='Waste disaggregation weight CSVs not available',
+)
+def test_writer_getters_match_materializer_v_and_u_intermediate(
+    cornerstone_full_model_config: object,
+) -> None:
+    writer_module.clear_publish_caches()
+    frames = materialize_electricity_disagg_cornerstone_frames()
+    pd.testing.assert_frame_equal(
+        writer_module._get_V(),
+        frames['V'],
+        check_names=True,
+        rtol=0.0,
+        atol=0.0,
+        check_flags=False,
+    )
+    extended_u = writer_module._get_U()
+    n_r, n_c = frames['Udom'].shape
+    pd.testing.assert_frame_equal(
+        extended_u.iloc[:n_r, :n_c],
+        frames['Udom'] + frames['Uimp'],
+        check_names=True,
+        rtol=0.0,
+        atol=0.0,
+        check_flags=False,
+    )
+    extended_ud = writer_module._get_Udom()
+    assert extended_ud.iloc[:n_r, :n_c].equals(frames['Udom'])

--- a/bedrock/extract/disaggregation/__tests__/test_export_cornerstone_waste_disagg_matrices.py
+++ b/bedrock/extract/disaggregation/__tests__/test_export_cornerstone_waste_disagg_matrices.py
@@ -7,97 +7,98 @@ from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
+import yaml
 
 import bedrock.transform.eeio.derived_cornerstone as derived_cornerstone
 from bedrock.extract.disaggregation import (
     export_cornerstone_waste_disagg_matrices as exp,
 )
+from bedrock.utils.config.usa_config import CONFIG_DIR, USAConfig
 
 
-def _canonical_full_model_config_mock() -> MagicMock:
-    m = MagicMock()
-    for key, val in exp._FULL_MODEL_MATRIX_EXPORT_FLAGS.items():
-        setattr(m, key, val)
-    return m
+def _canonical_usa_config_from_yaml() -> USAConfig:
+    path = Path(CONFIG_DIR) / exp.CORNERSTONE_FULL_MODEL_EXPORT_YAML
+    with open(path, encoding='utf-8') as f:
+        return USAConfig.model_validate(yaml.safe_load(f), strict=True)
 
 
 def test_assert_cornerstone_matrix_export_preconditions_passes() -> None:
-    with patch.object(
-        exp, "get_usa_config", return_value=_canonical_full_model_config_mock()
-    ):
-        with patch.object(exp, "get_waste_disagg_weights", return_value=MagicMock()):
+    cfg = _canonical_usa_config_from_yaml()
+    with patch.object(exp, 'get_usa_config', return_value=cfg):
+        with patch.object(exp, 'get_waste_disagg_weights', return_value=MagicMock()):
             exp.assert_cornerstone_matrix_export_preconditions()
 
 
 def test_assert_cornerstone_matrix_export_preconditions_raises_without_waste_weights() -> (
     None
 ):
-    with patch.object(
-        exp, "get_usa_config", return_value=_canonical_full_model_config_mock()
-    ):
-        with patch.object(exp, "get_waste_disagg_weights", return_value=None):
-            with pytest.raises(RuntimeError, match="waste disaggregation"):
+    cfg = _canonical_usa_config_from_yaml()
+    with patch.object(exp, 'get_usa_config', return_value=cfg):
+        with patch.object(exp, 'get_waste_disagg_weights', return_value=None):
+            with pytest.raises(RuntimeError, match='waste disaggregation'):
                 exp.assert_cornerstone_matrix_export_preconditions()
 
 
 def test_assert_cornerstone_matrix_export_preconditions_raises_on_flag_mismatch() -> (
     None
 ):
-    cfg = _canonical_full_model_config_mock()
-    cfg.load_E_from_flowsa = False
-    with patch.object(exp, "get_usa_config", return_value=cfg):
-        with patch.object(exp, "get_waste_disagg_weights", return_value=MagicMock()):
-            with pytest.raises(RuntimeError, match="load_E_from_flowsa"):
+    cfg = _canonical_usa_config_from_yaml()
+    cfg = cfg.model_copy(update={'load_E_from_flowsa': False})
+    with patch.object(exp, 'get_usa_config', return_value=cfg):
+        with patch.object(exp, 'get_waste_disagg_weights', return_value=MagicMock()):
+            with pytest.raises(RuntimeError, match='load_E_from_flowsa'):
                 exp.assert_cornerstone_matrix_export_preconditions()
 
 
 def test_export_cornerstone_matrices_to_csv_writes_expected_csvs(
     tmp_path: Path,
 ) -> None:
-    V = pd.DataFrame([[1.0]], index=["i0"], columns=["c0"])
-    Udom = pd.DataFrame([[2.0]], index=["c0"], columns=["i0"])
-    Uimp = pd.DataFrame([[3.0]], index=["c0"], columns=["i0"])
-    VA = pd.DataFrame([[4.0]], index=["V0"], columns=["i0"])
-    Y = pd.DataFrame([[5.0]], index=["c0"], columns=["F0"])
-    E = pd.DataFrame([[6.0]], index=["GHG0"], columns=["i0"])
-    uset = MagicMock()
-    uset.Udom = Udom
-    uset.Uimp = Uimp
-
-    with patch.object(
-        exp, "get_usa_config", return_value=_canonical_full_model_config_mock()
-    ):
-        with patch.object(exp, "get_waste_disagg_weights", return_value=MagicMock()):
-            with patch.object(exp, "derive_cornerstone_V", return_value=V):
-                with patch.object(exp, "derive_cornerstone_U_set", return_value=uset):
-                    with patch.object(exp, "derive_cornerstone_VA", return_value=VA):
-                        with patch.object(
-                            exp,
-                            "derive_cornerstone_Ytot_full_cs_matrix",
-                            return_value=Y,
-                        ):
-                            with patch.object(exp, "derive_E_usa", return_value=E):
-                                out = exp.export_cornerstone_matrices_to_csv(tmp_path)
+    V = pd.DataFrame([[1.0]], index=['i0'], columns=['c0'])
+    Udom = pd.DataFrame([[2.0]], index=['c0'], columns=['i0'])
+    Uimp = pd.DataFrame([[3.0]], index=['c0'], columns=['i0'])
+    VA = pd.DataFrame([[4.0]], index=['V0'], columns=['i0'])
+    Y = pd.DataFrame([[5.0]], index=['c0'], columns=['F0'])
+    E = pd.DataFrame([[6.0]], index=['GHG0'], columns=['i0'])
+    frames = {
+        'V': V,
+        'Udom': Udom,
+        'Uimp': Uimp,
+        'VA': VA,
+        'Y': Y,
+        'E': E,
+    }
+    cfg = _canonical_usa_config_from_yaml()
+    with patch.object(exp, 'get_usa_config', return_value=cfg):
+        with patch.object(exp, 'get_waste_disagg_weights', return_value=MagicMock()):
+            with patch(
+                'bedrock.publish.excel.writer.clear_publish_caches',
+            ):
+                with patch.object(
+                    exp,
+                    'materialize_electricity_disagg_cornerstone_frames',
+                    return_value=frames,
+                ):
+                    out = exp.export_cornerstone_matrices_to_csv(tmp_path)
 
     assert out.resolve() == tmp_path.resolve()
     names = {p.name for p in tmp_path.iterdir()}
     assert names == {
-        "cornerstone_V.csv",
-        "cornerstone_Udom.csv",
-        "cornerstone_Uimp.csv",
-        "cornerstone_VA.csv",
-        "cornerstone_Ytot_full_cs.csv",
-        "cornerstone_E.csv",
+        'cornerstone_V.csv',
+        'cornerstone_Udom.csv',
+        'cornerstone_Uimp.csv',
+        'cornerstone_VA.csv',
+        'cornerstone_Ytot_full_cs.csv',
+        'cornerstone_E.csv',
     }
-    round_trip = pd.read_csv(tmp_path / "cornerstone_V.csv", index_col=0)
+    round_trip = pd.read_csv(tmp_path / 'cornerstone_V.csv', index_col=0)
     pd.testing.assert_frame_equal(round_trip, V)
 
 
 def test_derive_cornerstone_ytot_full_cs_matrix_is_copy_of_underlying() -> None:
-    fake = pd.DataFrame({"F1": [1.0, 2.0]}, index=["c1", "c2"])
+    fake = pd.DataFrame({'F1': [1.0, 2.0]}, index=['c1', 'c2'])
     with patch.object(
         derived_cornerstone,
-        "_derive_cornerstone_Ytot_with_trade",
+        '_derive_cornerstone_Ytot_with_trade',
         return_value=fake,
     ):
         out = derived_cornerstone.derive_cornerstone_Ytot_full_cs_matrix()

--- a/bedrock/extract/disaggregation/electricity_disagg_cornerstone_materializer.py
+++ b/bedrock/extract/disaggregation/electricity_disagg_cornerstone_materializer.py
@@ -1,0 +1,44 @@
+"""Cornerstone matrix bundle for electricity disaggregation (PR1.1).
+
+Single-sourced with ``bedrock.publish.excel.writer`` for ``V`` and domestic/import
+Use totals. See ``Electricity_disagg_implementation.md`` § PR 1.1.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from bedrock.transform.allocation.derived import derive_E_usa
+from bedrock.transform.eeio.derived_cornerstone import (
+    derive_cornerstone_U_set,
+    derive_cornerstone_V,
+    derive_cornerstone_VA,
+    derive_cornerstone_Ytot_full_cs_matrix,
+)
+
+
+def intermediate_use_totals() -> pd.DataFrame:
+    """Commodity × industry total Use (``Udom + Uimp``) from one ``U_set`` call."""
+    uset = derive_cornerstone_U_set()
+    return uset.Udom + uset.Uimp
+
+
+def materialize_electricity_disagg_cornerstone_frames() -> dict[str, pd.DataFrame]:
+    """Return the six cornerstone-native frames required for electricity CSV export.
+
+    Keys: ``V``, ``Udom``, ``Uimp``, ``VA``, ``Y``, ``E`` — same objects as the
+    underlying ``derive_*`` functions (cached where those functions are cached).
+    """
+    V = derive_cornerstone_V()
+    uset = derive_cornerstone_U_set()
+    VA = derive_cornerstone_VA()
+    Y = derive_cornerstone_Ytot_full_cs_matrix()
+    E = derive_E_usa()
+    return {
+        'V': V,
+        'Udom': uset.Udom,
+        'Uimp': uset.Uimp,
+        'VA': VA,
+        'Y': Y,
+        'E': E,
+    }

--- a/bedrock/extract/disaggregation/export_cornerstone_waste_disagg_matrices.py
+++ b/bedrock/extract/disaggregation/export_cornerstone_waste_disagg_matrices.py
@@ -1,54 +1,101 @@
 """Export waste-disaggregated Cornerstone matrices for offline electricity disaggregation.
 
 Requires active :class:`~bedrock.utils.config.usa_config.USAConfig` to match the methodology
-flags in ``2025_usa_cornerstone_full_model.yaml`` and loadable waste disaggregation weights.
+subset in ``2025_usa_cornerstone_full_model.yaml`` (parsed via ``USAConfig``) and loadable
+waste disaggregation weights.
 """
 
 from __future__ import annotations
 
+import os
 import pathlib
 
-from bedrock.transform.allocation.derived import derive_E_usa
-from bedrock.transform.eeio.derived_cornerstone import (
-    derive_cornerstone_U_set,
-    derive_cornerstone_V,
-    derive_cornerstone_VA,
-    derive_cornerstone_Ytot_full_cs_matrix,
-    get_waste_disagg_weights,
+import yaml
+from pydantic import ValidationError
+
+from bedrock.extract.disaggregation.electricity_disagg_cornerstone_materializer import (
+    materialize_electricity_disagg_cornerstone_frames,
 )
-from bedrock.utils.config.usa_config import get_usa_config
+from bedrock.transform.eeio.derived_cornerstone import get_waste_disagg_weights
+from bedrock.utils.config.usa_config import CONFIG_DIR, USAConfig, get_usa_config
 
 _DISAGG_ROOT = pathlib.Path(__file__).resolve().parent
 
-_FULL_MODEL_MATRIX_EXPORT_FLAGS: dict[str, bool] = {
-    "use_cornerstone_2026_model_schema": True,
-    "load_E_from_flowsa": True,
-    "new_ghg_method": True,
-    "use_E_data_year_for_x_in_B": True,
-    "implement_waste_disaggregation": True,
-}
+CORNERSTONE_FULL_MODEL_EXPORT_YAML = '2025_usa_cornerstone_full_model.yaml'
+
+_EXPORT_METHODOLOGY_KEYS: tuple[str, ...] = (
+    'use_cornerstone_2026_model_schema',
+    'load_E_from_flowsa',
+    'new_ghg_method',
+    'use_E_data_year_for_x_in_B',
+    'implement_waste_disaggregation',
+)
+
+
+def _load_expected_cornerstone_export_config() -> USAConfig:
+    path = os.path.join(CONFIG_DIR, CORNERSTONE_FULL_MODEL_EXPORT_YAML)
+    with open(path, encoding='utf-8') as f:
+        data = yaml.safe_load(f)
+    try:
+        return USAConfig.model_validate(data, strict=True)
+    except ValidationError as e:
+        raise RuntimeError(
+            f'Failed to parse methodology YAML {CORNERSTONE_FULL_MODEL_EXPORT_YAML!r}: {e}'
+        ) from e
 
 
 def assert_cornerstone_matrix_export_preconditions() -> None:
     """Raise ``RuntimeError`` if the current config cannot dump cornerstone matrix CSVs."""
+
     cfg = get_usa_config()
+    expected = _load_expected_cornerstone_export_config()
     mismatches: list[str] = []
-    for key, expected in _FULL_MODEL_MATRIX_EXPORT_FLAGS.items():
+    for key in _EXPORT_METHODOLOGY_KEYS:
         actual = getattr(cfg, key)
-        if actual is not expected:
-            mismatches.append(f"{key}={actual!r} (expected {expected!r})")
+        exp_val = getattr(expected, key)
+        if actual != exp_val:
+            mismatches.append(f'{key}={actual!r} (expected {exp_val!r} from YAML pin)')
     if mismatches:
         raise RuntimeError(
-            "Cornerstone matrix export requires USAConfig methodology flags matching "
-            "`2025_usa_cornerstone_full_model.yaml`: "
-            + "; ".join(mismatches)
-            + ". Load that YAML via set_global_usa_config(...) before exporting."
+            'Cornerstone matrix export requires USAConfig methodology flags matching '
+            f'`{CORNERSTONE_FULL_MODEL_EXPORT_YAML}`: '
+            + '; '.join(mismatches)
+            + '. Load that YAML via set_global_usa_config(...) before exporting.'
         )
     if get_waste_disagg_weights() is None:
         raise RuntimeError(
-            "Cornerstone matrix export requires waste disaggregation weights "
-            "(implement_waste_disaggregation and readable weight CSVs)."
+            'Cornerstone matrix export requires waste disaggregation weights '
+            '(implement_waste_disaggregation and readable weight CSVs).'
         )
+
+
+def export_electricity_disagg_cornerstone_csvs(
+    output_dir: pathlib.Path | None = None,
+) -> pathlib.Path:
+    """Clear publish caches, assert preconditions, materialize, write six CSVs.
+
+    Import ``clear_publish_caches`` from ``publish`` inside this function to avoid
+    extract→publish import-time coupling.
+    """
+    from bedrock.publish.excel.writer import clear_publish_caches  # noqa: PLC0415
+
+    clear_publish_caches()
+    assert_cornerstone_matrix_export_preconditions()
+    frames = materialize_electricity_disagg_cornerstone_frames()
+    out = (
+        _DISAGG_ROOT / 'electricity_disagg_inputs'
+        if output_dir is None
+        else pathlib.Path(output_dir)
+    )
+    out.mkdir(parents=True, exist_ok=True)
+
+    frames['V'].to_csv(out / 'cornerstone_V.csv', index=True)
+    frames['Udom'].to_csv(out / 'cornerstone_Udom.csv', index=True)
+    frames['Uimp'].to_csv(out / 'cornerstone_Uimp.csv', index=True)
+    frames['VA'].to_csv(out / 'cornerstone_VA.csv', index=True)
+    frames['Y'].to_csv(out / 'cornerstone_Ytot_full_cs.csv', index=True)
+    frames['E'].to_csv(out / 'cornerstone_E.csv', index=True)
+    return out
 
 
 def export_cornerstone_matrices_to_csv(
@@ -58,33 +105,13 @@ def export_cornerstone_matrices_to_csv(
 
     Returns the directory written.
     """
-    assert_cornerstone_matrix_export_preconditions()
-    out = (
-        _DISAGG_ROOT / "electricity_disagg_inputs"
-        if output_dir is None
-        else pathlib.Path(output_dir)
-    )
-    out.mkdir(parents=True, exist_ok=True)
-
-    V = derive_cornerstone_V()
-    uset = derive_cornerstone_U_set()
-    VA = derive_cornerstone_VA()
-    Y = derive_cornerstone_Ytot_full_cs_matrix()
-    E = derive_E_usa()
-
-    V.to_csv(out / "cornerstone_V.csv", index=True)
-    uset.Udom.to_csv(out / "cornerstone_Udom.csv", index=True)
-    uset.Uimp.to_csv(out / "cornerstone_Uimp.csv", index=True)
-    VA.to_csv(out / "cornerstone_VA.csv", index=True)
-    Y.to_csv(out / "cornerstone_Ytot_full_cs.csv", index=True)
-    E.to_csv(out / "cornerstone_E.csv", index=True)
-    return out
+    return export_electricity_disagg_cornerstone_csvs(output_dir)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     # Offline use: set USA_CONFIG_FILE or call set_global_usa_config first.
     from bedrock.utils.config.usa_config import set_global_usa_config
 
-    set_global_usa_config("2025_usa_cornerstone_full_model.yaml")
+    set_global_usa_config(CORNERSTONE_FULL_MODEL_EXPORT_YAML)
     dest = export_cornerstone_matrices_to_csv()
-    print(f"Wrote cornerstone matrix CSVs to {dest.resolve()}")
+    print(f'Wrote cornerstone matrix CSVs to {dest.resolve()}')

--- a/bedrock/publish/__tests__/_helpers.py
+++ b/bedrock/publish/__tests__/_helpers.py
@@ -17,6 +17,7 @@ from typing import Callable
 
 import bedrock.utils.config.common as common
 from bedrock.publish.excel.writer import clear_publish_caches
+from bedrock.transform.eeio import derived_cornerstone as derived_cornerstone_module
 from bedrock.transform.eeio.derived import (
     derive_Aq_usa,
     derive_B_usa_non_finetuned,
@@ -58,6 +59,7 @@ CACHED_FUNCTIONS: list[Callable[..., object]] = [
     derive_cornerstone_Vnorm_scrap_corrected,
     derive_cornerstone_U_with_negatives,
     derive_cornerstone_U_set,
+    derived_cornerstone_module._derive_cornerstone_Ytot_with_trade,
     derive_cornerstone_Ytot_matrix_set,
     derive_cornerstone_VA,
     derive_cornerstone_Aq,

--- a/bedrock/publish/excel/writer.py
+++ b/bedrock/publish/excel/writer.py
@@ -376,9 +376,11 @@ def _assemble_extended_U(
 
 @functools.cache
 def _get_V() -> pd.DataFrame:
-    from bedrock.transform.eeio.derived_cornerstone import derive_cornerstone_V
+    from bedrock.extract.disaggregation.electricity_disagg_cornerstone_materializer import (
+        materialize_electricity_disagg_cornerstone_frames,
+    )
 
-    return derive_cornerstone_V()
+    return materialize_electricity_disagg_cornerstone_frames()['V']
 
 
 @functools.cache
@@ -387,15 +389,16 @@ def _get_U() -> pd.DataFrame:
     # Promote to a public `derive_cornerstone_Y_matrix()` once another
     # non-publish caller appears -- see option A in the writer module
     # docstring discussion.
+    from bedrock.extract.disaggregation.electricity_disagg_cornerstone_materializer import (
+        intermediate_use_totals,
+    )
     from bedrock.transform.eeio.derived_cornerstone import (
         _derive_cornerstone_Ytot_with_trade,
-        derive_cornerstone_U_set,
         derive_cornerstone_VA,
     )
     from bedrock.utils.taxonomy.cornerstone.final_demand import FINAL_DEMANDS
 
-    uset = derive_cornerstone_U_set()
-    intermediate = uset.Udom + uset.Uimp
+    intermediate = intermediate_use_totals()
     # Reindex by canonical FINAL_DEMANDS order so column layout matches
     # useeior's `U` regardless of source column ordering.
     fd_block = _derive_cornerstone_Ytot_with_trade()[list(FINAL_DEMANDS)]
@@ -410,13 +413,13 @@ def _get_U() -> pd.DataFrame:
 def _get_Udom() -> pd.DataFrame:
     # FD block intentionally truncated; bedrock has no Ydom matrix at
     # FD-category resolution today. See writer module docstring.
-    from bedrock.transform.eeio.derived_cornerstone import (
-        derive_cornerstone_U_set,
-        derive_cornerstone_VA,
+    from bedrock.extract.disaggregation.electricity_disagg_cornerstone_materializer import (
+        materialize_electricity_disagg_cornerstone_frames,
     )
+    from bedrock.transform.eeio.derived_cornerstone import derive_cornerstone_VA
 
     return _assemble_extended_U(
-        intermediate=derive_cornerstone_U_set().Udom,
+        intermediate=materialize_electricity_disagg_cornerstone_frames()['Udom'],
         fd=None,
         va=derive_cornerstone_VA(),
     )


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

Introduces `electricity_disagg_cornerstone_materializer.py` as a single-sourced module that materializes the six cornerstone frames (`V`, `Udom`, `Uimp`, `VA`, `Y`, `E`) required for electricity disaggregation CSV export. This consolidates what was previously scattered `derive_*` calls in both `export_cornerstone_waste_disagg_matrices.py` and `writer.py` into one canonical location.

`_get_V()`, `_get_U()`, and `_get_Udom()` in `writer.py` now delegate to `materialize_electricity_disagg_cornerstone_frames()` and `intermediate_use_totals()` from the new materializer, ensuring the writer and the CSV exporter are always in sync.

`export_cornerstone_waste_disagg_matrices.py` is updated to read expected methodology flags directly from the pinned YAML (`2025_usa_cornerstone_full_model.yaml`) via `USAConfig.model_validate` rather than a hardcoded dict, so the precondition check stays aligned with the YAML automatically. A new public entry point `export_electricity_disagg_cornerstone_csvs` is added (with `export_cornerstone_matrices_to_csv` kept as a backward-compatible alias) that clears publish caches before materializing.

## Testing

Three new smoke tests cover the materializer:
- `test_materialize_electricity_disagg_cornerstone_frames_smoke` — asserts all six frames are returned with consistent shapes and aligned indices.
- `test_intermediate_use_totals_matches_u_dom_plus_u_imp` — asserts `intermediate_use_totals()` equals `Udom + Uimp` from the full frame bundle.
- `test_writer_getters_match_materializer_v_and_u_intermediate` — asserts `_get_V()`, `_get_U()`, and `_get_Udom()` from the writer return values consistent with the materializer output.

Existing tests in `test_export_cornerstone_waste_disagg_matrices.py` are updated to load the expected config from the real YAML via `USAConfig.model_validate` and to patch `materialize_electricity_disagg_cornerstone_frames` directly instead of individual `derive_*` functions.