### PR TITLE
Provides access to eGRID generation and loss data

### DIFF
--- a/bedrock/extract/disaggregation/__tests__/tests_electricity_disagg.py
+++ b/bedrock/extract/disaggregation/__tests__/tests_electricity_disagg.py
@@ -14,8 +14,8 @@ from bedrock.extract.disaggregation.egrid_generation import (
     us_total_net_generation_mwh,
 )
 
-# stewi eGRID_2022_v1.2.0_7562dc3 flowbyfacility, US plant net generation sum
-_EGRID_2022_NET_GENERATION_MWH = 4_247_477_433
+# eGRID 2022 workbook, US sheet: USNGENAN ("U.S. annual net generation (MWh)")
+_EGRID_2022_NET_GENERATION_MWH = 4_240_140_533
 
 
 def test_derive_cornerstone_ytot_full_cs_matrix_is_copy_of_underlying() -> None:
@@ -35,7 +35,7 @@ def test_derive_cornerstone_ytot_full_cs_matrix_is_copy_of_underlying() -> None:
 
 @pytest.mark.eeio_integration
 def test_us_total_net_generation_mwh_2022_matches_stewi_egrid() -> None:
-    """Load stewi eGRID 2022 and confirm US net generation matches published inventory."""
+    """US net generation matches eGRID 2022 Excel US tab USNGENAN."""
     actual = us_total_net_generation_mwh(2022, download_if_missing=True)
     assert math.isclose(
         actual,

--- a/bedrock/extract/disaggregation/__tests__/tests_electricity_disagg.py
+++ b/bedrock/extract/disaggregation/__tests__/tests_electricity_disagg.py
@@ -2,11 +2,19 @@
 
 from __future__ import annotations
 
+import math
 from unittest.mock import patch
 
 import pandas as pd
+import pytest
 
 import bedrock.transform.eeio.derived_cornerstone as derived_cornerstone
+from bedrock.extract.disaggregation.egrid_generation import (
+    us_total_net_generation_mwh,
+)
+
+# stewi eGRID_2022_v1.2.0_7562dc3 flowbyfacility, US plant net generation sum
+_EGRID_2022_NET_GENERATION_MWH = 4_247_477_433
 
 
 def test_derive_cornerstone_ytot_full_cs_matrix_is_copy_of_underlying() -> None:
@@ -22,3 +30,15 @@ def test_derive_cornerstone_ytot_full_cs_matrix_is_copy_of_underlying() -> None:
         out = derived_cornerstone.derive_cornerstone_Ytot_full_cs_matrix()
     pd.testing.assert_frame_equal(out, fake)
     assert out is not fake
+
+
+@pytest.mark.eeio_integration
+def test_us_total_net_generation_mwh_2022_matches_stewi_egrid() -> None:
+    """Load stewi eGRID 2022 and confirm US net generation matches published inventory."""
+    actual = us_total_net_generation_mwh(2022, download_if_missing=True)
+    assert math.isclose(
+        actual,
+        _EGRID_2022_NET_GENERATION_MWH,
+        rel_tol=0,
+        abs_tol=1.0,
+    )

--- a/bedrock/extract/disaggregation/__tests__/tests_electricity_disagg.py
+++ b/bedrock/extract/disaggregation/__tests__/tests_electricity_disagg.py
@@ -10,6 +10,7 @@ import pytest
 
 import bedrock.transform.eeio.derived_cornerstone as derived_cornerstone
 from bedrock.extract.disaggregation.egrid_generation import (
+    load_egrid_ggl,
     us_total_net_generation_mwh,
 )
 
@@ -42,3 +43,11 @@ def test_us_total_net_generation_mwh_2022_matches_stewi_egrid() -> None:
         rel_tol=0,
         abs_tol=1.0,
     )
+
+
+@pytest.mark.eeio_integration
+def test_load_egrid_ggl_2018_us_grid_gross_loss() -> None:
+    """GGL sheet via stewi extract_eGRID_excel; U.S. grid gross loss for 2018."""
+    ggl = load_egrid_ggl(2018, download_if_missing=True)
+    us_row = ggl.loc[ggl["region"] == "U.S.", "grid_gross_loss"].iloc[0]
+    assert math.isclose(us_row, 0.048681, rel_tol=0, abs_tol=1e-6)

--- a/bedrock/extract/disaggregation/egrid_generation.py
+++ b/bedrock/extract/disaggregation/egrid_generation.py
@@ -1,0 +1,135 @@
+"""US net electricity generation from EPA eGRID facility inventories (stewi).
+
+
+
+Stewi loads plant-level ``Plant annual net generation (MWh)`` as ``FlowName``
+
+``Electricity`` in MJ (``MWh_MJ`` = 3600). Summing facility rows matches stewi's
+
+eGRID national-total validation for that flow.
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import pandas as pd
+import stewi
+from stewi.globals import MWh_MJ
+from stewi.globals import config as stewi_config
+
+EGRID_INVENTORY = "eGRID"
+
+NET_GENERATION_FLOW = "Electricity"
+
+
+DEFAULT_YEAR_START = 2016
+
+DEFAULT_YEAR_END = 2024
+
+
+def egrid_inventory_years(year_start: int, year_end: int) -> list[int]:
+    """Calendar years with stewi eGRID source config in ``[year_start, year_end]``.
+
+
+
+    EPA does not publish eGRID every year (e.g. no 2017).
+
+    """
+
+    keys = stewi_config()["databases"][EGRID_INVENTORY]
+
+    configured = sorted(int(k) for k in keys if str(k).isdigit())
+
+    return [y for y in configured if year_start <= y <= year_end]
+
+
+def load_egrid_flowbyfacility(
+    year: int,
+    *,
+    download_if_missing: bool = True,
+) -> pd.DataFrame:
+    """Return stewi eGRID flow-by-facility inventory for *year*."""
+
+    return stewi.getInventory(
+        EGRID_INVENTORY,
+        year,
+        stewiformat="flowbyfacility",
+        download_if_missing=download_if_missing,
+    )
+
+
+def _net_generation_mj(flowbyfacility: pd.DataFrame) -> float:
+    """Sum ``Electricity`` (net generation) across rows of a stewi eGRID flowbyfacility table, in MJ."""
+
+    gen = flowbyfacility.loc[
+        flowbyfacility["FlowName"] == NET_GENERATION_FLOW, "FlowAmount"
+    ]
+
+    if gen.empty:
+
+        msg = (
+            f"eGRID flow-by-facility has no {NET_GENERATION_FLOW!r} rows "
+            "(plant annual net generation)"
+        )
+
+        raise ValueError(msg)
+
+    units = flowbyfacility.loc[
+        flowbyfacility["FlowName"] == NET_GENERATION_FLOW, "Unit"
+    ].unique()
+
+    if len(units) != 1 or units[0] != "MJ":
+
+        msg = f"unexpected units for {NET_GENERATION_FLOW!r}: {units.tolist()}"
+
+        raise ValueError(msg)
+
+    return float(gen.sum())
+
+
+def us_total_net_generation_mwh(
+    year: int,
+    *,
+    download_if_missing: bool = True,
+) -> float:
+    """Sum US plant annual net generation (MWh) from stewi eGRID for *year*."""
+
+    inv = load_egrid_flowbyfacility(year, download_if_missing=download_if_missing)
+
+    return _net_generation_mj(inv) / MWh_MJ
+
+
+def us_total_net_generation_by_year(
+    year_start: int = DEFAULT_YEAR_START,
+    year_end: int = DEFAULT_YEAR_END,
+    *,
+    years: Iterable[int] | None = None,
+    download_if_missing: bool = True,
+) -> pd.Series[float]:
+    """US net generation by inventory year (values in MWh, index = year).
+
+
+
+    When *years* is omitted, uses ``egrid_inventory_years(year_start, year_end)``.
+
+    """
+
+    if years is None:
+
+        year_list = egrid_inventory_years(year_start, year_end)
+
+    else:
+
+        year_list = sorted(years)
+
+    totals: dict[int, float] = {}
+
+    for year in year_list:
+
+        totals[year] = us_total_net_generation_mwh(
+            year, download_if_missing=download_if_missing
+        )
+
+    return pd.Series(totals, dtype=float, name="net_generation_mwh")

--- a/bedrock/extract/disaggregation/egrid_generation.py
+++ b/bedrock/extract/disaggregation/egrid_generation.py
@@ -12,22 +12,13 @@ from stewi.egrid import OUTPUT_PATH, _config, download_eGRID, extract_eGRID_exce
 from stewi.globals import MWh_MJ
 from stewi.globals import config as stewi_config
 
-EGRID_INVENTORY = "eGRID"
-NET_GENERATION_FLOW = "Electricity"
-GGL_SHEET_PREFIX = "GGL"
-
 DEFAULT_YEAR_START = 2016
 DEFAULT_YEAR_END = 2024
-
-_COL_YEAR = "Data Year"
-_COL_REGION_SUBSTR = "interconnect power grids"
-_COL_EST_LOSS_SUBSTR = "Estimated losses (MWh)"
-_COL_GRID_GROSS_LOSS_SUBSTR = "Grid gross loss"
 
 
 def egrid_inventory_years(year_start: int, year_end: int) -> list[int]:
     """Calendar years with stewi eGRID source config in [year_start, year_end]."""
-    keys = stewi_config()["databases"][EGRID_INVENTORY]
+    keys = stewi_config()["databases"]["eGRID"]
     configured = sorted(int(k) for k in keys if str(k).isdigit())
     return [y for y in configured if year_start <= y <= year_end]
 
@@ -36,7 +27,7 @@ def _require_egrid_year(year: int) -> str:
     year_str = str(year)
     if year_str not in _config:
         raise stewi.exceptions.InventoryNotAvailableError(
-            inv=EGRID_INVENTORY,
+            inv="eGRID",
             year=year_str,
         )
     return year_str
@@ -74,15 +65,15 @@ def load_egrid_ggl(
     year_str = _require_egrid_year(year)
     if download_if_missing:
         ensure_egrid_workbook(year, download_if_missing=True)
-    raw = extract_eGRID_excel(year_str, GGL_SHEET_PREFIX, index="field")
+    raw = extract_eGRID_excel(year_str, "GGL", index="field")
     return _normalize_ggl(raw)
 
 
 def _normalize_ggl(raw: pd.DataFrame) -> pd.DataFrame:
-    region_col = _find_column(raw, _COL_REGION_SUBSTR)
-    est_col = _find_column(raw, _COL_EST_LOSS_SUBSTR)
-    loss_col = _find_column(raw, _COL_GRID_GROSS_LOSS_SUBSTR)
-    year_col = _COL_YEAR if _COL_YEAR in raw.columns else _find_column(raw, "Year")
+    region_col = _find_column(raw, "interconnect power grids")
+    est_col = _find_column(raw, "Estimated losses (MWh)")
+    loss_col = _find_column(raw, "Grid gross loss")
+    year_col = "Data Year" if "Data Year" in raw.columns else _find_column(raw, "Year")
 
     out = pd.DataFrame(
         {
@@ -124,7 +115,7 @@ def load_egrid_flowbyfacility(
 ) -> pd.DataFrame:
     """Return stewi eGRID flow-by-facility inventory for *year*."""
     return stewi.getInventory(
-        EGRID_INVENTORY,
+        "eGRID",
         year,
         stewiformat="flowbyfacility",
         download_if_missing=download_if_missing,
@@ -133,20 +124,18 @@ def load_egrid_flowbyfacility(
 
 def _net_generation_mj(flowbyfacility: pd.DataFrame) -> float:
     """Sum Electricity (net generation) across a stewi eGRID flowbyfacility table, in MJ."""
-    gen = flowbyfacility.loc[
-        flowbyfacility["FlowName"] == NET_GENERATION_FLOW, "FlowAmount"
-    ]
+    gen = flowbyfacility.loc[flowbyfacility["FlowName"] == "Electricity", "FlowAmount"]
     if gen.empty:
         msg = (
-            f"eGRID flow-by-facility has no {NET_GENERATION_FLOW!r} rows "
+            "eGRID flow-by-facility has no 'Electricity' rows "
             "(plant annual net generation)"
         )
         raise ValueError(msg)
     units = flowbyfacility.loc[
-        flowbyfacility["FlowName"] == NET_GENERATION_FLOW, "Unit"
+        flowbyfacility["FlowName"] == "Electricity", "Unit"
     ].unique()
     if len(units) != 1 or units[0] != "MJ":
-        msg = f"unexpected units for {NET_GENERATION_FLOW!r}: {units.tolist()}"
+        msg = f"unexpected units for 'Electricity': {units.tolist()}"
         raise ValueError(msg)
     return float(gen.sum())
 

--- a/bedrock/extract/disaggregation/egrid_generation.py
+++ b/bedrock/extract/disaggregation/egrid_generation.py
@@ -6,10 +6,10 @@ from collections.abc import Iterable
 from pathlib import Path
 
 import pandas as pd
-import stewi
 import stewi.exceptions
 from stewi.egrid import OUTPUT_PATH, _config, download_eGRID, extract_eGRID_excel
-from stewi.globals import MWh_MJ
+from stewi.formats import StewiFormat
+from stewi.globals import MWh_MJ, read_inventory
 from stewi.globals import config as stewi_config
 
 DEFAULT_YEAR_START = 2016
@@ -73,7 +73,13 @@ def _normalize_ggl(raw: pd.DataFrame) -> pd.DataFrame:
     region_col = _find_column(raw, "interconnect power grids")
     est_col = _find_column(raw, "Estimated losses (MWh)")
     loss_col = _find_column(raw, "Grid gross loss")
-    year_col = "Data Year" if "Data Year" in raw.columns else _find_column(raw, "Year")
+    year_col = next(
+        (c for c in ("Data Year", "Data year") if c in raw.columns),
+        None,
+    )
+    if year_col is None:
+        msg = f"GGL sheet missing Data Year column; got {list(raw.columns)}"
+        raise ValueError(msg)
 
     out = pd.DataFrame(
         {
@@ -113,13 +119,23 @@ def load_egrid_flowbyfacility(
     *,
     download_if_missing: bool = True,
 ) -> pd.DataFrame:
-    """Return stewi eGRID flow-by-facility inventory for *year*."""
-    return stewi.getInventory(
+    """Return stewi eGRID flow-by-facility parquet for *year* without getInventory filters.
+
+    Uses ``read_inventory`` so plant net generation matches the stored inventory
+    (sum of PLNT / US ``USNGENAN``). ``getInventory`` re-aggregates on read and drops
+    non-positive ``FlowAmount`` rows, which raises the US electricity total.
+    """
+    _require_egrid_year(year)
+    inv = read_inventory(
         "eGRID",
         year,
-        stewiformat="flowbyfacility",
+        StewiFormat.FLOWBYFACILITY,
         download_if_missing=download_if_missing,
     )
+    if inv is None:
+        msg = f"eGRID flow-by-facility inventory not available for {year}"
+        raise FileNotFoundError(msg)
+    return inv
 
 
 def _net_generation_mj(flowbyfacility: pd.DataFrame) -> float:
@@ -145,7 +161,7 @@ def us_total_net_generation_mwh(
     *,
     download_if_missing: bool = True,
 ) -> float:
-    """Sum US plant annual net generation (MWh) from stewi eGRID for *year*."""
+    """Sum US plant annual net generation (MWh); matches PLNT / US workbook totals."""
     inv = load_egrid_flowbyfacility(year, download_if_missing=download_if_missing)
     return _net_generation_mj(inv) / MWh_MJ
 

--- a/bedrock/extract/disaggregation/egrid_generation.py
+++ b/bedrock/extract/disaggregation/egrid_generation.py
@@ -1,48 +1,120 @@
-"""US net electricity generation from EPA eGRID facility inventories (stewi).
-
-
-
-Stewi loads plant-level ``Plant annual net generation (MWh)`` as ``FlowName``
-
-``Electricity`` in MJ (``MWh_MJ`` = 3600). Summing facility rows matches stewi's
-
-eGRID national-total validation for that flow.
-
-"""
+"""eGRID inputs for electricity disaggregation (stewi inventories and workbook sheets)."""
 
 from __future__ import annotations
 
 from collections.abc import Iterable
+from pathlib import Path
 
 import pandas as pd
 import stewi
+import stewi.exceptions
+from stewi.egrid import OUTPUT_PATH, _config, download_eGRID, extract_eGRID_excel
 from stewi.globals import MWh_MJ
 from stewi.globals import config as stewi_config
 
 EGRID_INVENTORY = "eGRID"
-
 NET_GENERATION_FLOW = "Electricity"
-
+GGL_SHEET_PREFIX = "GGL"
 
 DEFAULT_YEAR_START = 2016
-
 DEFAULT_YEAR_END = 2024
+
+_COL_YEAR = "Data Year"
+_COL_REGION_SUBSTR = "interconnect power grids"
+_COL_EST_LOSS_SUBSTR = "Estimated losses (MWh)"
+_COL_GRID_GROSS_LOSS_SUBSTR = "Grid gross loss"
 
 
 def egrid_inventory_years(year_start: int, year_end: int) -> list[int]:
-    """Calendar years with stewi eGRID source config in ``[year_start, year_end]``.
-
-
-
-    EPA does not publish eGRID every year (e.g. no 2017).
-
-    """
-
+    """Calendar years with stewi eGRID source config in [year_start, year_end]."""
     keys = stewi_config()["databases"][EGRID_INVENTORY]
-
     configured = sorted(int(k) for k in keys if str(k).isdigit())
-
     return [y for y in configured if year_start <= y <= year_end]
+
+
+def _require_egrid_year(year: int) -> str:
+    year_str = str(year)
+    if year_str not in _config:
+        raise stewi.exceptions.InventoryNotAvailableError(
+            inv=EGRID_INVENTORY,
+            year=year_str,
+        )
+    return year_str
+
+
+def ensure_egrid_workbook(year: int, *, download_if_missing: bool = True) -> Path:
+    """Return the local eGRID workbook path for a stewi-configured year."""
+    year_str = _require_egrid_year(year)
+    path = OUTPUT_PATH / _config[year_str]["file_name"]
+    if not path.is_file():
+        if not download_if_missing:
+            msg = f"eGRID workbook not found for {year}: {path}"
+            raise FileNotFoundError(msg)
+        download_eGRID(year_str)
+    if not path.is_file():
+        msg = f"eGRID workbook not found for {year} after download: {path}"
+        raise FileNotFoundError(msg)
+    return path
+
+
+def _find_column(df: pd.DataFrame, substring: str) -> str:
+    matches = [c for c in df.columns if substring in str(c)]
+    if not matches:
+        msg = f"No column containing {substring!r} in GGL sheet; got {list(df.columns)}"
+        raise ValueError(msg)
+    return str(matches[0])
+
+
+def load_egrid_ggl(
+    year: int,
+    *,
+    download_if_missing: bool = True,
+) -> pd.DataFrame:
+    """Grid gross loss and estimated losses by interconnect region for one inventory year."""
+    year_str = _require_egrid_year(year)
+    if download_if_missing:
+        ensure_egrid_workbook(year, download_if_missing=True)
+    raw = extract_eGRID_excel(year_str, GGL_SHEET_PREFIX, index="field")
+    return _normalize_ggl(raw)
+
+
+def _normalize_ggl(raw: pd.DataFrame) -> pd.DataFrame:
+    region_col = _find_column(raw, _COL_REGION_SUBSTR)
+    est_col = _find_column(raw, _COL_EST_LOSS_SUBSTR)
+    loss_col = _find_column(raw, _COL_GRID_GROSS_LOSS_SUBSTR)
+    year_col = _COL_YEAR if _COL_YEAR in raw.columns else _find_column(raw, "Year")
+
+    out = pd.DataFrame(
+        {
+            "year": pd.to_numeric(raw[year_col], errors="coerce").astype("Int64"),
+            "region": raw[region_col].astype(str).str.strip(),
+            "estimated_losses_mwh": pd.to_numeric(raw[est_col], errors="coerce"),
+            "grid_gross_loss": pd.to_numeric(raw[loss_col], errors="coerce"),
+        }
+    )
+    if out["year"].isna().any():
+        raise ValueError("GGL sheet has non-numeric Data Year values")
+    return out.astype({"year": int})
+
+
+def grid_loss_by_region_by_year(
+    year_start: int = DEFAULT_YEAR_START,
+    year_end: int = DEFAULT_YEAR_END,
+    *,
+    years: Iterable[int] | None = None,
+    download_if_missing: bool = True,
+) -> pd.DataFrame:
+    """Stacked GGL rows for each inventory year (long format: year, region, losses)."""
+    if years is None:
+        year_list = egrid_inventory_years(year_start, year_end)
+    else:
+        year_list = sorted(years)
+
+    frames = [
+        load_egrid_ggl(year, download_if_missing=download_if_missing)
+        for year in year_list
+    ]
+    return pd.concat(frames, ignore_index=True)
 
 
 def load_egrid_flowbyfacility(
@@ -51,7 +123,6 @@ def load_egrid_flowbyfacility(
     download_if_missing: bool = True,
 ) -> pd.DataFrame:
     """Return stewi eGRID flow-by-facility inventory for *year*."""
-
     return stewi.getInventory(
         EGRID_INVENTORY,
         year,
@@ -61,31 +132,22 @@ def load_egrid_flowbyfacility(
 
 
 def _net_generation_mj(flowbyfacility: pd.DataFrame) -> float:
-    """Sum ``Electricity`` (net generation) across rows of a stewi eGRID flowbyfacility table, in MJ."""
-
+    """Sum Electricity (net generation) across a stewi eGRID flowbyfacility table, in MJ."""
     gen = flowbyfacility.loc[
         flowbyfacility["FlowName"] == NET_GENERATION_FLOW, "FlowAmount"
     ]
-
     if gen.empty:
-
         msg = (
             f"eGRID flow-by-facility has no {NET_GENERATION_FLOW!r} rows "
             "(plant annual net generation)"
         )
-
         raise ValueError(msg)
-
     units = flowbyfacility.loc[
         flowbyfacility["FlowName"] == NET_GENERATION_FLOW, "Unit"
     ].unique()
-
     if len(units) != 1 or units[0] != "MJ":
-
         msg = f"unexpected units for {NET_GENERATION_FLOW!r}: {units.tolist()}"
-
         raise ValueError(msg)
-
     return float(gen.sum())
 
 
@@ -95,9 +157,7 @@ def us_total_net_generation_mwh(
     download_if_missing: bool = True,
 ) -> float:
     """Sum US plant annual net generation (MWh) from stewi eGRID for *year*."""
-
     inv = load_egrid_flowbyfacility(year, download_if_missing=download_if_missing)
-
     return _net_generation_mj(inv) / MWh_MJ
 
 
@@ -108,28 +168,15 @@ def us_total_net_generation_by_year(
     years: Iterable[int] | None = None,
     download_if_missing: bool = True,
 ) -> pd.Series[float]:
-    """US net generation by inventory year (values in MWh, index = year).
-
-
-
-    When *years* is omitted, uses ``egrid_inventory_years(year_start, year_end)``.
-
-    """
-
+    """US net generation by inventory year (values in MWh, index = year)."""
     if years is None:
-
         year_list = egrid_inventory_years(year_start, year_end)
-
     else:
-
         year_list = sorted(years)
 
     totals: dict[int, float] = {}
-
     for year in year_list:
-
         totals[year] = us_total_net_generation_mwh(
             year, download_if_missing=download_if_missing
         )
-
     return pd.Series(totals, dtype=float, name="net_generation_mwh")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     # EPA dependencies
     "fedelemflowlist @ git+https://github.com/FLCAC-admin/fedelemflowlist.git#egg=fedelemflowlist",
     "esupy @ git+https://github.com/USEPA/esupy.git#egg=esupy",
-    "StEWI @ git+https://github.com/USEPA/standardizedinventories.git#egg=StEWI",
+    "StEWI @ git+https://github.com/cornerstone-data/standardizedinventories.git#egg=StEWI",
     # Configuration and validation
     "pydantic>=2.7.1,<3.0.0",
     "pyyaml>=6.0,<7.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -201,7 +201,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.7.1,<3.0.0" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "pyyaml", specifier = ">=6.0,<7.0.0" },
-    { name = "stewi", git = "https://github.com/USEPA/standardizedinventories.git" },
+    { name = "stewi", git = "https://github.com/cornerstone-data/standardizedinventories.git" },
     { name = "tabula-py", specifier = "==2.10.0" },
     { name = "tenacity", specifier = ">=8.2.3,<9.0.0" },
     { name = "tqdm", specifier = ">=4.66.2,<5.0.0" },
@@ -2346,7 +2346,7 @@ wheels = [
 [[package]]
 name = "stewi"
 version = "1.2.1"
-source = { git = "https://github.com/USEPA/standardizedinventories.git#bbb8147c0de1fb5531027dce9f67d97bec755f06" }
+source = { git = "https://github.com/cornerstone-data/standardizedinventories.git#bbb8147c0de1fb5531027dce9f67d97bec755f06" }
 dependencies = [
     { name = "esupy" },
     { name = "numpy" },


### PR DESCRIPTION
cc:
Closes: #400 

## What changed? Why?

Adds access to eGRID generation and grid loss data via stewi. Note, 2024 data won't be available until https://github.com/cornerstone-data/standardizedinventories/pull/1 is pulled in.

### Primary APIs

**`us_total_net_generation_by_year`** — US plant annual net generation (MWh) from stewi `getInventory('eGRID', year)` flow-by-facility (`FlowName` `Electricity`, summed and converted from MJ).

**`grid_loss_by_region_by_year`** — Grid gross loss and estimated losses by interconnect region from the eGRID workbook **GGL** tab (`stewi.egrid.extract_eGRID_excel`), stacked across inventory years.

Both restrict years to those in stewi’s eGRID config; unconfigured years raise `InventoryNotAvailableError`.

### Sample output

`us_total_net_generation_by_year(years=[2018, 2020, 2022])`:

```
2018    4,168,370,118
2020    4,021,549,453
2022    4,240,140,533
```

`grid_loss_by_region_by_year(years=[2018, 2022])`:

```
    year   region  estimated_losses_mwh  grid_gross_loss
0   2018   Alaska          3.079710e+05         0.051235
1   2018  Eastern          1.445862e+08         0.048820
2   2018    ERCOT          1.846727e+07         0.048711
3   2018   Hawaii          4.814720e+05         0.051412
4   2018  Western          3.484580e+07         0.048044
5   2018     U.S.          1.986887e+08         0.048681
6   2022   Alaska          3.246610e+05         0.050000
7   2022  Eastern          1.515906e+08         0.051000
8   2022    ERCOT          2.198908e+07         0.051000
9   2022   Hawaii          4.889390e+05         0.054000
10  2022  Western          3.761298e+07         0.051000
11  2022     U.S.          2.120062e+08         0.051000
```

## Testing

- `uv run pytest bedrock/extract/disaggregation/__tests__/tests_electricity_disagg.py -v` (unit)
- `uv run pytest bedrock/extract/disaggregation/__tests__/tests_electricity_disagg.py -m eeio_integration -v` (stewi eGRID 2022 net gen; 2018 GGL U.S. grid gross loss)
- `uv run black --check .` and `uv run ruff check .` on work-stream files
