### PR TITLE
Gate summary A/q dollar-year realignment behind config flag

### DIFF
--- a/bedrock/transform/eeio/__tests__/test_summary_a_realigned.py
+++ b/bedrock/transform/eeio/__tests__/test_summary_a_realigned.py
@@ -1,0 +1,81 @@
+"""Tests for the summary-tables A branch with dollar-year-aligned scaling.
+
+``scale_a_matrix_with_summary_tables=True`` now always:
+  1. deflates the target-year summary A to 2017 USD before forming the ratio
+     against the 2017 summary A (so the ratio is in matched dollar years),
+  2. applies the structural ratio to the 2017 detail A,
+  3. inflates the result 2017 → model_year.
+
+See `.claude/plans/summary_a_dollar_year_realignment_plan.md`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bedrock.transform.eeio.derived_cornerstone import (
+    derive_cornerstone_Aq,
+    derive_cornerstone_Aq_scaled,
+)
+from bedrock.utils.config.usa_config import get_usa_config
+
+
+def _set_summary_tables(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = get_usa_config()
+    monkeypatch.setattr(cfg, 'use_cornerstone_2026_model_schema', True)
+    monkeypatch.setattr(cfg, 'scale_a_matrix_with_summary_tables', True)
+    monkeypatch.setattr(cfg, 'scale_a_matrix_with_useeio_method', False)
+    monkeypatch.setattr(cfg, 'scale_a_matrix_with_industry_price_index', False)
+    monkeypatch.setattr(cfg, 'scale_a_matrix_with_commodity_price_index', False)
+    monkeypatch.setattr(cfg, 'load_useeio_nowcast_A_matrix', False)
+    derive_cornerstone_Aq_scaled.cache_clear()
+
+
+def test_summary_tables_branch_is_noop_at_model_year_equals_detail_year(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ``model_year == detail_year == 2017``, the cross-year ratio is
+    identically 1, the summary-A deflation is a no-op, and the final inflate
+    is a no-op — so the summary-tables branch must return the base 2017 A
+    unchanged.
+    """
+    cfg = get_usa_config()
+    _set_summary_tables(monkeypatch)
+    monkeypatch.setattr(cfg, 'model_base_year', 2017)
+
+    base = derive_cornerstone_Aq()
+    result = derive_cornerstone_Aq_scaled()
+
+    max_dev_dom = (result.Adom.to_numpy() - base.Adom.to_numpy()).max()
+    max_dev_imp = (result.Aimp.to_numpy() - base.Aimp.to_numpy()).max()
+    assert (
+        abs(max_dev_dom) < 1e-9
+    ), f"Adom drifted at model_year=2017 (max |Δ| = {max_dev_dom:.2e})"
+    assert (
+        abs(max_dev_imp) < 1e-9
+    ), f"Aimp drifted at model_year=2017 (max |Δ| = {max_dev_imp:.2e})"
+
+
+def test_summary_tables_branch_no_nan_no_negatives(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Summary-tables A and q should have no NaN and no negative entries —
+    the deflate step preserves sign, ``scale_cornerstone_A``'s downstream
+    cap enforces non-negativity on the per-matrix output, and the final
+    inflate is sign-preserving.
+
+    Column-sum ≤ 1 is not asserted: the final price-index inflation
+    (``diag(p) @ A @ diag(1/p)``) can push some columns above 1, matching
+    the default CEDA branch's behavior — the codebase does not re-cap after
+    inflation.
+    """
+    cfg = get_usa_config()
+    _set_summary_tables(monkeypatch)
+    monkeypatch.setattr(cfg, 'model_base_year', 2023)
+
+    result = derive_cornerstone_Aq_scaled()
+    assert not result.Adom.isna().to_numpy().any(), 'Adom has NaN'
+    assert not result.Aimp.isna().to_numpy().any(), 'Aimp has NaN'
+    assert (result.Adom.to_numpy() >= 0).all(), 'Adom has negatives'
+    assert (result.Aimp.to_numpy() >= 0).all(), 'Aimp has negatives'
+    assert not result.scaled_q.isna().to_numpy().any(), 'scaled_q has NaN'

--- a/bedrock/transform/eeio/__tests__/test_summary_a_realigned.py
+++ b/bedrock/transform/eeio/__tests__/test_summary_a_realigned.py
@@ -24,6 +24,7 @@ def _set_summary_tables(monkeypatch: pytest.MonkeyPatch) -> None:
     cfg = get_usa_config()
     monkeypatch.setattr(cfg, 'use_cornerstone_2026_model_schema', True)
     monkeypatch.setattr(cfg, 'scale_a_matrix_with_summary_tables', True)
+    monkeypatch.setattr(cfg, 'adjust_summary_A_and_q_dollar_year', True)
     monkeypatch.setattr(cfg, 'scale_a_matrix_with_useeio_method', False)
     monkeypatch.setattr(cfg, 'scale_a_matrix_with_industry_price_index', False)
     monkeypatch.setattr(cfg, 'scale_a_matrix_with_commodity_price_index', False)

--- a/bedrock/transform/eeio/__tests__/test_summary_a_realigned.py
+++ b/bedrock/transform/eeio/__tests__/test_summary_a_realigned.py
@@ -27,7 +27,6 @@ def _set_summary_tables(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(cfg, 'scale_a_matrix_with_useeio_method', False)
     monkeypatch.setattr(cfg, 'scale_a_matrix_with_industry_price_index', False)
     monkeypatch.setattr(cfg, 'scale_a_matrix_with_commodity_price_index', False)
-    monkeypatch.setattr(cfg, 'load_useeio_nowcast_A_matrix', False)
     derive_cornerstone_Aq_scaled.cache_clear()
 
 

--- a/bedrock/transform/eeio/cornerstone_year_scaling.py
+++ b/bedrock/transform/eeio/cornerstone_year_scaling.py
@@ -17,6 +17,10 @@ from bedrock.transform.eeio.derived_2017 import (
     derive_summary_Aimp_usa,
     derive_summary_q_usa,
 )
+from bedrock.utils.economic.inflation_helpers_cornerstone import (
+    adjust_summary_A_dollar_year,
+    adjust_summary_q_dollar_year,
+)
 from bedrock.utils.math.formulas import compute_total_industry_inputs
 from bedrock.utils.taxonomy.bea.matrix_mappings import USA_SUMMARY_MUT_YEARS
 from bedrock.utils.taxonomy.bea_v2017_to_ceda_v7_helpers import (
@@ -71,9 +75,19 @@ def scale_cornerstone_A(
     original_year: USA_SUMMARY_MUT_YEARS,
     dom_or_imp_or_total: ta.Literal['dom', 'imp', 'total'],
 ) -> pd.DataFrame:
-    """Scale detail A element-wise using summary A ratios."""
+    """Scale detail A element-wise using summary A ratios.
+
+    The target-year summary A is rebased into ``original_year`` USD via the
+    ITA-based summary commodity price ratio before the ratio is taken, so
+    the structural cross-year ratio is formed in a consistent dollar year.
+    See plan `.claude/plans/summary_a_dollar_year_realignment_plan.md`.
+    """
     A_summary_base = _get_summary_A(original_year, dom_or_imp_or_total)
-    A_summary_target = _get_summary_A(target_year, dom_or_imp_or_total)
+    A_summary_target = adjust_summary_A_dollar_year(
+        A_summary=_get_summary_A(target_year, dom_or_imp_or_total),
+        from_year=target_year,
+        to_year=original_year,
+    )
 
     summary_to_cornerstone = load_bea_v2017_summary_to_cornerstone()
     detail_sectors = list(A.index)
@@ -123,9 +137,18 @@ def scale_cornerstone_q(
     target_year: USA_SUMMARY_MUT_YEARS,
     original_year: USA_SUMMARY_MUT_YEARS,
 ) -> pd.Series[float]:
-    ratio = (
-        derive_summary_q_usa(target_year) / derive_summary_q_usa(original_year)
-    ).fillna(1.0)
+    """Scale detail q element-wise using summary q ratios.
+
+    The target-year summary q is rebased into ``original_year`` USD via the
+    ITA-based summary commodity price ratio before forming the cross-year
+    ratio.
+    """
+    q_summary_target = adjust_summary_q_dollar_year(
+        q_summary=derive_summary_q_usa(target_year),
+        from_year=target_year,
+        to_year=original_year,
+    )
+    ratio = (q_summary_target / derive_summary_q_usa(original_year)).fillna(1.0)
     return ta.cast(
         pd.Series,
         _apply_summary_ratio_to_sectors(ratio, q, axis='rows'),

--- a/bedrock/transform/eeio/cornerstone_year_scaling.py
+++ b/bedrock/transform/eeio/cornerstone_year_scaling.py
@@ -17,6 +17,7 @@ from bedrock.transform.eeio.derived_2017 import (
     derive_summary_Aimp_usa,
     derive_summary_q_usa,
 )
+from bedrock.utils.config.usa_config import get_usa_config
 from bedrock.utils.economic.inflation_helpers_cornerstone import (
     adjust_summary_A_dollar_year,
     adjust_summary_q_dollar_year,
@@ -77,17 +78,21 @@ def scale_cornerstone_A(
 ) -> pd.DataFrame:
     """Scale detail A element-wise using summary A ratios.
 
-    The target-year summary A is rebased into ``original_year`` USD via the
-    ITA-based summary commodity price ratio before the ratio is taken, so
-    the structural cross-year ratio is formed in a consistent dollar year.
-    See plan `.claude/plans/summary_a_dollar_year_realignment_plan.md`.
+    When ``cfg.adjust_summary_A_and_q_dollar_year`` is set, the target-year summary A
+    is rebased into ``original_year`` USD via the ITA-based summary commodity
+    price ratio before the ratio is taken, so the structural cross-year ratio
+    is formed in a consistent dollar year. Otherwise the ratio is taken on the
+    raw target-year summary A (pre-realignment behavior). See plan
+    `.claude/plans/summary_a_dollar_year_realignment_plan.md`.
     """
     A_summary_base = _get_summary_A(original_year, dom_or_imp_or_total)
-    A_summary_target = adjust_summary_A_dollar_year(
-        A_summary=_get_summary_A(target_year, dom_or_imp_or_total),
-        from_year=target_year,
-        to_year=original_year,
-    )
+    A_summary_target = _get_summary_A(target_year, dom_or_imp_or_total)
+    if get_usa_config().adjust_summary_A_and_q_dollar_year:
+        A_summary_target = adjust_summary_A_dollar_year(
+            A_summary=A_summary_target,
+            from_year=target_year,
+            to_year=original_year,
+        )
 
     summary_to_cornerstone = load_bea_v2017_summary_to_cornerstone()
     detail_sectors = list(A.index)
@@ -139,15 +144,18 @@ def scale_cornerstone_q(
 ) -> pd.Series[float]:
     """Scale detail q element-wise using summary q ratios.
 
-    The target-year summary q is rebased into ``original_year`` USD via the
-    ITA-based summary commodity price ratio before forming the cross-year
-    ratio.
+    When ``cfg.adjust_summary_A_and_q_dollar_year`` is set, the target-year summary q
+    is rebased into ``original_year`` USD via the ITA-based summary commodity
+    price ratio before forming the cross-year ratio. Otherwise the ratio is
+    taken on the raw target-year summary q (pre-realignment behavior).
     """
-    q_summary_target = adjust_summary_q_dollar_year(
-        q_summary=derive_summary_q_usa(target_year),
-        from_year=target_year,
-        to_year=original_year,
-    )
+    q_summary_target = derive_summary_q_usa(target_year)
+    if get_usa_config().adjust_summary_A_and_q_dollar_year:
+        q_summary_target = adjust_summary_q_dollar_year(
+            q_summary=q_summary_target,
+            from_year=target_year,
+            to_year=original_year,
+        )
     ratio = (q_summary_target / derive_summary_q_usa(original_year)).fillna(1.0)
     return ta.cast(
         pd.Series,

--- a/bedrock/transform/eeio/derived_cornerstone.py
+++ b/bedrock/transform/eeio/derived_cornerstone.py
@@ -542,18 +542,6 @@ def derive_cornerstone_Aq_scaled() -> SingleRegionAqMatrixSet:
     if cfg.scale_a_matrix_with_useeio_method:
         return base
 
-    # USEEIO nowcast: load externally-balanced detail SUTs from GCS and
-    # derive Cornerstone A directly. Bypasses all internal scaling/inflation;
-    # treats the upstream USEEIO team's GRAS-balanced 2018–2023 SUTs as the
-    # source of structural change. Loaders: bedrock.extract.iot.useeio_nowcast;
-    # derivation: bedrock.transform.eeio.derived_useeio_nowcast.
-    if cfg.load_useeio_nowcast_A_matrix:
-        from bedrock.transform.eeio.derived_useeio_nowcast import (  # noqa: PLC0415
-            derive_useeio_nowcast_Aq_cornerstone,
-        )
-
-        return derive_useeio_nowcast_Aq_cornerstone(year=model_year)
-
     # Summary tables: scale 2017 → model_year using summary A ratios computed
     # entirely in 2017 USD (`scale_cornerstone_A` rebases the target-year
     # summary A to 2017 USD before the ratio is taken), then inflate the

--- a/bedrock/transform/eeio/derived_cornerstone.py
+++ b/bedrock/transform/eeio/derived_cornerstone.py
@@ -542,23 +542,52 @@ def derive_cornerstone_Aq_scaled() -> SingleRegionAqMatrixSet:
     if cfg.scale_a_matrix_with_useeio_method:
         return base
 
-    # Summary tables only: scale 2017 → model_year directly using summary A ratios,
-    # skipping the intermediate io_year step and price inflation.
+    # USEEIO nowcast: load externally-balanced detail SUTs from GCS and
+    # derive Cornerstone A directly. Bypasses all internal scaling/inflation;
+    # treats the upstream USEEIO team's GRAS-balanced 2018–2023 SUTs as the
+    # source of structural change. Loaders: bedrock.extract.iot.useeio_nowcast;
+    # derivation: bedrock.transform.eeio.derived_useeio_nowcast.
+    if cfg.load_useeio_nowcast_A_matrix:
+        from bedrock.transform.eeio.derived_useeio_nowcast import (  # noqa: PLC0415
+            derive_useeio_nowcast_Aq_cornerstone,
+        )
+
+        return derive_useeio_nowcast_Aq_cornerstone(year=model_year)
+
+    # Summary tables: scale 2017 → model_year using summary A ratios computed
+    # entirely in 2017 USD (`scale_cornerstone_A` rebases the target-year
+    # summary A to 2017 USD before the ratio is taken), then inflate the
+    # resulting detail A from 2017 → model_year. See
+    # `.claude/plans/summary_a_dollar_year_realignment_plan.md`.
     if cfg.scale_a_matrix_with_summary_tables:
-        Adom = scale_cornerstone_A(
-            base.Adom,
-            target_year=model_year,
+        Adom = inflate_cornerstone_A_matrix_with_industry_pi(
+            scale_cornerstone_A(
+                base.Adom,
+                target_year=model_year,
+                original_year=detail_year,
+                dom_or_imp_or_total='dom',
+            ),
             original_year=detail_year,
-            dom_or_imp_or_total='dom',
-        )
-        Aimp = scale_cornerstone_A(
-            base.Aimp,
             target_year=model_year,
-            original_year=detail_year,
-            dom_or_imp_or_total='imp',
         )
-        q = scale_cornerstone_q(
-            base.scaled_q, target_year=model_year, original_year=detail_year
+        Aimp = inflate_cornerstone_A_matrix_with_industry_pi(
+            scale_cornerstone_A(
+                base.Aimp,
+                target_year=model_year,
+                original_year=detail_year,
+                dom_or_imp_or_total='imp',
+            ),
+            original_year=detail_year,
+            target_year=model_year,
+        )
+        q = inflate_cornerstone_q_or_y_with_industry_pi(
+            scale_cornerstone_q(
+                base.scaled_q,
+                target_year=model_year,
+                original_year=detail_year,
+            ),
+            original_year=detail_year,
+            target_year=model_year,
         )
         return SingleRegionAqMatrixSet(
             Adom=pt.DataFrame[CornerstoneAMatrix](Adom),  # type: ignore[arg-type]

--- a/bedrock/transform/eeio/derived_cornerstone.py
+++ b/bedrock/transform/eeio/derived_cornerstone.py
@@ -573,7 +573,7 @@ def derive_cornerstone_Aq_scaled() -> SingleRegionAqMatrixSet:
             Adom = inflate_cornerstone_A_matrix_with_commodity_pi(
                 Adom, original_year=detail_year, target_year=model_year
             )
-            Aimp = inflate_cornerstone_A_matrix_with_industry_pi(
+            Aimp = inflate_cornerstone_A_matrix_with_commodity_pi(
                 Aimp, original_year=detail_year, target_year=model_year
             )
             q = inflate_cornerstone_q_or_y_with_industry_pi(

--- a/bedrock/transform/eeio/derived_cornerstone.py
+++ b/bedrock/transform/eeio/derived_cornerstone.py
@@ -570,7 +570,7 @@ def derive_cornerstone_Aq_scaled() -> SingleRegionAqMatrixSet:
             original_year=detail_year,
         )
         if cfg.adjust_summary_A_and_q_dollar_year:
-            Adom = inflate_cornerstone_A_matrix_with_industry_pi(
+            Adom = inflate_cornerstone_A_matrix_with_commodity_pi(
                 Adom, original_year=detail_year, target_year=model_year
             )
             Aimp = inflate_cornerstone_A_matrix_with_industry_pi(

--- a/bedrock/transform/eeio/derived_cornerstone.py
+++ b/bedrock/transform/eeio/derived_cornerstone.py
@@ -542,41 +542,43 @@ def derive_cornerstone_Aq_scaled() -> SingleRegionAqMatrixSet:
     if cfg.scale_a_matrix_with_useeio_method:
         return base
 
-    # Summary tables: scale 2017 → model_year using summary A ratios computed
-    # entirely in 2017 USD (`scale_cornerstone_A` rebases the target-year
-    # summary A to 2017 USD before the ratio is taken), then inflate the
-    # resulting detail A from 2017 → model_year. See
+    # Summary tables: scale 2017 → model_year using summary A ratios.
+    #
+    # When `cfg.adjust_summary_A_and_q_dollar_year` is set, `scale_cornerstone_A`
+    # rebases the target-year summary A into 2017 USD before the ratio is taken,
+    # so the structural cross-year ratio is formed entirely in 2017 USD; the
+    # scaled detail A is then inflated 2017 → model_year. When the flag is off,
+    # the ratio carries the raw target-year-vs-2017 price drift and no final
+    # inflation is applied (pre-realignment behavior). See
     # `.claude/plans/summary_a_dollar_year_realignment_plan.md`.
     if cfg.scale_a_matrix_with_summary_tables:
-        Adom = inflate_cornerstone_A_matrix_with_industry_pi(
-            scale_cornerstone_A(
-                base.Adom,
-                target_year=model_year,
-                original_year=detail_year,
-                dom_or_imp_or_total='dom',
-            ),
-            original_year=detail_year,
+        Adom = scale_cornerstone_A(
+            base.Adom,
             target_year=model_year,
-        )
-        Aimp = inflate_cornerstone_A_matrix_with_industry_pi(
-            scale_cornerstone_A(
-                base.Aimp,
-                target_year=model_year,
-                original_year=detail_year,
-                dom_or_imp_or_total='imp',
-            ),
             original_year=detail_year,
-            target_year=model_year,
+            dom_or_imp_or_total='dom',
         )
-        q = inflate_cornerstone_q_or_y_with_industry_pi(
-            scale_cornerstone_q(
-                base.scaled_q,
-                target_year=model_year,
-                original_year=detail_year,
-            ),
+        Aimp = scale_cornerstone_A(
+            base.Aimp,
+            target_year=model_year,
             original_year=detail_year,
-            target_year=model_year,
+            dom_or_imp_or_total='imp',
         )
+        q = scale_cornerstone_q(
+            base.scaled_q,
+            target_year=model_year,
+            original_year=detail_year,
+        )
+        if cfg.adjust_summary_A_and_q_dollar_year:
+            Adom = inflate_cornerstone_A_matrix_with_industry_pi(
+                Adom, original_year=detail_year, target_year=model_year
+            )
+            Aimp = inflate_cornerstone_A_matrix_with_industry_pi(
+                Aimp, original_year=detail_year, target_year=model_year
+            )
+            q = inflate_cornerstone_q_or_y_with_industry_pi(
+                q, original_year=detail_year, target_year=model_year
+            )
         return SingleRegionAqMatrixSet(
             Adom=pt.DataFrame[CornerstoneAMatrix](Adom),  # type: ignore[arg-type]
             Aimp=pt.DataFrame[CornerstoneAMatrix](Aimp),  # type: ignore[arg-type]

--- a/bedrock/transform/eeio/derived_cornerstone.py
+++ b/bedrock/transform/eeio/derived_cornerstone.py
@@ -576,7 +576,7 @@ def derive_cornerstone_Aq_scaled() -> SingleRegionAqMatrixSet:
             Aimp = inflate_cornerstone_A_matrix_with_commodity_pi(
                 Aimp, original_year=detail_year, target_year=model_year
             )
-            q = inflate_cornerstone_q_or_y_with_industry_pi(
+            q = inflate_cornerstone_q_or_y_with_commodity_pi(
                 q, original_year=detail_year, target_year=model_year
             )
         return SingleRegionAqMatrixSet(

--- a/bedrock/utils/config/configs/2025_usa_cornerstone_A_summary_tables_realigned.yaml
+++ b/bedrock/utils/config/configs/2025_usa_cornerstone_A_summary_tables_realigned.yaml
@@ -1,0 +1,8 @@
+# Summary-tables A-matrix scaling with dollar-year realignment.
+# Like 2025_usa_cornerstone_A_summary_tables.yaml, but rebases the target-year
+# summary A/q into 2017 USD before forming the cross-year ratio, then inflates
+# the scaled detail A/q 2017 -> model_year. See
+# `.claude/plans/summary_a_dollar_year_realignment_plan.md`.
+use_cornerstone_2026_model_schema: True
+scale_a_matrix_with_summary_tables: True
+adjust_summary_A_and_q_dollar_year: True

--- a/bedrock/utils/config/configs/2025_usa_cornerstone_full_model_A_summary_tables_realigned.yaml
+++ b/bedrock/utils/config/configs/2025_usa_cornerstone_full_model_A_summary_tables_realigned.yaml
@@ -1,0 +1,10 @@
+# Full v0.2 model bundled with summary-tables A-matrix scaling and dollar-year
+# realignment: the target-year summary A/q is rebased into 2017 USD before the
+# cross-year ratio, then the scaled detail A/q is inflated 2017 -> model_year.
+use_cornerstone_2026_model_schema: True
+load_E_from_flowsa: True
+new_ghg_method: True
+use_E_data_year_for_x_in_B: True
+implement_waste_disaggregation: True
+scale_a_matrix_with_summary_tables: True
+adjust_summary_A_and_q_dollar_year: True

--- a/bedrock/utils/config/usa_config.py
+++ b/bedrock/utils/config/usa_config.py
@@ -81,6 +81,7 @@ class USAConfig(BaseModel):
     scale_a_matrix_with_summary_tables: bool = False  # DRI: mo.li
     scale_a_matrix_with_industry_price_index: bool = False  # DRI: mo.li
     scale_a_matrix_with_commodity_price_index: bool = False  # DRI: mo.li
+    adjust_summary_A_and_q_dollar_year: bool = False  # DRI: mo.li
     apply_inflation_to_V: bool = False  # DRI: WesIngwersen
     ### GHG Methodology selection
     load_E_from_flowsa: bool = False  # if True, use load_E_from_flowsa()

--- a/bedrock/utils/economic/__tests__/test_summary_commodity_price_ratio.py
+++ b/bedrock/utils/economic/__tests__/test_summary_commodity_price_ratio.py
@@ -1,0 +1,126 @@
+"""Tests for the ITA-based summary commodity price ratio helpers.
+
+Validates:
+- ITA reduces to truth at the 2017 benchmark (q = C_m @ x is exact).
+- V_norm columns are stochastic.
+- Ratio is identity at year == year.
+- Index coverage matches USA_2017_SUMMARY_INDUSTRY_CODES.
+- Deflate / inflate round-trip preserves an A matrix.
+
+See `.claude/plans/summary_a_dollar_year_realignment_plan.md`.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from bedrock.transform.eeio.derived_cornerstone import derive_cornerstone_q
+from bedrock.utils.economic.inflation_helpers_cornerstone import (
+    adjust_summary_A_dollar_year,
+    derive_cornerstone_q_and_vnorm_for_year,
+    get_summary_commodity_price_index,
+    get_summary_commodity_price_ratio,
+)
+from bedrock.utils.taxonomy.bea.v2017_industry_summary import (
+    USA_2017_SUMMARY_INDUSTRY_CODES,
+)
+
+
+def test_ita_q_at_2017_matches_derive_cornerstone_q() -> None:
+    """Under ITA, ``q[y] = C_m[2017] @ x[y]`` is exact when ``y == 2017``
+    (because C_m and x are then both from the 2017 V). The result must
+    therefore agree with ``derive_cornerstone_q()`` (which is V.sum(axis=0)
+    directly off 2017 V) within numerical noise.
+    """
+    q_ita = derive_cornerstone_q_and_vnorm_for_year(2017)[0]
+    q_truth = derive_cornerstone_q()
+
+    aligned_ita = q_ita.reindex(q_truth.index, fill_value=0.0)
+    # The BEA detail x for 2017 may differ slightly from V.sum(axis=1) due to
+    # before/after-redefinition. We assert relative agreement to 1% on the
+    # bulk of the distribution rather than exact bit-equality.
+    nonzero = q_truth.abs() > 1.0
+    rel_dev = ((aligned_ita - q_truth).abs() / q_truth.abs())[nonzero]
+    assert (
+        rel_dev.median() < 0.01
+    ), f"ITA q at 2017 deviates from derive_cornerstone_q (median rel dev {rel_dev.median():.2%})"
+
+
+def test_ita_vnorm_columns_are_stochastic() -> None:
+    """Each column of V_norm[y] should sum to ~1 (market shares of industries
+    supplying each commodity). Excludes commodities with zero coverage.
+    """
+    vnorm = derive_cornerstone_q_and_vnorm_for_year(2022)[1]
+    col_sums = vnorm.sum(axis=0)
+    covered = col_sums > 1e-9
+    deviations = (col_sums[covered] - 1.0).abs()
+    assert (
+        deviations.max() < 1e-9
+    ), f"V_norm columns not stochastic (max |sum-1| = {deviations.max():.2e})"
+
+
+def test_summary_commodity_price_ratio_is_identity_at_year_to_self() -> None:
+    """``get_summary_commodity_price_ratio(y, y)`` must be all 1.0 for every
+    summary code (ratio of any value with itself).
+    """
+    ratio = get_summary_commodity_price_ratio(2017, 2017)
+    max_abs_dev = (ratio - 1.0).abs().max()
+    assert (
+        max_abs_dev < 1e-12
+    ), f"Expected ratio == 1.0 at year=year, got max abs deviation {max_abs_dev:.2e}"
+
+
+def test_summary_commodity_price_ratio_index_coverage() -> None:
+    """Output must be indexed exactly on USA_2017_SUMMARY_INDUSTRY_CODES."""
+    ratio = get_summary_commodity_price_ratio(2017, 2022)
+    assert list(ratio.index) == list(USA_2017_SUMMARY_INDUSTRY_CODES)
+
+
+def test_summary_commodity_price_index_positive() -> None:
+    """All entries should be strictly positive — neither the upstream BEA PI
+    nor the V-norm-weighted aggregation can produce zeros or negatives.
+    """
+    pi = get_summary_commodity_price_index(2022)
+    assert (pi > 0).all(), "Summary commodity PI has non-positive entries"
+
+
+def test_adjust_summary_A_dollar_year_roundtrip() -> None:
+    """Adjusting Y → 2017 composed with the inverse transform should recover
+    the original A within numerical noise. Verifies the
+    ``diag(1/p) @ A @ diag(p)`` form is self-consistent.
+    """
+    p = get_summary_commodity_price_ratio(2017, 2022)
+    A = pd.DataFrame(
+        np.random.default_rng(0).random(
+            (len(USA_2017_SUMMARY_INDUSTRY_CODES), len(USA_2017_SUMMARY_INDUSTRY_CODES))
+        ),
+        index=pd.Index(USA_2017_SUMMARY_INDUSTRY_CODES),
+        columns=pd.Index(USA_2017_SUMMARY_INDUSTRY_CODES),
+    )
+    adjusted = adjust_summary_A_dollar_year(A, from_year=2022, to_year=2017)
+    # Manually invert via diag(p) @ A @ diag(1/p) (inverse of
+    # diag(1/p) @ A @ diag(p)).
+    p_vec = p.reindex(A.index, fill_value=1.0).to_numpy(dtype=float)
+    reinverted = pd.DataFrame(
+        np.diag(p_vec) @ adjusted.to_numpy() @ np.diag(1.0 / p_vec),
+        index=A.index,
+        columns=A.columns,
+    )
+    max_dev = (reinverted - A).abs().to_numpy().max()
+    assert (
+        max_dev < 1e-9
+    ), f"adjust ∘ inverse round-trip failed (max |Δ| = {max_dev:.2e})"
+
+
+def test_adjust_summary_A_dollar_year_is_noop_when_years_match() -> None:
+    """When from_year == to_year, the price ratio is all 1.0 and adjust must
+    return a byte-identical matrix.
+    """
+    A = pd.DataFrame(
+        np.random.default_rng(1).random((5, 5)),
+        index=pd.Index(USA_2017_SUMMARY_INDUSTRY_CODES[:5]),
+        columns=pd.Index(USA_2017_SUMMARY_INDUSTRY_CODES[:5]),
+    )
+    adjusted = adjust_summary_A_dollar_year(A, from_year=2017, to_year=2017)
+    pd.testing.assert_frame_equal(adjusted, A, check_exact=False, atol=1e-12)

--- a/bedrock/utils/economic/inflation_helpers_cornerstone.py
+++ b/bedrock/utils/economic/inflation_helpers_cornerstone.py
@@ -11,6 +11,7 @@ identifiable parent (e.g. S00402 used goods) receive a neutral ratio of 1.0.
 from __future__ import annotations
 
 import functools
+import typing as ta
 
 import numpy as np
 import pandas as pd
@@ -19,6 +20,18 @@ from bedrock.transform.iot.derived_price_index import derive_industry_price_inde
 from bedrock.utils.config.usa_config import get_usa_config
 from bedrock.utils.economic.inflation_helpers_ceda import (
     obtain_inflation_factors_from_reference_data,
+)
+from bedrock.utils.math.formulas import (
+    compute_commodity_mix_matrix,
+    compute_Vnorm_matrix,
+    compute_x,
+)
+from bedrock.utils.taxonomy.bea.matrix_mappings import USA_GROSS_INDUSTRY_OUTPUT_YEARS
+from bedrock.utils.taxonomy.bea.v2017_industry_summary import (
+    USA_2017_SUMMARY_INDUSTRY_CODES,
+)
+from bedrock.utils.taxonomy.bea_v2017_to_ceda_v7_helpers import (
+    load_bea_v2017_summary_to_cornerstone,
 )
 from bedrock.utils.taxonomy.cornerstone.commodities import COMMODITIES
 from bedrock.utils.taxonomy.cornerstone.industries import INDUSTRIES
@@ -188,3 +201,232 @@ def inflate_cornerstone_B_matrix_with_industry_pi(
 ) -> pd.DataFrame:
     price_ratio = get_cornerstone_industry_price_ratio(target_year, original_year)
     return B * price_ratio.reindex(B.columns, fill_value=1.0).values
+
+
+# ---------------------------------------------------------------------------
+# Summary-level commodity price ratio + summary A/q dollar-year adjustment
+#
+# Used to rebase a BEA summary A (or q) from one dollar-year basis to another
+# before forming the structural cross-year ratio in scale_cornerstone_A /
+# scale_cornerstone_q. Without this, the ratio mixes inter-sector relative
+# price changes with real input-share changes.
+#
+# The adjustment is direction-agnostic: deflating when from_year > to_year,
+# inflating when from_year < to_year.
+#
+# Summary commodity PI is built ITA-style (Industry-Technology Assumption):
+# the 2017 commodity-mix matrix C_m = V/x is held fixed, and BEA's published
+# year-y industry gross output drives year-specificity for q and V_norm. See
+# `derive_cornerstone_q_and_vnorm_for_year` below.
+# ---------------------------------------------------------------------------
+
+
+def adjust_summary_A_dollar_year(
+    A_summary: pd.DataFrame,
+    from_year: int,
+    to_year: int,
+) -> pd.DataFrame:
+    """Rebase a summary A matrix from ``from_year`` USD to ``to_year`` USD via
+    ``diag(1/p) @ A @ diag(p)``, where ``p`` is the summary commodity price
+    ratio (from_year → to_year).
+
+    Real A: ``A_to[i, j] = A_from[i, j] * p[j] / p[i]`` — row-axis is input
+    deflation, column-axis is output re-inflation, so the ratio of deflated
+    input to deflated output recovers a real-quantity coefficient.
+
+    Direction-agnostic: deflates when from_year > to_year, inflates when
+    from_year < to_year.
+    """
+    p = get_summary_commodity_price_ratio(original_year=to_year, target_year=from_year)
+    p_row = np.asarray(p.reindex(A_summary.index, fill_value=1.0).to_numpy(dtype=float))
+    p_col = np.asarray(
+        p.reindex(A_summary.columns, fill_value=1.0).to_numpy(dtype=float)
+    )
+    return pd.DataFrame(
+        np.diag(1.0 / p_row) @ A_summary.to_numpy() @ np.diag(p_col),
+        index=A_summary.index,
+        columns=A_summary.columns,
+    )
+
+
+def adjust_summary_q_dollar_year(
+    q_summary: pd.Series[float],
+    from_year: int,
+    to_year: int,
+) -> pd.Series[float]:
+    """Rebase a summary q (commodity gross output) vector from ``from_year``
+    USD to ``to_year`` USD by elementwise division by the summary commodity
+    price ratio.
+
+    Direction-agnostic: deflates when from_year > to_year, inflates when
+    from_year < to_year.
+    """
+    p = get_summary_commodity_price_ratio(original_year=to_year, target_year=from_year)
+    return q_summary / p.reindex(q_summary.index, fill_value=1.0)
+
+
+@functools.cache
+def get_summary_commodity_price_ratio(
+    original_year: int, target_year: int
+) -> pd.Series[float]:
+    """Cross-year ratio of summary commodity price indices, indexed on
+    ``USA_2017_SUMMARY_INDUSTRY_CODES`` (commodity and industry summary codes
+    overlap at BEA 2017 summary granularity).
+
+    Built as the ratio of two ITA-based Paasche summary commodity PIs (see
+    ``get_summary_commodity_price_index``).
+    """
+    pi_orig = get_summary_commodity_price_index(original_year)
+    pi_targ = get_summary_commodity_price_index(target_year)
+    ratio = pi_targ / pi_orig
+    return ratio.where(np.isfinite(ratio), 1.0).fillna(1.0)
+
+
+@functools.cache
+def get_summary_commodity_price_index(year: int) -> pd.Series[float]:
+    """Summary commodity price index for ``year``, ITA-based Paasche
+    construction. Indexed on ``USA_2017_SUMMARY_INDUSTRY_CODES``.
+
+    Construction::
+
+        PI_industry_detail[y]      ← cornerstone-reindexed PI for year y
+        PI_commodity_detail[y]     = V_norm[y].T @ PI_industry_detail[y]
+        PI_commodity_summary[K, y] = (q[y]-weighted mean of PI_commodity_detail
+                                      over cornerstone children of K)
+
+    `V_norm[y]` and `q[y]` come from ``derive_cornerstone_q_and_vnorm_for_year``
+    — constructed under ITA (2017 commodity-mix matrix held fixed, year-y
+    industry GO drives year-specificity). See that helper's docstring for what's
+    frozen vs. year-specific.
+
+    Fallbacks: summary codes with no cornerstone children fill 100 (neutral
+    flat trajectory → ratio = 1 against any other year's neutral fill);
+    summary blocks where all children have zero ``q[y]`` weight fall back to
+    an unweighted mean of children's PI.
+    """
+    pi_year_industry = _cornerstone_indexed_industry_pi(year)
+    q_y, V_norm_y = derive_cornerstone_q_and_vnorm_for_year(year)
+
+    # V_norm rows are cornerstone industries; align pi_year_industry on those.
+    pi_ind_aligned = pi_year_industry.reindex(V_norm_y.index, fill_value=100.0)
+    pi_com_detail = V_norm_y.T @ pi_ind_aligned  # (cornerstone commodities,)
+
+    summary_to_corn = load_bea_v2017_summary_to_cornerstone()
+    out: dict[str, float] = {}
+    for summary_code, children in summary_to_corn.items():
+        children_in_idx = [c for c in children if c in pi_com_detail.index]
+        if not children_in_idx:
+            continue
+        w = q_y.reindex(children_in_idx, fill_value=0.0)
+        p = pi_com_detail.reindex(children_in_idx, fill_value=100.0)
+        wsum = float(w.sum())
+        out[str(summary_code)] = (
+            float((p * w).sum() / wsum) if wsum > 0 else float(p.mean())
+        )
+    return pd.Series(out, dtype=float).reindex(
+        USA_2017_SUMMARY_INDUSTRY_CODES, fill_value=100.0
+    )
+
+
+@functools.cache
+def derive_cornerstone_q_and_vnorm_for_year(
+    year: int,
+) -> tuple[pd.Series[float], pd.DataFrame]:
+    """Year-y ``(q, V_norm)`` at cornerstone detail granularity.
+
+    Constructed under the **Industry-Technology Assumption (ITA)**: each
+    industry's commodity-output split (the commodity-mix matrix
+    ``C_m = V / x``) is held constant at 2017; year-y industry size ``x[y]``
+    (BEA's published gross-output time series) drives year-specificity. This
+    is the only way to get year-y ``q`` / ``V_norm`` at detail granularity
+    because BEA only publishes detail Make tables for benchmark years.
+    Identity used::
+
+        q[y] = C_m[2017] @ x[y]      (exact when C_m, x are from the same V;
+                                       used in eeio_diagnostics.py:414)
+
+    V[y] is reconstructed as ``C_m[2017].T · diag(x[y])`` (i.e., each industry
+    row of 2017's V is scaled by ``x[y, i] / x[2017, i]``), and V_norm[y] is
+    then ``V[y] / q[y]`` (column-normalized, market shares).
+
+    Returns ``(q_y, V_norm_y)`` with cornerstone commodity / industry indices.
+    At ``year == cfg.usa_base_io_data_year`` both reduce to their 2017
+    counterparts (regression-tested).
+    """
+    # Local import: derived_cornerstone imports from this module, mirroring the
+    # existing pattern at the top of `get_vnorm_adjusted_commodity_price_ratio`.
+    from bedrock.transform.eeio.cornerstone_expansion import (  # noqa: PLC0415
+        CS_INDUSTRY_LIST,
+        cs_industry_to_bea_map,
+        expand_vector,
+    )
+    from bedrock.transform.eeio.derived_cornerstone import (  # noqa: PLC0415
+        _distribute_waste_parent_x_using_v_row_shares,
+        derive_cornerstone_V,
+    )
+    from bedrock.transform.iot.derived_gross_industry_output import (  # noqa: PLC0415
+        derive_gross_output,
+    )
+
+    cfg = get_usa_config()
+    V_2017 = derive_cornerstone_V()
+    x_2017 = compute_x(V=V_2017)
+    # C_m: commodity × industry, each row sums to 1 (within-industry split).
+    C_m = compute_commodity_mix_matrix(V=V_2017, x=x_2017)
+
+    x_bea_y = derive_gross_output(
+        # `derive_gross_output` types target_year as the Literal of supported
+        # years; this helper's caller passes a runtime int, so we cast.
+        target_year=ta.cast(USA_GROSS_INDUSTRY_OUTPUT_YEARS, year),
+        iot_before_or_after_redefinition=cfg.iot_before_or_after_redefinition,
+    )
+    x_y = expand_vector(x_bea_y, CS_INDUSTRY_LIST, cs_industry_to_bea_map())
+    # When waste disagg is on, expand_vector duplicates the 562000 parent GO
+    # across waste children; redistribute via 2017 V row shares so the
+    # disaggregated industries get the right share. No-op when waste disagg
+    # is off (the helper short-circuits on missing weights).
+    x_y = _distribute_waste_parent_x_using_v_row_shares(x_y)
+    x_y = x_y.reindex(x_2017.index, fill_value=0.0)
+
+    q_y = C_m @ x_y
+    q_y = q_y.reindex(V_2017.columns, fill_value=0.0)
+    V_y = C_m.T.mul(x_y, axis=0).reindex(
+        index=V_2017.index, columns=V_2017.columns, fill_value=0.0
+    )
+    V_norm_y = compute_Vnorm_matrix(V=V_y, q=q_y)
+    return q_y, V_norm_y
+
+
+@functools.cache
+def _cornerstone_indexed_industry_pi(year: int) -> pd.Series[float]:
+    """Cornerstone-industry-indexed PI for one year, with CEDA-v7-parent
+    fallback for cornerstone-only codes (mirrors the per-year half of
+    ``get_cornerstone_industry_price_ratio``).
+
+    Always indexed on ``CORNERSTONE_INDUSTRIES`` regardless of
+    ``update_inflation_factors`` (V_norm.T @ pi_industry in the ITA flow needs
+    industry granularity; the existing dispatch's commodity branch returns
+    commodity-indexed values for the legacy ``diag(p) @ A @ diag(1/p)`` flow,
+    which we don't want here).
+
+    Codes with no parent in the upstream PI fall back to 100 (BEA convention
+    2017 = 100); any ratio against another year that also falls back is 1.0.
+    """
+    cfg = get_usa_config()
+    price_index = (
+        derive_industry_price_index()
+        if cfg.update_inflation_factors
+        else obtain_inflation_factors_from_reference_data()
+    )
+
+    pi_year: pd.Series[float] = price_index[year]
+    series = pi_year.reindex(CORNERSTONE_INDUSTRIES).astype(float)
+    parent_map = _cornerstone_to_ceda_v7_parent()
+    for child, parent_code in parent_map.items():
+        if (
+            child in series.index
+            and pd.isna(series.loc[child])
+            and parent_code in pi_year.index
+        ):
+            series.loc[child] = float(pi_year.loc[parent_code])
+    return series.fillna(100.0)


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

Adds an opt-in `adjust_summary_A_and_q_dollar_year` config flag (default `False`) that gates the summary A/q dollar-year realignment. When the flag is off, the pre-realignment behavior is reproduced exactly, so existing summary-tables configs are unaffected.

When the flag is set:

- `scale_cornerstone_A` / `scale_cornerstone_q` rebase the target-year summary A/q into `original_year` USD via an ITA-based summary commodity price ratio before forming the cross-year structural ratio. Without this rebase, the ratio mixed inter-sector relative price changes with real input-share changes.
- `derive_cornerstone_Aq_scaled()` inflates the summary-tables-scaled A/q `detail_year` → `model_year` afterwards. The rebase and this inflation are a matched pair (the rebase strips the price drift the inflation re-applies), so both are gated by the single flag to avoid double-counting.

When off, the ratio is taken on the raw target-year summary and the summary-tables branch applies no final inflation.

New helpers in `bedrock/utils/economic/inflation_helpers_cornerstone.py`:

- `adjust_summary_A_dollar_year` / `adjust_summary_q_dollar_year` — direction-agnostic dollar-year rebase using `diag(1/p) @ A @ diag(p)`
- `get_summary_commodity_price_ratio` / `get_summary_commodity_price_index` — ITA-based Paasche summary commodity PI, weighted by year-y q
- `derive_cornerstone_q_and_vnorm_for_year` — year-y `(q, V_norm)` at cornerstone detail under ITA (2017 `C_m` held fixed, BEA year-y industry GO drives year-specificity)
- `_cornerstone_indexed_industry_pi` — per-year industry PI with CEDA-v7-parent fallback

New configs that enable the flag:

- `2025_usa_cornerstone_A_summary_tables_realigned.yaml`
- `2025_usa_cornerstone_full_model_A_summary_tables_realigned.yaml`

## Testing

New tests `test_summary_a_realigned.py` (sets the flag) and `test_summary_commodity_price_ratio.py` cover the realigned scaling and the summary PI construction. All four CI checks (format, lint, test, typecheck) pass locally.