### PR TITLE
replace `use_useeio_B` with `deflate_x_to_detail_io_year_for_B`

### DIFF
--- a/bedrock/transform/eeio/__tests__/test_useeio_b_steps.py
+++ b/bedrock/transform/eeio/__tests__/test_useeio_b_steps.py
@@ -39,8 +39,8 @@ def test_useeio_b_adjust_divide_transform_steps(
         dc,
         "get_usa_config",
         lambda: SimpleNamespace(
-            use_useeio_B=True,
-            use_E_data_year_for_x_in_B=False,
+            deflate_x_to_detail_io_year_for_B=True,
+            use_E_data_year_for_x_in_B=True,
             usa_ghg_data_year=2023,
             usa_detail_original_year=2017,
         ),

--- a/bedrock/transform/eeio/__tests__/test_waste_disagg_pipeline_integration.py
+++ b/bedrock/transform/eeio/__tests__/test_waste_disagg_pipeline_integration.py
@@ -16,10 +16,7 @@ import pytest
 
 from bedrock.extract.disaggregation.disagg_weights import DisaggWeights
 from bedrock.transform.allocation.derived import derive_E_usa
-from bedrock.transform.eeio import (
-    cornerstone_bea_intermediates,
-    cornerstone_expansion,
-)
+from bedrock.transform.eeio import cornerstone_expansion
 from bedrock.transform.eeio.derived_cornerstone import (
     _WASTE_NEW_CODES,
     _derive_cornerstone_Ytot_with_trade,
@@ -458,7 +455,6 @@ class TestPipelineB:
                 "B runtime path should not call BEA-expansion E helpers"
             )
 
-        monkeypatch.setattr(cornerstone_bea_intermediates, "bea_E", _raise_if_called)
         monkeypatch.setattr(
             cornerstone_expansion,
             "expand_ghg_matrix_from_bea_to_cornerstone",

--- a/bedrock/transform/eeio/cornerstone_bea_intermediates.py
+++ b/bedrock/transform/eeio/cornerstone_bea_intermediates.py
@@ -16,11 +16,6 @@ from bedrock.extract.iot.io_2017 import (
     load_2017_Utot_usa,
     load_2017_V_usa,
 )
-from bedrock.transform.allocation.derived import derive_E_usa
-from bedrock.transform.iot.derived_gross_industry_output import (
-    derive_gross_output_after_redefinition,
-)
-from bedrock.utils.config.usa_config import get_usa_config
 from bedrock.utils.math.formulas import (
     compute_A_matrix,
     compute_q,
@@ -29,9 +24,6 @@ from bedrock.utils.math.formulas import (
     compute_x,
 )
 from bedrock.utils.math.handle_negatives import handle_negative_matrix_values
-from bedrock.utils.taxonomy.usa_taxonomy_correspondence_helpers import (
-    load_usa_2017_industry__ceda_v7_correspondence,
-)
 
 # ---------------------------------------------------------------------------
 # Core output vectors
@@ -95,50 +87,3 @@ def bea_Aq() -> tuple[pd.DataFrame, pd.DataFrame, pd.Series[float]]:
         V_norm=Vnorm,
     )
     return Adom, Aimp, bea_q()
-
-
-# ---------------------------------------------------------------------------
-# Emissions: CEDA v7 → BEA industry → B
-# ---------------------------------------------------------------------------
-
-
-@functools.cache
-def _ceda_v7_industry_corresp() -> pd.DataFrame:
-    """CEDA v7 → BEA 2017 industry correspondence (rows=CEDA v7, cols=BEA industry)."""
-    return load_usa_2017_industry__ceda_v7_correspondence()
-
-
-@functools.cache
-def _x_weighted_ceda_industry_corresp() -> pd.DataFrame:
-    """CEDA v7 → BEA industry correspondence, row-normalized by industry output (x).
-
-    Handles both disaggregation (one CEDA v7 → multiple BEA codes) and
-    government aggregation by weighting proportionally by x.
-    """
-    corresp = _ceda_v7_industry_corresp()
-    x = bea_x()
-    x_aligned = x.reindex(corresp.columns, fill_value=0.0)
-    weighted = corresp.multiply(x_aligned, axis=1)
-    row_sums = weighted.sum(axis=1)
-    return weighted.div(row_sums.replace(0, 1), axis=0)
-
-
-@functools.cache
-def bea_E() -> pd.DataFrame:
-    """E (ghg × BEA_industry) — CEDA v7 emissions mapped to BEA industry space."""
-    return derive_E_usa() @ _x_weighted_ceda_industry_corresp()
-
-
-@functools.cache
-def bea_B() -> pd.DataFrame:
-    """B (ghg × BEA_commodity).  B = (E / x) @ V_norm."""
-    E = bea_E()
-    if get_usa_config().use_E_data_year_for_x_in_B:
-        x = derive_gross_output_after_redefinition(
-            target_year=get_usa_config().usa_ghg_data_year
-        )
-    else:
-        x = bea_x()  # this is 2017 x
-    Vnorm = bea_Vnorm_scrap_corrected()
-    Bi = E.divide(x, axis=1).fillna(0.0)
-    return Bi @ Vnorm

--- a/bedrock/transform/eeio/derived_cornerstone.py
+++ b/bedrock/transform/eeio/derived_cornerstone.py
@@ -653,26 +653,32 @@ def derive_cornerstone_B_via_vnorm() -> pd.DataFrame:
 
     Always computed in Cornerstone space: E = derive_E_usa(), then B = (E / x) @ Vnorm.
     Industry ``x`` is:
-    - USEEIO B method (`use_useeio_B=True`): target-year gross output adjusted
-      to original-year USD using industry chained-price index ratio.
+    - ``deflate_x_to_detail_io_year_for_B=True``: gross output from the BEA
+      gross-output time series at ``usa_ghg_data_year`` (nominal), divided by
+      ``PI(usa_ghg_data_year)/PI(usa_detail_original_year)`` so ``E/x`` uses
+      ``usa_detail_original_year`` chain dollars. ``USAConfig`` requires
+      ``use_E_data_year_for_x_in_B`` to be true whenever deflation is on; the
+      deflate branch always builds nominal ``x`` via
+      ``derive_cornerstone_x_after_redefinition()`` before the PI ratio, so
+      ``use_E_data_year_for_x_in_B`` does not further branch choice here.
     - otherwise: ``derive_cornerstone_x_after_redefinition()`` when
       ``use_E_data_year_for_x_in_B`` is True, else ``derive_cornerstone_x()``.
     No BEA intermediate or expand_ghg_matrix_from_bea_to_cornerstone.
     """
     E = derive_E_usa()
     cfg = get_usa_config()
-    if cfg.use_useeio_B:
-        # USEEIO B method:
-        #   1) adjust target-year industry output into original-year USD
-        #   2) divide E by adjusted industry output
-        #   3) transform to commodity space using market shares (Vnorm)
+    if cfg.deflate_x_to_detail_io_year_for_B:
+        # Deflate GHG-year nominal gross output to detail IO year ($) for E/x:
+        #   1) nominal industry output at usa_ghg_data_year
+        #   2) divide by PI(ghg)/PI(detail) so x matches usa_detail_original_year $
+        #   3) divide E by adjusted industry output; map to commodities via Vnorm
         x_nominal = derive_cornerstone_x_after_redefinition()
         ratio = get_cornerstone_industry_price_ratio(
             original_year=cfg.usa_detail_original_year,
             target_year=cfg.usa_ghg_data_year,
         )
-        # ratio is PI_target / PI_original; divide nominal target-year dollars
-        # to convert x into original-year dollars for USEEIO-style B.
+        # ratio is PI_target / PI_original; divide nominal GHG-year dollars
+        # so x is expressed in usa_detail_original_year chain dollars for E/x.
         ratio_aligned = ratio.reindex(x_nominal.index)
         ratio_aligned = ratio_aligned.where(ratio_aligned.notna(), 1.0)
         x = x_nominal / ratio_aligned
@@ -692,23 +698,21 @@ def derive_cornerstone_B_via_vnorm() -> pd.DataFrame:
 def derive_cornerstone_B_non_finetuned() -> pd.DataFrame:
     """Year-scaled + inflated B, derived self-contained from CEDA v7 → cornerstone."""
     cfg = get_usa_config()
-    # USEEIO B method keeps B on the base derivation path (no summary scaling /
-    # price inflation of B). use_E_data_year_for_x_in_B remains an independent
-    # x-sourcing switch inside derive_cornerstone_B_via_vnorm().
-    if cfg.use_useeio_B:
-        return derive_cornerstone_B_via_vnorm()
+    # ``deflate_x_to_detail_io_year_for_B`` implies ``use_E_data_year_for_x_in_B``
+    # (``USAConfig``). When either path is active, keep B on vnorm only (no
+    # summary scaling / industry PI inflation of B here); vnorm applies the
+    # deflate branch when that flag is set.
     if cfg.use_E_data_year_for_x_in_B:
         return derive_cornerstone_B_via_vnorm()
-    else:
-        return inflate_cornerstone_B_matrix_with_industry_pi(
-            scale_cornerstone_B(
-                B=derive_cornerstone_B_via_vnorm(),
-                original_year=cfg.usa_detail_original_year,
-                target_year=cfg.usa_io_data_year,
-            ),
-            original_year=cfg.usa_io_data_year,
-            target_year=cfg.model_base_year,
-        )
+    return inflate_cornerstone_B_matrix_with_industry_pi(
+        scale_cornerstone_B(
+            B=derive_cornerstone_B_via_vnorm(),
+            original_year=cfg.usa_detail_original_year,
+            target_year=cfg.usa_io_data_year,
+        ),
+        original_year=cfg.usa_io_data_year,
+        target_year=cfg.model_base_year,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/bedrock/utils/config/__tests__/test_usa_config.py
+++ b/bedrock/utils/config/__tests__/test_usa_config.py
@@ -184,12 +184,15 @@ def test_disallow_m2_without_useeio_schema() -> None:
         )
 
 
-def test_disallow_useeio_b_with_e_data_year_x_flag() -> None:
+def test_disallow_deflate_x_without_use_e_for_x_in_b() -> None:
     with pytest.raises(
         ValueError,
-        match='use_useeio_B and use_E_data_year_for_x_in_B cannot both be true',
+        match='deflate_x_to_detail_io_year_for_B requires use_E_data_year_for_x_in_B',
     ):
         USAConfig.model_validate(
-            {'use_useeio_B': True, 'use_E_data_year_for_x_in_B': True},
+            {
+                'deflate_x_to_detail_io_year_for_B': True,
+                'use_E_data_year_for_x_in_B': False,
+            },
             strict=True,
         )

--- a/bedrock/utils/config/configs/useeio_phoebe_23.yaml
+++ b/bedrock/utils/config/configs/useeio_phoebe_23.yaml
@@ -18,7 +18,7 @@ usa_ghg_data_year: 2023
 #####
 use_cornerstone_2026_model_schema: true
 load_E_from_flowsa: true
-use_E_data_year_for_x_in_B: false
+use_E_data_year_for_x_in_B: true
 implement_waste_disaggregation: true
 
 # USEEIO-style A: keep 2017 base A when scaling A,q (PR #229 / Issue #182).
@@ -26,7 +26,7 @@ implement_waste_disaggregation: true
 scale_a_matrix_with_useeio_method: true
 
 use_useeio_schema: true
-use_useeio_B: true
+deflate_x_to_detail_io_year_for_B: true
 use_ghg_national_2023_m2: true
 skip_scrap_adjustment_in_vnorm: true
 

--- a/bedrock/utils/config/configs/useeio_phoebe_23_restore_cornerstone_A.yaml
+++ b/bedrock/utils/config/configs/useeio_phoebe_23_restore_cornerstone_A.yaml
@@ -10,14 +10,14 @@ usa_ghg_data_year: 2023
 
 use_cornerstone_2026_model_schema: true
 load_E_from_flowsa: true
-use_E_data_year_for_x_in_B: false
+use_E_data_year_for_x_in_B: true
 implement_waste_disaggregation: true
 
 # Restore A-scaling behavior to Anchor A for this single sensitivity.
 scale_a_matrix_with_useeio_method: false
 
 use_useeio_schema: true
-use_useeio_B: true
+deflate_x_to_detail_io_year_for_B: true
 use_ghg_national_2023_m2: true
 skip_scrap_adjustment_in_vnorm: true
 new_ghg_method: false

--- a/bedrock/utils/config/configs/useeio_phoebe_23_restore_cornerstone_B.yaml
+++ b/bedrock/utils/config/configs/useeio_phoebe_23_restore_cornerstone_B.yaml
@@ -1,5 +1,5 @@
 # Sensitivity from useeio_phoebe_23: restore Cornerstone B approach.
-# Sets use_useeio_B to false so B-matrix construction returns to the
+# Sets deflate_x_to_detail_io_year_for_B to false so B-matrix construction returns to the
 # Cornerstone default (the rest of the rebuild stays as in useeio_phoebe_23).
 
 model_base_year: 2017
@@ -16,7 +16,7 @@ implement_waste_disaggregation: true
 scale_a_matrix_with_useeio_method: true
 
 use_useeio_schema: true
-use_useeio_B: false # False means use Cornerstone B approach
+deflate_x_to_detail_io_year_for_B: false # False means use Cornerstone B approach
 use_ghg_national_2023_m2: true
 skip_scrap_adjustment_in_vnorm: true
 new_ghg_method: false

--- a/bedrock/utils/config/configs/useeio_phoebe_23_restore_ghg.yaml
+++ b/bedrock/utils/config/configs/useeio_phoebe_23_restore_ghg.yaml
@@ -9,13 +9,13 @@ usa_ghg_data_year: 2023
 
 use_cornerstone_2026_model_schema: true
 load_E_from_flowsa: true
-use_E_data_year_for_x_in_B: false
+use_E_data_year_for_x_in_B: true
 implement_waste_disaggregation: true
 
 scale_a_matrix_with_useeio_method: true
 
 use_useeio_schema: true
-use_useeio_B: true
+deflate_x_to_detail_io_year_for_B: true
 use_ghg_national_2023_m2: false # False means use GHG_Cornerstone_2023
 skip_scrap_adjustment_in_vnorm: true
 new_ghg_method: true # True means use GHG_Cornerstone_2023

--- a/bedrock/utils/config/configs/useeio_phoebe_23_restore_iot_redefinition.yaml
+++ b/bedrock/utils/config/configs/useeio_phoebe_23_restore_iot_redefinition.yaml
@@ -11,13 +11,13 @@ usa_ghg_data_year: 2023
 
 use_cornerstone_2026_model_schema: true
 load_E_from_flowsa: true
-use_E_data_year_for_x_in_B: false
+use_E_data_year_for_x_in_B: true
 implement_waste_disaggregation: true
 
 scale_a_matrix_with_useeio_method: true
 
 use_useeio_schema: true
-use_useeio_B: true
+deflate_x_to_detail_io_year_for_B: true
 use_ghg_national_2023_m2: true
 skip_scrap_adjustment_in_vnorm: true
 new_ghg_method: false

--- a/bedrock/utils/config/configs/useeio_phoebe_23_restore_schema_and_ghg.yaml
+++ b/bedrock/utils/config/configs/useeio_phoebe_23_restore_schema_and_ghg.yaml
@@ -10,13 +10,13 @@ usa_ghg_data_year: 2023
 
 use_cornerstone_2026_model_schema: true
 load_E_from_flowsa: true
-use_E_data_year_for_x_in_B: false
+use_E_data_year_for_x_in_B: true
 implement_waste_disaggregation: true
 
 scale_a_matrix_with_useeio_method: true
 
 use_useeio_schema: false # False means use Cornerstone schema
-use_useeio_B: true
+deflate_x_to_detail_io_year_for_B: true
 use_ghg_national_2023_m2: false # Restore Cornerstone GHG method
 skip_scrap_adjustment_in_vnorm: true
 new_ghg_method: true

--- a/bedrock/utils/config/configs/useeio_phoebe_23_restore_scrap.yaml
+++ b/bedrock/utils/config/configs/useeio_phoebe_23_restore_scrap.yaml
@@ -9,13 +9,13 @@ usa_ghg_data_year: 2023
 
 use_cornerstone_2026_model_schema: true
 load_E_from_flowsa: true
-use_E_data_year_for_x_in_B: false
+use_E_data_year_for_x_in_B: true
 implement_waste_disaggregation: true
 
 scale_a_matrix_with_useeio_method: true
 
 use_useeio_schema: true
-use_useeio_B: true
+deflate_x_to_detail_io_year_for_B: true
 use_ghg_national_2023_m2: true
 skip_scrap_adjustment_in_vnorm: false # False means perform scrap adjustment
 new_ghg_method: false

--- a/bedrock/utils/config/usa_config.py
+++ b/bedrock/utils/config/usa_config.py
@@ -153,7 +153,10 @@ class USAConfig(BaseModel):
 
     @model_validator(mode='after')
     def _validate_deflate_x_requires_use_e_for_x_in_b(self) -> USAConfig:
-        if self.deflate_x_to_detail_io_year_for_B and not self.use_E_data_year_for_x_in_B:
+        if (
+            self.deflate_x_to_detail_io_year_for_B
+            and not self.use_E_data_year_for_x_in_B
+        ):
             raise ValueError(
                 'deflate_x_to_detail_io_year_for_B requires use_E_data_year_for_x_in_B '
                 'to be true'

--- a/bedrock/utils/config/usa_config.py
+++ b/bedrock/utils/config/usa_config.py
@@ -59,8 +59,22 @@ class USAConfig(BaseModel):
     use_cornerstone_2026_model_schema: bool = False  # DRI: mo.li
     use_useeio_schema: bool = False
     ### IO Methodology selection
-    use_E_data_year_for_x_in_B: bool = False  # DRI: mo.li
-    use_useeio_B: bool = False
+    use_E_data_year_for_x_in_B: bool = Field(
+        default=False,
+        description=(
+            'Use BEA gross-output time series at usa_ghg_data_year for industry x '
+            'in B. Must be true whenever deflate_x_to_detail_io_year_for_B is true.'
+        ),
+    )
+    deflate_x_to_detail_io_year_for_B: bool = Field(
+        default=False,
+        description=(
+            'Deflate BEA gross-output industry x at usa_ghg_data_year to '
+            'usa_detail_original_year chain dollars before E/x in B '
+            '(derive_cornerstone_B_via_vnorm). Requires '
+            'use_E_data_year_for_x_in_B to be true.'
+        ),
+    )
     implement_waste_disaggregation: bool = False  # DRI: jorge.vendries
     eeio_waste_disaggregation: ta.Optional[EEIOWasteDisaggConfig] = None
     scale_a_matrix_with_useeio_method: bool = False  # DRI: mo.li
@@ -138,6 +152,15 @@ class USAConfig(BaseModel):
         return self
 
     @model_validator(mode='after')
+    def _validate_deflate_x_requires_use_e_for_x_in_b(self) -> USAConfig:
+        if self.deflate_x_to_detail_io_year_for_B and not self.use_E_data_year_for_x_in_B:
+            raise ValueError(
+                'deflate_x_to_detail_io_year_for_B requires use_E_data_year_for_x_in_B '
+                'to be true'
+            )
+        return self
+
+    @model_validator(mode='after')
     def _validate_ghg_flag_compatibility(self) -> USAConfig:
         if self.new_ghg_method and self.use_ghg_national_2023_m2:
             raise ValueError(
@@ -146,10 +169,6 @@ class USAConfig(BaseModel):
         if self.use_ghg_national_2023_m2 and not self.use_useeio_schema:
             raise ValueError(
                 'use_ghg_national_2023_m2 requires use_useeio_schema to be true'
-            )
-        if self.use_useeio_B and self.use_E_data_year_for_x_in_B:
-            raise ValueError(
-                'use_useeio_B and use_E_data_year_for_x_in_B cannot both be true'
             )
         return self
 


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

- Renames `use_useeio_B` to `deflate_x_to_detail_io_year_for_B` which better describes its function and clarifies that it is not mutulaly exclusive (but rather follows from) `use_E_data_year_for_x_in_B`. 
- Deflation now requires `use_E_data_year_for_x_in_B` at config load.
- Unused `bea_B` / `bea_E` helpers are removed from `cornerstone_bea_intermediates.py`. 
- USEEIO Phoebe YAMLs use the new flag name.

## Testing

Pipeline not changed. Tests pass.

