### PR TITLE
inflate factors in diagnostics for USEEIO path

### DIFF
--- a/bedrock/utils/validation/__tests__/test_calculate_ef_diagnostics.py
+++ b/bedrock/utils/validation/__tests__/test_calculate_ef_diagnostics.py
@@ -68,7 +68,16 @@ class TestCalculateEfDiagnostics:
             {"sector": "1111B0"},
         ]
 
+        mock_config = MagicMock()
+        mock_config.use_cornerstone_2026_model_schema = False
+        mock_config.use_E_data_year_for_x_in_B = False
+        mock_config.diagnostics_baseline_source = "gcs_snapshot"
+
         with (
+            patch(
+                "bedrock.utils.validation.calculate_ef_diagnostics.get_usa_config",
+                return_value=mock_config,
+            ),
             patch(
                 "bedrock.utils.validation.diagnostics_helpers.pull_efs_for_diagnostics",
                 return_value=efs,

--- a/bedrock/utils/validation/__tests__/test_diagnostics_helpers.py
+++ b/bedrock/utils/validation/__tests__/test_diagnostics_helpers.py
@@ -8,12 +8,68 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from bedrock.utils.config.usa_config import USAConfig
 from bedrock.utils.validation.diagnostics_helpers import (
     OldEfSet,
     construct_ef_diff_dataframe,
+    d_n_new_inflated_eligibility,
     diff_and_perc_diff_two_vectors,
     inflation_adjust_ef_denom_to_new_base_year,
 )
+
+
+class TestDNNewInflatedEligibility:
+    def test_emit_when_deflate_path(self) -> None:
+        cfg = USAConfig(
+            use_cornerstone_2026_model_schema=True,
+            use_E_data_year_for_x_in_B=True,
+            deflate_x_to_detail_io_year_for_B=True,
+        )
+        ok, reason = d_n_new_inflated_eligibility(cfg)
+        assert ok is True
+        assert reason == ''
+
+    def test_skip_when_model_base_year_equals_detail_original_year(self) -> None:
+        cfg = USAConfig(
+            use_cornerstone_2026_model_schema=True,
+            use_E_data_year_for_x_in_B=True,
+            deflate_x_to_detail_io_year_for_B=True,
+            model_base_year=2017,
+        )
+        ok, reason = d_n_new_inflated_eligibility(cfg)
+        assert ok is False
+        assert 'identity' in reason.lower()
+
+    def test_skip_use_e_without_deflate(self) -> None:
+        cfg = USAConfig(
+            use_cornerstone_2026_model_schema=True,
+            use_E_data_year_for_x_in_B=True,
+            deflate_x_to_detail_io_year_for_B=False,
+        )
+        ok, reason = d_n_new_inflated_eligibility(cfg)
+        assert ok is False
+        assert 'GHG-year nominal' in reason
+
+    def test_skip_default_b_inflation_path(self) -> None:
+        cfg = USAConfig(
+            use_cornerstone_2026_model_schema=True,
+            deflate_x_to_detail_io_year_for_B=False,
+            use_E_data_year_for_x_in_B=False,
+        )
+        ok, reason = d_n_new_inflated_eligibility(cfg)
+        assert ok is False
+        assert 'double-apply' in reason
+
+    def test_skip_legacy_non_cornerstone(self) -> None:
+        cfg = USAConfig(
+            use_cornerstone_2026_model_schema=False,
+            use_E_data_year_for_x_in_B=True,
+            deflate_x_to_detail_io_year_for_B=True,
+        )
+        ok, reason = d_n_new_inflated_eligibility(cfg)
+        assert ok is False
+        assert 'legacy' in reason.lower()
+
 
 SECTORS = ["1111A0", "1111B0", "221100"]
 

--- a/bedrock/utils/validation/analysis/README.md
+++ b/bedrock/utils/validation/analysis/README.md
@@ -100,7 +100,9 @@ uv run python -m bedrock.utils.validation.analysis.combine_ef_diagnostics \
     --combo v0.2 [--refresh] [--output-xlsx PATH] [--output-sheet-id ID]
 ```
 
-`--combo` picks a `ComboSpec` from `combinations.COMBINATIONS`. The local
+`--combo` picks a `ComboSpec` from `combinations.COMBINATIONS`. Merged
+`D_and_diffs` / `N_and_diffs` tabs use each run's `D_new_inflated` /
+`N_new_inflated` column when present, otherwise `D_new` / `N_new`. The local
 workbook is always written, defaulting to
 `analysis/output/<combo>/ef_diagnostics_merged.xlsx`; pass `--output-xlsx
 <path>` to override or `--output-xlsx ""` to skip. The Google Sheets push

--- a/bedrock/utils/validation/analysis/combine_ef_diagnostics.py
+++ b/bedrock/utils/validation/analysis/combine_ef_diagnostics.py
@@ -18,14 +18,15 @@ runs skip the network.
 
 Output tabs (identical schema to the legacy xlsx flow):
   1) ``D_and_diffs_merged`` -- ``sector``, ``sector_name``, one column per
-     ``config_name`` containing ``D_new``. When the combo's
+     ``config_name`` containing ``D_new_inflated`` when that column exists on
+     the run's tab, otherwise ``D_new``. When the combo's
      ``target_mapping`` references ``pinned_useeio_baseline`` (only
      meaningful when the first run is a USEEIO Excel-baseline comparison),
      an extra ``pinned_useeio_baseline`` column sourced from that run's
      ``D_old_inflated`` is inserted before the per-config columns.
   2) ``N_and_diffs_merged`` -- ``sector``, ``sector_name``, one column per
-     ``config_name`` containing ``N_new``. Mirrors (1) for
-     ``pinned_useeio_baseline``.
+     ``config_name`` containing ``N_new_inflated`` when present, otherwise
+     ``N_new``. Mirrors (1) for ``pinned_useeio_baseline``.
   3) ``D_net_diff`` / ``N_net_diff`` -- per-config net differences computed
      as ``config - target_config`` using the combo's target mapping.
   4) ``totals`` -- one USA-level row per ``config_name``. Source depends
@@ -229,12 +230,41 @@ def _extract_config_name(config_summary_map: dict[str, object], label: str) -> s
     return str(config_summary_map['config_name'])
 
 
+def _resolve_metric_column(
+    df: pd.DataFrame,
+    *,
+    tab: str,
+    label: str,
+    sheet_id: str,
+    preferred_col: str,
+    fallback_col: str,
+) -> str:
+    """Return ``preferred_col`` when present on the tab, else ``fallback_col``."""
+    if preferred_col in df.columns:
+        return preferred_col
+    if fallback_col in df.columns:
+        logger.info(
+            "Tab '%s' in Sheet '%s' (%s): no `%s`; using `%s`.",
+            tab,
+            label,
+            sheet_id,
+            preferred_col,
+            fallback_col,
+        )
+        return fallback_col
+    raise ValueError(
+        f"Tab '{tab}' in Sheet '{label}' ({sheet_id}) must have `{preferred_col}` "
+        f'or `{fallback_col}`. Found: {list(df.columns)}'
+    )
+
+
 def _read_sector_and_values(
     sheet_id: str,
     label: str,
     tab: str,
-    metric_col: str,
     *,
+    preferred_metric_col: str,
+    fallback_metric_col: str | None = None,
     refresh: bool = False,
 ) -> tuple[pd.DataFrame, pd.Series]:
     """Read one ``D_and_diffs`` / ``N_and_diffs`` tab and return ``(sector_meta, values)``."""
@@ -244,10 +274,21 @@ def _read_sector_and_values(
             f"Tab '{tab}' in Sheet '{label}' ({sheet_id}) must have a `sector_name` "
             f'column. Found: {list(df.columns)}'
         )
-    if metric_col not in df.columns:
-        raise ValueError(
-            f"Tab '{tab}' in Sheet '{label}' ({sheet_id}) must have a `{metric_col}` "
-            f'column. Found: {list(df.columns)}'
+    if fallback_metric_col is None:
+        if preferred_metric_col not in df.columns:
+            raise ValueError(
+                f"Tab '{tab}' in Sheet '{label}' ({sheet_id}) must have a "
+                f'`{preferred_metric_col}` column. Found: {list(df.columns)}'
+            )
+        metric_col = preferred_metric_col
+    else:
+        metric_col = _resolve_metric_column(
+            df,
+            tab=tab,
+            label=label,
+            sheet_id=sheet_id,
+            preferred_col=preferred_metric_col,
+            fallback_col=fallback_metric_col,
         )
 
     sector_code_col = _find_sector_code_column(df, tab=tab)
@@ -465,14 +506,14 @@ def merge_sheets(
             sheet_id=first_sheet_id,
             label=first_label,
             tab='D_and_diffs',
-            metric_col='D_old_inflated',
+            preferred_metric_col='D_old_inflated',
             refresh=refresh,
         )
         _, pinned_baseline_n = _read_sector_and_values(
             sheet_id=first_sheet_id,
             label=first_label,
             tab='N_and_diffs',
-            metric_col='N_old_inflated',
+            preferred_metric_col='N_old_inflated',
             refresh=refresh,
         )
 
@@ -481,14 +522,16 @@ def merge_sheets(
             sheet_id=sheet_id,
             label=label,
             tab='D_and_diffs',
-            metric_col='D_new',
+            preferred_metric_col='D_new_inflated',
+            fallback_metric_col='D_new',
             refresh=refresh,
         )
         _, n_new = _read_sector_and_values(
             sheet_id=sheet_id,
             label=label,
             tab='N_and_diffs',
-            metric_col='N_new',
+            preferred_metric_col='N_new_inflated',
+            fallback_metric_col='N_new',
             refresh=refresh,
         )
 

--- a/bedrock/utils/validation/calculate_ef_diagnostics.py
+++ b/bedrock/utils/validation/calculate_ef_diagnostics.py
@@ -23,6 +23,43 @@ from bedrock.utils.validation.significant_sectors import SIGNIFICANT_SECTORS
 logger = logging.getLogger(__name__)
 
 
+def _ef_vector_as_series(single_col_df: pd.DataFrame) -> pd.Series[float]:
+    return ta.cast('pd.Series[float]', single_col_df.iloc[:, 0])
+
+
+def _vector_perc_diff(new: pd.Series[float], old: pd.Series[float]) -> pd.Series[float]:
+    """Match :func:`diff_and_perc_diff_two_vectors` percent branch (old in denominator)."""
+    diff = new - old
+    return (
+        (diff / old.replace(0, np.nan)).replace([np.inf, -np.inf], np.nan).fillna(0.0)
+    )
+
+
+def _merge_ef_new_inflated_into_comparison(
+    comparison: pd.DataFrame,
+    inflated_new: pd.DataFrame,
+    *,
+    ef_name: str,
+) -> pd.DataFrame:
+    """Place ``{ef}_new_inflated`` before ``{ef}_new``; ``{ef}_perc_diff`` uses inflated vs old."""
+    new_col = f'{ef_name}_new'
+    old_inflated_col = f'{ef_name}_old_inflated'
+    inflated_col = f'{ef_name}_new_inflated'
+    perc_col = f'{ef_name}_perc_diff'
+
+    ser = _ef_vector_as_series(inflated_new).reindex(comparison.index)
+    old_infl = ta.cast('pd.Series[float]', comparison[old_inflated_col])
+
+    out = comparison.copy()
+    out[inflated_col] = ser
+    out[perc_col] = _vector_perc_diff(ser, old_infl)
+
+    cols = comparison.columns.tolist()
+    insert_at = cols.index(new_col)
+    ordered = cols[:insert_at] + [inflated_col] + cols[insert_at:]
+    return out[ordered]
+
+
 def _add_comparison_type_column(
     df: pd.DataFrame,
     mapped_sectors: ta.Dict[str, str],
@@ -64,8 +101,12 @@ def calculate_ef_diagnostics(sheet_id: str) -> None:
     Compares current emission factors (EFs) against a previous snapshot release,
     writing results to a Google Sheet. The following tabs are produced:
 
-    - N_and_diffs: Total EFs new vs old, with absolute and percent diffs.
-    - D_and_diffs: Direct EFs new vs old.
+    - N_and_diffs: Total EFs new vs old. When eligible, inserts ``N_new_inflated``
+      before ``N_new`` and sets ``N_perc_diff`` from ``N_new_inflated`` vs
+      ``N_old_inflated``. Omitted when ``model_base_year`` equals
+      ``usa_detail_original_year`` (identity adjustment).
+    - D_and_diffs: Direct EFs new vs old; same ``D_new_inflated`` / ``D_perc_diff``
+      rules as ``N_and_diffs`` when eligible.
     - D_and_N_significant_sectors: Combined D and N comparisons for significant sectors.
     - N_and_D_summary_stats: Summary statistics of percent diffs.
     - output_contrib_new_vs_old: Top N contributing sectors to each EF's change,
@@ -118,8 +159,35 @@ def calculate_ef_diagnostics(sheet_id: str) -> None:
         sector_desc=sector_desc,
     )
 
+    # Compare D (direct EFs) new vs old
+    D_comparison = construct_ef_diff_dataframe(
+        ef_name='D',
+        ef_new=efs.D_new,
+        ef_old=efs.D_old,
+        sector_desc=sector_desc,
+    )
+
     if use_cornerstone:
         _add_comparison_type_column(N_comparison, active_mappings)
+        _add_comparison_type_column(D_comparison, active_mappings)
+
+    if efs.D_new_inflated is not None:
+        assert efs.N_new_inflated is not None
+        t0 = time.time()
+        N_comparison = _merge_ef_new_inflated_into_comparison(
+            N_comparison,
+            efs.N_new_inflated,
+            ef_name='N',
+        )
+        D_comparison = _merge_ef_new_inflated_into_comparison(
+            D_comparison,
+            efs.D_new_inflated,
+            ef_name='D',
+        )
+        logger.info(
+            '[TIMING] attach D_new_inflated/N_new_inflated columns to EF tabs in %.1fs',
+            time.time() - t0,
+        )
 
     t0 = time.time()
     update_sheet_tab(
@@ -131,17 +199,6 @@ def calculate_ef_diagnostics(sheet_id: str) -> None:
     logger.info(
         f'[TIMING] Write N_and_diffs to Google Sheets in {time.time() - t0:.1f}s'
     )
-
-    # Compare D (direct EFs) new vs old
-    D_comparison = construct_ef_diff_dataframe(
-        ef_name='D',
-        ef_new=efs.D_new,
-        ef_old=efs.D_old,
-        sector_desc=sector_desc,
-    )
-
-    if use_cornerstone:
-        _add_comparison_type_column(D_comparison, active_mappings)
 
     t0 = time.time()
     update_sheet_tab(

--- a/bedrock/utils/validation/diagnostics_helpers.py
+++ b/bedrock/utils/validation/diagnostics_helpers.py
@@ -5,7 +5,8 @@ This module provides:
 - Core comparison functions (diff, percent diff)
 - Summary statistics calculations
 - Inflation adjustment for EF denominators
-- Data loading for diagnostics
+- Data loading for diagnostics (optional ``D_new_inflated`` / ``N_new_inflated`` when
+  eligible; merged into ``D_and_diffs`` / ``N_and_diffs`` by ``calculate_ef_diagnostics``)
 - Schema alignment for CEDA v7 ↔ cornerstone diagnostics
 """
 
@@ -19,7 +20,7 @@ import numpy as np
 import pandas as pd
 from pydantic import BaseModel
 
-from bedrock.utils.config.usa_config import get_usa_config
+from bedrock.utils.config.usa_config import USAConfig, get_usa_config
 from bedrock.utils.economic.inflation_helpers_ceda import (
     obtain_inflation_factors_from_reference_data,
 )
@@ -65,15 +66,67 @@ class EfsForDiagnostics(BaseModel):
     Contains new (derived) EFs and old (snapshot) EFs for both D and N:
     - D = direct emission factors (from B matrix)
     - N = total emission factors (from M matrix)
+
+    ``D_new_inflated`` / ``N_new_inflated`` are optional: when present, they are
+    ``D`` / ``N`` after sector price-index adjustment from ``usa_detail_original_year``
+    to ``model_base_year`` (same machinery as ``D_old_inflated`` /
+    ``N_old_inflated``). Emitted only when ``deflate_x_to_detail_io_year_for_B`` is
+    enabled and :func:`d_n_new_inflated_eligibility` allows it.
     """
 
     D_new: pd.DataFrame
     N_new: pd.DataFrame
     D_old: OldEfSet
     N_old: OldEfSet
+    D_new_inflated: ta.Optional[pd.DataFrame] = None
+    N_new_inflated: ta.Optional[pd.DataFrame] = None
 
     class Config:
         arbitrary_types_allowed = True
+
+
+def d_n_new_inflated_eligibility(cfg: USAConfig) -> tuple[bool, str]:
+    """Whether ``D_new_inflated`` / ``N_new_inflated`` should be computed for *cfg*.
+
+    Uses :func:`inflation_adjust_ef_denom_to_new_base_year` on ``D_new`` / ``N_new``
+    (sector BEA price indices), matching the baseline side. Applies when ``B`` is built
+    with ``deflate_x_to_detail_io_year_for_B`` (denominator in
+    ``usa_detail_original_year`` chain dollars). When ``model_base_year`` equals
+    ``usa_detail_original_year``, adjustment is identity.
+
+    Returns:
+        ``(True, "")`` to emit adjusted vectors, or ``(False, reason)`` to skip
+        (leaving optional fields ``None``) and avoid double-applying inflation when
+        ``derive_cornerstone_B_non_finetuned`` already inflates ``B`` to
+        ``model_base_year``.
+    """
+    if not cfg.use_cornerstone_2026_model_schema:
+        return (
+            False,
+            'use_cornerstone_2026_model_schema is false (legacy B path; no '
+            'cornerstone D_new_inflated hook)',
+        )
+    if cfg.deflate_x_to_detail_io_year_for_B:
+        if cfg.model_base_year == cfg.usa_detail_original_year:
+            return (
+                False,
+                'model_base_year equals usa_detail_original_year; '
+                'EF denominator adjustment for D/N is identity (no separate inflated columns)',
+            )
+        return (True, '')
+    if cfg.use_E_data_year_for_x_in_B:
+        return (
+            False,
+            'use_E_data_year_for_x_in_B without deflate_x_to_detail_io_year_for_B: '
+            'B uses GHG-year nominal gross output in the denominator; adjusting '
+            'from usa_detail_original_year would mis-state dollar years',
+        )
+    return (
+        False,
+        'derive_cornerstone_B_non_finetuned already applies '
+        'inflate_cornerstone_B_matrix_with_industry_pi to model_base_year; '
+        'skipping second denominator inflation pass (would double-apply)',
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -263,6 +316,16 @@ def align_efs_across_schemas(
         N_old=OldEfSet(
             raw=_reindex_and_fill(efs.N_old.raw, full_index, old_fill),
             inflated=_reindex_and_fill(efs.N_old.inflated, full_index, old_fill),
+        ),
+        D_new_inflated=(
+            _reindex_and_fill(efs.D_new_inflated, full_index, new_fill)
+            if efs.D_new_inflated is not None
+            else None
+        ),
+        N_new_inflated=(
+            _reindex_and_fill(efs.N_new_inflated, full_index, new_fill)
+            if efs.N_new_inflated is not None
+            else None
         ),
     )
     return aligned_efs, active_mappings
@@ -510,6 +573,35 @@ def pull_efs_for_diagnostics() -> EfsForDiagnostics:
     N_new = compute_n(M=M_new)
     logger.info(f'[TIMING] New L, M, D, N matrices computed in {time.time() - t0:.1f}s')
 
+    emit_inflated, inflated_skip_reason = d_n_new_inflated_eligibility(config)
+    d_new_inflated: pd.DataFrame | None = None
+    n_new_inflated: pd.DataFrame | None = None
+    if emit_inflated:
+        t_inf = time.time()
+        d_ser = inflation_adjust_ef_denom_to_new_base_year(
+            old_ef_vector=ta.cast('pd.Series[float]', D_new.squeeze()),
+            new_base_year=config.model_base_year,
+            old_base_year=config.usa_detail_original_year,
+        )
+        n_ser = inflation_adjust_ef_denom_to_new_base_year(
+            old_ef_vector=ta.cast('pd.Series[float]', N_new.squeeze()),
+            new_base_year=config.model_base_year,
+            old_base_year=config.usa_detail_original_year,
+        )
+        d_new_inflated = d_ser.to_frame()
+        n_new_inflated = n_ser.to_frame()
+        logger.info(
+            '[TIMING] D_new_inflated/N_new_inflated (sector PI %s→%s $) in %.1fs',
+            config.usa_detail_original_year,
+            config.model_base_year,
+            time.time() - t_inf,
+        )
+    else:
+        logger.info(
+            'Skipping D_new_inflated/N_new_inflated: %s',
+            inflated_skip_reason,
+        )
+
     t0 = time.time()
     if config.diagnostics_baseline_source == 'gcs_useeio_xlsx':
         from bedrock.utils.validation.useeio_excel_baseline import (
@@ -564,6 +656,8 @@ def pull_efs_for_diagnostics() -> EfsForDiagnostics:
             raw=N_old_raw.to_frame(),
             inflated=N_old_inflated.to_frame(),
         ),
+        D_new_inflated=d_new_inflated,
+        N_new_inflated=n_new_inflated,
     )
 
 


### PR DESCRIPTION
cc:
Closes:

When USEEIO-style configs use `deflate_x_to_detail_io_year_for_B`, new `D` and `N` are in `usa_detail_original_year` chain dollars while the baseline side is already inflated to `model_base_year`. EF diagnostics add optional `D_new_inflated` and `N_new_inflated` via the same sector price-index adjustment as `D_old_inflated` / `N_old_inflated` (`inflation_adjust_ef_denom_to_new_base_year`).

- `pull_efs_for_diagnostics` emits inflated vectors when `d_n_new_inflated_eligibility` allows it (skips identity year, double-apply, and legacy paths).
- `calculate_ef_diagnostics` inserts `{D|N}_new_inflated` before `{D|N}_new` and recomputes `{D|N}_perc_diff` against `{D|N}_old_inflated`.
- `combine_ef_diagnostics` prefers `D_new_inflated` / `N_new_inflated` when merging runs.

Does **not** address [#384](https://github.com/cornerstone-data/bedrock/issues/384) (EF inflation helper still uses sector reference-data price ratios via `obtain_inflation_factors_from_reference_data`, not model commodity/V-norm ratios). This PR reuses that helper for `D_new_inflated` / `N_new_inflated` so new and old sides stay comparable in diagnostics; fixing #384 is separate work.

## Testing

```powershell
uv run pytest bedrock/utils/validation/__tests__/test_diagnostics_helpers.py bedrock/utils/validation/__tests__/test_calculate_ef_diagnostics.py bedrock/utils/validation/__tests__/test_diagnostics_sector_alignment.py -q
```

Results in [diagnostics like this one](https://docs.google.com/spreadsheets/d/1WeabDjR9-y9rtfGvGmTl8dp2Ch-o7miNIvsMBdpr4wI/edit?usp=sharing)