### PR TITLE
Adds GHG data from plant level eGRID data

### DIFF
--- a/bedrock/analysis/electricity/verify_egrid_to_sector_vs_national.py
+++ b/bedrock/analysis/electricity/verify_egrid_to_sector_vs_national.py
@@ -1,0 +1,101 @@
+"""Check ``egrid_to_sector`` FBS totals vs stewi eGRID US national tab.
+
+    uv run python -m bedrock.analysis.electricity.verify_egrid_to_sector_vs_national
+    uv run python -m bedrock.analysis.electricity.verify_egrid_to_sector_vs_national 2022
+
+Optional argv[1] is stewi eGRID inventory year (default 2023). Requires local stewi
+build for that year. Reference totals on GitHub (standardizedinventories stewi/data).
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pandas as pd
+
+from bedrock.extract.stewifbs.stewiFBS import egrid_to_sector
+
+DEFAULT_EGRID_YEAR = '2023'
+TOLERANCE_PCT = 0.1
+_GHG = ('Carbon dioxide', 'Methane', 'Nitrous oxide')
+_NAT_TOTALS_URL = (
+    'https://raw.githubusercontent.com/cornerstone-data/standardizedinventories/'
+    'refs/heads/main/stewi/data/eGRID_{year}_NationalTotals.csv'
+)
+
+# Minimal ``egrid_to_sector`` config (not a full FBS method stub).
+_EGRID_TO_SECTOR_CONFIG: dict = {
+    'data_format': 'FBS_outside_flowsa',
+    'geoscale': 'national',
+    'target_naics_year': 2017,
+    'activity_schema': 'NAICS_2017_Code',
+    'activity_to_sector_mapping': 'EPA_eGRID',
+    'industry_spec': {
+        'default': 'NAICS_6',
+        'NAICS_6': [
+            '221111',
+            '221112',
+            '221113',
+            '221114',
+            '221115',
+            '221116',
+            '221117',
+            '221118',
+            '221121',
+            '221122',
+        ],
+    },
+    'selection_fields': {
+        'Compartment': 'air',
+        'FlowName': list(_GHG),
+    },
+}
+
+
+def _flow_kg(amount: float, unit: str) -> float:
+    if unit == 'tons':
+        return amount * 907.18474
+    if unit == 'lbs':
+        return amount * 0.4535924
+    return amount
+
+
+def main() -> int:
+    year = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_EGRID_YEAR
+    nat_url = _NAT_TOTALS_URL.format(year=year)
+    config = {
+        **_EGRID_TO_SECTOR_CONFIG,
+        'inventory_dict': {'eGRID': year},
+        'year': int(year),
+    }
+
+    fbs_kg = (
+        pd.DataFrame(egrid_to_sector(config, full_name='egrid_national_verify'))
+        .groupby('Flowable')['FlowAmount']
+        .sum()
+    )
+
+    nat = pd.read_csv(nat_url).loc[lambda d: d['FlowName'].isin(_GHG)]
+    ref_kg = nat.apply(lambda r: _flow_kg(float(r['FlowAmount']), r['Unit']), axis=1)
+    ref_kg.index = nat['FlowName']
+
+    print(f'eGRID {year}  reference: {nat_url}')
+    print(f'tolerance: {TOLERANCE_PCT}%')
+    print()
+    ok = True
+    for flow in _GHG:
+        ref = float(ref_kg[flow])
+        got = float(fbs_kg.get(flow, 0.0))
+        pct = abs(got - ref) / ref * 100.0
+        print(
+            f'  {flow:16}  national={ref:,.0f} kg  fbs={got:,.0f} kg  diff={pct:.3f}%'
+        )
+        ok = ok and pct <= TOLERANCE_PCT
+
+    print()
+    print('PASS' if ok else 'FAIL')
+    return 0 if ok else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/bedrock/analysis/electricity/verify_egrid_to_sector_vs_national.py
+++ b/bedrock/analysis/electricity/verify_egrid_to_sector_vs_national.py
@@ -45,10 +45,7 @@ _EGRID_TO_SECTOR_CONFIG: dict = {
             '221122',
         ],
     },
-    'selection_fields': {
-        'Compartment': 'air',
-        'FlowName': list(_GHG),
-    },
+    'include_flow_names': list(_GHG),
 }
 
 

--- a/bedrock/analysis/electricity/verify_egrid_to_sector_vs_national.py
+++ b/bedrock/analysis/electricity/verify_egrid_to_sector_vs_national.py
@@ -10,6 +10,7 @@ build for that year. Reference totals on GitHub (standardizedinventories stewi/d
 from __future__ import annotations
 
 import sys
+from typing import Any
 
 import pandas as pd
 
@@ -24,7 +25,7 @@ _NAT_TOTALS_URL = (
 )
 
 # Minimal ``egrid_to_sector`` config (not a full FBS method stub).
-_EGRID_TO_SECTOR_CONFIG: dict = {
+_EGRID_TO_SECTOR_CONFIG: dict[str, Any] = {
     'data_format': 'FBS_outside_flowsa',
     'geoscale': 'national',
     'target_naics_year': 2017,
@@ -60,7 +61,7 @@ def _flow_kg(amount: float, unit: str) -> float:
 def main() -> int:
     year = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_EGRID_YEAR
     nat_url = _NAT_TOTALS_URL.format(year=year)
-    config = {
+    config: dict[str, Any] = {
         **_EGRID_TO_SECTOR_CONFIG,
         'inventory_dict': {'eGRID': year},
         'year': int(year),

--- a/bedrock/extract/stewifbs/stewiFBS.py
+++ b/bedrock/extract/stewifbs/stewiFBS.py
@@ -269,6 +269,24 @@ def assign_naics_from_egrid_fuel(
     )
 
 
+def _subset_stewi_include_flow_names(
+    df: pd.DataFrame, flow_names: list[str] | tuple[str, ...]
+) -> pd.DataFrame:
+    """Keep stewi rows whose ``FlowName`` is in ``include_flow_names`` (method yaml)."""
+    if 'FlowName' not in df.columns:
+        raise KeyError(
+            'Stewi dataframe must include FlowName before include_flow_names filter'
+        )
+    allowed = frozenset(flow_names)
+    out = df.loc[df['FlowName'].isin(allowed)]
+    if out.empty:
+        log.warning(
+            'No stewi rows after include_flow_names filter: %s',
+            sorted(allowed),
+        )
+    return out
+
+
 def egrid_to_sector(
     config: dict[str, Any],
     full_name: str,
@@ -486,12 +504,20 @@ def assign_naics_to_stewicombo(
 
 def prepare_stewi_fbs(df_load: pd.DataFrame, config: dict[str, Any]) -> FlowBySector:
     """
-    Function to prepare an emissions df from stewi or stewicombo for use as FBS
-    :param df_load: a dataframe of emissions and mapped faciliites from stewi
-                    or stewicombo
-    :param config: dictionary, FBS method data source configuration
-    :return: FlowBySector
+    Prepare stewi or stewicombo emissions as FBS.
+
+    Optional method keys (same pattern as ``compartments`` for compartment filter):
+
+    - ``include_flow_names``: list of stewi ``FlowName`` values to keep; omitted
+      means all flows. Popped before ``prepare_fbs`` so it is not reapplied on
+      FBS-shaped data. Prefer this over ``selection_fields`` on stewi sources.
     """
+    include_flow_names = config.pop('include_flow_names', None)
+    config.pop('selection_fields', None)
+
+    if include_flow_names is not None:
+        df_load = _subset_stewi_include_flow_names(df_load, include_flow_names)
+
     inventory_dict = config['inventory_dict']
     config['fedefl_mapping'] = [x for x in inventory_dict if x != 'RCRAInfo']
     config['drop_unmapped_rows'] = True

--- a/bedrock/extract/stewifbs/stewiFBS.py
+++ b/bedrock/extract/stewifbs/stewiFBS.py
@@ -8,8 +8,11 @@ These functions are called if referenced in flowbysectormethods as
 data_format FBS_outside_flowsa with the function specified in FBS_datapull_fxn
 """
 
-import os
+from __future__ import annotations
+
 import sys
+from pathlib import Path
+from typing import Any
 
 import facilitymatcher
 import numpy as np
@@ -24,13 +27,18 @@ from bedrock.transform.flowbyfunctions import assign_fips_location_system
 from bedrock.transform.flowbysector import FlowBySector
 from bedrock.utils.config.settings import process_adjustmentpath
 from bedrock.utils.logging.flowsa_log import log
+from bedrock.utils.mapping import naics as naics_mapping
 from bedrock.utils.mapping.location import apply_county_FIPS, update_geoscale
-from bedrock.utils.mapping.naics import convert_naics_year
+
+InventoryDict = dict[str, str]
 
 
 def stewicombo_to_sector(
-    config, full_name, external_config_path: str = None, **_
-) -> 'FlowBySector':
+    config: dict[str, Any],
+    full_name: str,
+    external_config_path: str | None = None,
+    **_kwargs: Any,
+) -> FlowBySector:
     """
     Returns emissions from stewicombo in fbs format, requires stewi >= 0.9.5
     :param config: which may contain the following elements:
@@ -51,7 +59,7 @@ def stewicombo_to_sector(
     inventory_name = config.get('local_inventory_name')
     config['full_name'] = full_name
 
-    df = None
+    df: pd.DataFrame | None = None
     if inventory_name is not None:
         df = stewicombo.getInventory(inventory_name, download_if_missing=True)
     if df is None:
@@ -66,7 +74,7 @@ def stewicombo_to_sector(
 
     if df is None:
         # Inventories not found for stewicombo, return empty FBS
-        return
+        return FlowBySector(pd.DataFrame(), convert_df_to_flowby=True)
 
     facility_mapping = extract_facility_data(config['inventory_dict'])
 
@@ -91,14 +99,15 @@ def stewicombo_to_sector(
             external_config_path,
         )
 
-    fbs = prepare_stewi_fbs(df, config)
-
-    return fbs
+    return prepare_stewi_fbs(df, config)
 
 
 def stewi_to_sector(
-    config, full_name, external_config_path: str = None, **_
-) -> 'FlowBySector':
+    config: dict[str, Any],
+    full_name: str,
+    external_config_path: str | None = None,
+    **_kwargs: Any,
+) -> FlowBySector:
     """
     Returns emissions from stewi in fbs format, requires stewi >= 0.9.5
     :param config: which may contain the following elements:
@@ -109,8 +118,9 @@ def stewi_to_sector(
         functions: list of functions (str) to call for additional processing
     :return: FlowBySector object
     """
+    _ = (external_config_path, _kwargs)
     # determine if fxns specified in FBS method yaml
-    functions = config.get('functions', [])
+    functions: list[str] = config.get('functions', [])
     config['full_name'] = full_name
 
     # run stewi to generate inventory and filter for LCI
@@ -127,13 +137,10 @@ def stewi_to_sector(
             .assign(Source=database)
         )
         df = pd.concat([df, inv], ignore_index=True)
-    if config.get('compartments'):
+    compartments = config.get('compartments')
+    if compartments:
         # Subset based on primary compartment
-        df = df[
-            df['Compartment']
-            .str.split('/', expand=True)[0]
-            .isin(config.get('compartments'))
-        ]
+        df = df[df['Compartment'].str.split('/', expand=True)[0].isin(compartments)]
     facility_mapping = extract_facility_data(config['inventory_dict'])
     # Convert NAICS to string (first to int to avoid decimals)
     facility_mapping['NAICS'] = facility_mapping['NAICS'].astype(int).astype(str)
@@ -148,7 +155,12 @@ def stewi_to_sector(
     return fbs
 
 
-def reassign_process_to_sectors(df, year, file_list, external_config_path):
+def reassign_process_to_sectors(
+    df: pd.DataFrame,
+    year: str,
+    file_list: list[str],
+    external_config_path: str | None = None,
+) -> pd.DataFrame:
     """
     Reassigns emissions from a specific process or SCC and NAICS combination
     to a new NAICS.
@@ -163,12 +175,14 @@ def reassign_process_to_sectors(df, year, file_list, external_config_path):
     """
     df_adj = pd.DataFrame()
     for file in file_list:
-        fpath = process_adjustmentpath / f"{file}.csv"
+        fpath: Path = process_adjustmentpath / f'{file}.csv'
         if external_config_path:
-            f_out_path = f"{external_config_path}process_adjustments/{file}.csv"
-            if os.path.isfile(f_out_path):
+            f_out_path = (
+                Path(external_config_path) / 'process_adjustments' / f'{file}.csv'
+            )
+            if f_out_path.is_file():
                 fpath = f_out_path
-        log.debug(f"modifying processes from {fpath}")
+        log.debug(f'modifying processes from {fpath}')
         df_adj0 = pd.read_csv(fpath, dtype='str')
         df_adj = pd.concat([df_adj, df_adj0], ignore_index=True)
 
@@ -182,7 +196,7 @@ def reassign_process_to_sectors(df, year, file_list, external_config_path):
         df_adj = df_adj.drop_duplicates(subset=['source_naics', 'source_process'])
 
     # obtain and prepare SCC dataset
-    keep_sec_cntx = True if any('/' in s for s in df.Compartment.unique()) else False
+    keep_sec_cntx = bool(any('/' in s for s in df.Compartment.unique()))
     df_fbp = stewi.getInventory(
         'NEI',
         year,
@@ -240,11 +254,10 @@ def reassign_process_to_sectors(df, year, file_list, external_config_path):
             'SRS_ID',
         ]
     ).rename(columns={'target_naics': 'NAICS'})
-    df = pd.concat([df, df_fbp], ignore_index=True)
-    return df
+    return pd.concat([df, df_fbp], ignore_index=True)
 
 
-def extract_facility_data(inventory_dict):
+def extract_facility_data(inventory_dict: InventoryDict) -> pd.DataFrame:
     """
     Returns df of facilities from each inventory in inventory_dict,
     including FIPS code
@@ -252,7 +265,7 @@ def extract_facility_data(inventory_dict):
                 {'NEI':'2017', 'TRI':'2017'})
     :return: df
     """
-    facilities_list = []
+    facilities_list: list[pd.DataFrame] = []
     # load facility data from stewi output directory, keeping only the
     # facility IDs, and geographic information
     for database, year in inventory_dict.items():
@@ -262,7 +275,7 @@ def extract_facility_data(inventory_dict):
         facilities = facilities[['FacilityID', 'State', 'County', 'NAICS']]
         if len(facilities[facilities.duplicated(subset='FacilityID', keep=False)]) > 0:
             log.debug(
-                f'Duplicate facilities in {database}_{year} - ' 'keeping first listed'
+                f'Duplicate facilities in {database}_{year} - keeping first listed'
             )
             facilities = facilities.drop_duplicates(subset='FacilityID', keep='first')
         facilities_list.append(facilities)
@@ -271,7 +284,7 @@ def extract_facility_data(inventory_dict):
     return facility_mapping.pipe(apply_county_FIPS)
 
 
-def obtain_NAICS_from_facility_matcher(inventory_list):
+def obtain_NAICS_from_facility_matcher(inventory_list: list[str]) -> pd.DataFrame:
     """
     Returns dataframe of all facilities with included in inventory_list with
     their first or primary NAICS.
@@ -284,13 +297,16 @@ def obtain_NAICS_from_facility_matcher(inventory_list):
         inventories_of_interest_list=inventory_list,
         download_if_missing=True,
     )
-    all_NAICS = all_NAICS.query('PRIMARY_INDICATOR == "PRIMARY"').drop(
+    return all_NAICS.query('PRIMARY_INDICATOR == "PRIMARY"').drop(
         columns=['PRIMARY_INDICATOR']
     )
-    return all_NAICS
 
 
-def assign_naics_to_stewicombo(df, all_NAICS, facility_mapping):
+def assign_naics_to_stewicombo(
+    df: pd.DataFrame,
+    all_NAICS: pd.DataFrame,
+    facility_mapping: pd.DataFrame,
+) -> pd.DataFrame:
     """
     Apply naics to combined inventory preferentially using FRS_ID.
     When FRS_ID does not provide unique NAICS, then use NAICS assigned by
@@ -307,21 +323,20 @@ def assign_naics_to_stewicombo(df, all_NAICS, facility_mapping):
     )
 
     # next use NAICS from inventory sources
-    df = (
+    return (
         df.merge(
             facility_mapping[['FacilityID', 'NAICS']],
             how='left',
             on='FacilityID',
-            suffixes=(None, "_y"),
+            suffixes=(None, '_y'),
         )
         .assign(NAICS=lambda x: x['NAICS'].fillna(x['NAICS_y']))
         .drop(columns=['NAICS_y'])
         .query('NAICS != "None"')
     )
-    return df
 
 
-def prepare_stewi_fbs(df_load, config) -> 'FlowBySector':
+def prepare_stewi_fbs(df_load: pd.DataFrame, config: dict[str, Any]) -> FlowBySector:
     """
     Function to prepare an emissions df from stewi or stewicombo for use as FBS
     :param df_load: a dataframe of emissions and mapped faciliites from stewi
@@ -329,31 +344,29 @@ def prepare_stewi_fbs(df_load, config) -> 'FlowBySector':
     :param config: dictionary, FBS method data source configuration
     :return: FlowBySector
     """
-    config['fedefl_mapping'] = [
-        x for x in config.get('inventory_dict').keys() if x != 'RCRAInfo'
-    ]
+    inventory_dict = config['inventory_dict']
+    config['fedefl_mapping'] = [x for x in inventory_dict if x != 'RCRAInfo']
     config['drop_unmapped_rows'] = True
     if 'year' not in config:
         config['year'] = df_load['Year'][0]
 
-    # find activity schema
-    activity_schema = (
-        config['activity_schema']
-        if isinstance(config['activity_schema'], str)
-        else config.get('activity_schema', {}).get(config['year'])
-    )
+    activity_schema_raw = config['activity_schema']
+    if isinstance(activity_schema_raw, str):
+        activity_schema: str = activity_schema_raw
+    else:
+        activity_schema = config.get('activity_schema', {}).get(config['year'])
 
     fbs = FlowByActivity(
         df_load.pipe(update_geoscale, config['geoscale'])
         # ^^ update location to appropriate geoscale prior to aggregating
-        .rename(columns={"NAICS": "ActivityProducedBy", 'Source': 'SourceName'})
+        .rename(columns={'NAICS': 'ActivityProducedBy', 'Source': 'SourceName'})
         .assign(Class='Chemicals')
         .assign(ActivityConsumedBy=np.nan)
         .pipe(
-            convert_naics_year,
+            naics_mapping.convert_naics_year,
             f"NAICS_{config['target_naics_year']}_Code",
             activity_schema,
-            config.get('full_name'),
+            config['full_name'],
         )
         .assign(
             FlowType=lambda x: np.where(
@@ -375,7 +388,7 @@ def prepare_stewi_fbs(df_load, config) -> 'FlowBySector':
     return fbs
 
 
-def add_stewi_metadata(inventory_dict):
+def add_stewi_metadata(inventory_dict: InventoryDict) -> dict[str, Any]:
     """
     Access stewi metadata for generating FBS metdata file
     :param inventory_dict: a dictionary of inventory types and years (e.g.,
@@ -385,14 +398,14 @@ def add_stewi_metadata(inventory_dict):
     return compile_metadata(inventory_dict)
 
 
-def add_stewicombo_metadata(inventory_name):
+def add_stewicombo_metadata(inventory_name: str) -> dict[str, Any]:
     """Access locally stored stewicombo metadata by filename"""
     return read_source_metadata(
         stewicombo.globals.paths, set_stewicombo_meta(inventory_name)
     )
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     import bedrock
 
     fbs = bedrock.transform.flowbysector.FlowBySector.generateFlowBySector(

--- a/bedrock/extract/stewifbs/stewiFBS.py
+++ b/bedrock/extract/stewifbs/stewiFBS.py
@@ -29,6 +29,7 @@ from bedrock.utils.config.settings import process_adjustmentpath
 from bedrock.utils.logging.flowsa_log import log
 from bedrock.utils.mapping import naics as naics_mapping
 from bedrock.utils.mapping.location import apply_county_FIPS, update_geoscale
+from bedrock.utils.mapping.sectormapping import get_activitytosector_mapping
 
 InventoryDict = dict[str, str]
 
@@ -153,6 +154,153 @@ def stewi_to_sector(
         fbs = getattr(sys.modules[__name__], function)(fbs)
 
     return fbs
+
+
+# Stewi facility ``Plant primary fuel`` uses eGRID PLPRMFL codes; map to PLFUELCT
+# categories before NAICS crosswalk (EPA eGRID code lookup, plant primary fuel table).
+_EGRID_PLPRMFL_TO_PLFUELCT: dict[str, str] = {
+    'AB': 'BIOMASS',
+    'BFG': 'OFSL',
+    'BIT': 'COAL',
+    'BLQ': 'BIOMASS',
+    'COG': 'COAL',
+    'DFO': 'OIL',
+    'GEO': 'GEOTHERMAL',
+    'JF': 'OIL',
+    'KER': 'OIL',
+    'LFG': 'BIOMASS',
+    'LIG': 'COAL',
+    'MSW': 'BIOMASS',
+    'MWH': 'OTHF',
+    'NG': 'GAS',
+    'NUC': 'NUCLEAR',
+    'OBG': 'BIOMASS',
+    'OBL': 'BIOMASS',
+    'OBS': 'BIOMASS',
+    'OG': 'OFSL',
+    'OTH': 'OTHF',
+    'PC': 'OIL',
+    'PRG': 'OTHF',
+    'PUR': 'OTHF',
+    'RC': 'COAL',
+    'RFO': 'OIL',
+    'SGC': 'COAL',
+    'SUB': 'COAL',
+    'SUN': 'SOLAR',
+    'TDF': 'OFSL',
+    'WAT': 'HYDRO',
+    'WC': 'COAL',
+    'WDL': 'BIOMASS',
+    'WDS': 'BIOMASS',
+    'WH': 'OTHF',
+    'WND': 'WIND',
+    'WO': 'OIL',
+}
+
+
+def _egrid_plprmfl_to_plfuelct(fuel: str) -> str | None:
+    key = str(fuel).strip().upper()
+    if key in _EGRID_PLPRMFL_TO_PLFUELCT:
+        return _EGRID_PLPRMFL_TO_PLFUELCT[key]
+    if key in _EGRID_PLPRMFL_TO_PLFUELCT.values():
+        return key
+    return None
+
+
+def load_egrid_emissions_via_stewi(year: str | int) -> pd.DataFrame:
+    """Load stewi eGRID flow-by-facility emissions with facility location and fuel."""
+    year_str = str(year)
+    df = stewi.getInventory('eGRID', year_str, download_if_missing=True)
+    facilities = stewi.getInventoryFacilities(
+        'eGRID', year_str, download_if_missing=True
+    )
+    facilities = (
+        facilities[['FacilityID', 'State', 'County', 'Plant primary fuel']]
+        .drop_duplicates(subset='FacilityID', keep='first')
+        .pipe(lambda d: apply_county_FIPS(d, unmatched='national'))
+    )
+    return df.merge(facilities, how='left', on='FacilityID')
+
+
+def assign_naics_from_egrid_fuel(
+    df: pd.DataFrame,
+    mapping_name: str,
+    *,
+    external_config_path: str | None = None,
+) -> pd.DataFrame:
+    """Map eGRID primary fuel (PLPRMFL or PLFUELCT) to target NAICS (2017) codes."""
+    if 'PrimaryFuelCategory' not in df.columns:
+        if 'Plant primary fuel' not in df.columns:
+            raise KeyError(
+                'eGRID dataframe must include Plant primary fuel from stewi facilities'
+            )
+        df = df.assign(
+            PrimaryFuelCategory=df['Plant primary fuel'].map(_egrid_plprmfl_to_plfuelct)
+        )
+    else:
+        df = df.assign(
+            PrimaryFuelCategory=df['PrimaryFuelCategory'].map(
+                _egrid_plprmfl_to_plfuelct
+            )
+        )
+    crosswalk = get_activitytosector_mapping(mapping_name, external_config_path)[
+        ['Activity', 'Sector']
+    ].drop_duplicates(subset=['Activity'])
+    merged = df.merge(
+        crosswalk,
+        left_on='PrimaryFuelCategory',
+        right_on='Activity',
+        how='left',
+    )
+    unmapped_mask = merged['Sector'].isna() & merged['PrimaryFuelCategory'].notna()
+    if unmapped_mask.any():
+        unmapped_fuels = sorted(
+            merged.loc[unmapped_mask, 'PrimaryFuelCategory'].unique()
+        )
+        log.warning(
+            'eGRID primary fuel categories without NAICS mapping in %s: %s',
+            mapping_name,
+            unmapped_fuels,
+        )
+    return (
+        merged.assign(NAICS=merged['Sector'])
+        .drop(columns=['Activity', 'Sector'], errors='ignore')
+        .dropna(subset=['NAICS'])
+    )
+
+
+def egrid_to_sector(
+    config: dict[str, Any],
+    full_name: str,
+    external_config_path: str | None = None,
+    **_kwargs: Any,
+) -> FlowBySector:
+    """
+    Build a national FBS from stewi eGRID plant-level air emissions.
+
+    Loads ``eGRID`` via stewi, then assigns NAICS from primary fuel category.
+    """
+    _ = _kwargs
+    config['full_name'] = full_name
+    mapping_name = config.get('activity_to_sector_mapping', 'EPA_eGRID')
+    inventory_dict: InventoryDict = config['inventory_dict']
+    if len(inventory_dict) != 1 or 'eGRID' not in inventory_dict:
+        raise ValueError(
+            "egrid_to_sector expects inventory_dict with a single 'eGRID' year entry"
+        )
+    egrid_year = inventory_dict['eGRID']
+
+    df = load_egrid_emissions_via_stewi(egrid_year)
+
+    df = assign_naics_from_egrid_fuel(
+        df, mapping_name, external_config_path=external_config_path
+    )
+    df = df.assign(
+        Year=int(config.get('year', egrid_year)),
+        Source='eGRID',
+        Class='Chemicals',
+    )
+    return prepare_stewi_fbs(df, config)
 
 
 def reassign_process_to_sectors(
@@ -384,7 +532,6 @@ def prepare_stewi_fbs(df_load: pd.DataFrame, config: dict[str, Any]) -> FlowBySe
     ).prepare_fbs()
 
     fbs.config.update({'data_format': 'FBS'})
-
     return fbs
 
 

--- a/bedrock/extract/stewifbs/stewiFBS.py
+++ b/bedrock/extract/stewifbs/stewiFBS.py
@@ -549,7 +549,17 @@ def prepare_stewi_fbs(df_load: pd.DataFrame, config: dict[str, Any]) -> FlowBySe
         )
         .pipe(assign_fips_location_system, config['year'])
         # ^^ Consider upating this old function
-        .drop(columns=['FacilityID', 'FRS_ID', 'State', 'County'], errors='ignore')
+        .drop(
+            columns=[
+                'FacilityID',
+                'FRS_ID',
+                'State',
+                'County',
+                'Plant primary fuel',
+                'PrimaryFuelCategory',
+            ],
+            errors='ignore',
+        )
         .dropna(subset=['Location'])
         .reset_index(drop=True),
         full_name=config.get('full_name'),

--- a/bedrock/transform/ghg/GHG_national_Cornerstone_2023_egrid.yaml
+++ b/bedrock/transform/ghg/GHG_national_Cornerstone_2023_egrid.yaml
@@ -1,0 +1,54 @@
+# Cornerstone 2023 national GHG FBS inheriting GHG_national_Cornerstone_2023.
+# electric_power emissions come from stewi eGRID (plant-level) instead of
+# EPA_GHGI_T_2_1 / EPA_GHGI_T_3_8 / EPA_GHGI_T_3_9 electric_power activity sets.
+
+!include:GHG_national_Cornerstone_2023.yaml
+  industry_spec:
+    !include:Cornerstone_2025_target.yaml:industry_spec
+      NAICS_6:
+        !include:Cornerstone_2025_target.yaml:industry_spec:NAICS_6
+        - '221111'
+        - '221112'
+        - '221113'
+        - '221114'
+        - '221115'
+        - '221116'
+        - '221117'
+        - '221118'
+        - '221121'
+        - '221122'
+  source_names: !include:GHG_national_Cornerstone_2023.yaml:source_names
+    EPA_GHGI_T_2_1:
+      !include:GHG_national_Cornerstone_2023.yaml:source_names:EPA_GHGI_T_2_1
+      activity_sets:
+        !include:GHG_national_Cornerstone_2023.yaml:source_names:EPA_GHGI_T_2_1:activity_sets
+        electric_power:
+          selection_fields:
+            PrimaryActivity: __handled_by_EPA_eGRID__
+          attribution_method: direct
+
+    EPA_GHGI_T_3_8: &stationary_combustion
+      !include:GHG_national_Cornerstone_2023.yaml:source_names:EPA_GHGI_T_3_8
+      activity_sets:
+        !include:GHG_national_Cornerstone_2023.yaml:source_names:EPA_GHGI_T_3_8:activity_sets
+        electric_power:
+          selection_fields:
+            PrimaryActivity: __handled_by_EPA_eGRID__
+          attribution_method: direct
+
+    EPA_GHGI_T_3_9: *stationary_combustion
+
+    EPA_eGRID_electric:
+      data_format: FBS_outside_flowsa
+      activity_schema: NAICS_2017_Code
+      activity_to_sector_mapping: EPA_eGRID
+      FBS_datapull_fxn: !script_function:stewiFBS egrid_to_sector
+      inventory_dict:
+        eGRID: 2023
+      year: 2023
+      selection_fields:
+        Compartment: air
+        FlowName:
+          - Carbon dioxide
+          - Methane
+          - Nitrous oxide

--- a/bedrock/transform/ghg/GHG_national_Cornerstone_2023_egrid.yaml
+++ b/bedrock/transform/ghg/GHG_national_Cornerstone_2023_egrid.yaml
@@ -46,9 +46,7 @@
       inventory_dict:
         eGRID: 2023
       year: 2023
-      selection_fields:
-        Compartment: air
-        FlowName:
-          - Carbon dioxide
-          - Methane
-          - Nitrous oxide
+      include_flow_names:
+        - Carbon dioxide
+        - Methane
+        - Nitrous oxide

--- a/bedrock/utils/config/common.py
+++ b/bedrock/utils/config/common.py
@@ -291,17 +291,16 @@ fba_wsec_default_grouping_fields = get_flow_by_groupby_cols(
 )
 
 
-def clean_str_and_capitalize(s: str) -> str:
+def clean_str_and_capitalize(s: object) -> str:
     """
-    Trim whitespace, modify string so first letter capitalized.
-    :param s: str
-    :return: str, formatted
+    Trim whitespace, lowercase, and capitalize the first character.
+    Null and NaN values become an empty string.
     """
-    if isinstance(s.__class__, str):
-        s = s.strip()
-        s = s.lower()
-        s = s.capitalize()
-    return s
+    if s is None or (isinstance(s, float) and pd.isna(s)):
+        return ''
+    if not isinstance(s, str):
+        s = str(s)
+    return s.strip().lower().capitalize()
 
 
 def capitalize_first_letter(string: str) -> str:

--- a/bedrock/utils/mapping/activitytosectormapping/NAICS_Crosswalk_EPA_GHGI_Cornerstone.csv
+++ b/bedrock/utils/mapping/activitytosectormapping/NAICS_Crosswalk_EPA_GHGI_Cornerstone.csv
@@ -32,8 +32,8 @@ EPA_GHGI_Cornerstone,N2O from Product Uses,NAICS_2017_Code,622,,,EPA_GHGI_T_2_1
 EPA_GHGI_Cornerstone,N2O from Product Uses,NAICS_2017_Code,623,,,EPA_GHGI_T_2_1
 EPA_GHGI_Cornerstone,"Caprolactam, Glyoxal, and Glyoxylic Acid Production",NAICS_2017_Code,32519,,325190,EPA_GHGI_T_2_1
 EPA_GHGI_Cornerstone,Electronics Industry,NAICS_2017_Code,334413,,"334413, name change from Semiconductor Manufacture",EPA_GHGI_T_2_1
-EPA_GHGI_Cornerstone,Electrical Transmission and Distribution,NAICS_2017_Code,2211,,221100,EPA_GHGI_T_2_1
-EPA_GHGI_Cornerstone,Electrical Equipment,NAICS_2017_Code,2211,,new activity,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone,Electrical Transmission and Distribution,NAICS_2017_Code,221121,,221100,EPA_GHGI_T_2_1
+EPA_GHGI_Cornerstone,Electrical Equipment,NAICS_2017_Code,221121,,new activity,EPA_GHGI_T_2_1
 EPA_GHGI_Cornerstone,Electric Power,NAICS_2017_Code,2211,,"Commodity: 221100 (or I: 221100, S00101, S00202)",EPA_GHGI_T_2_1
 EPA_GHGI_Cornerstone,Liming,NAICS_2017_Code,111,,all ag sectors - proportional via BEA 327400,EPA_GHGI_T_2_1
 EPA_GHGI_Cornerstone,Urea Fertilization,NAICS_2017_Code,111,,"111, 112",EPA_GHGI_T_2_1

--- a/bedrock/utils/mapping/activitytosectormapping/NAICS_Crosswalk_EPA_eGRID.csv
+++ b/bedrock/utils/mapping/activitytosectormapping/NAICS_Crosswalk_EPA_eGRID.csv
@@ -1,0 +1,12 @@
+ActivitySourceName,Activity,SectorSourceName,Sector,SectorType,Notes
+EPA_eGRID,COAL,NAICS_2017_Code,221112,Fossil,PLFUELCT: coal fuel types; NAICS 221112 Fossil Fuel Electric Power Generation
+EPA_eGRID,GAS,NAICS_2017_Code,221112,Fossil,PLFUELCT: gas fuel types; aligned with GHGI Natural Gas Electric Power -> 221112
+EPA_eGRID,OIL,NAICS_2017_Code,221112,Fossil,PLFUELCT: oil fuel types; aligned with GHGI Fuel Oil Electric Power -> 221112
+EPA_eGRID,OFSL,NAICS_2017_Code,221112,Fossil,PLFUELCT: other fossil fuel types
+EPA_eGRID,BIOMASS,NAICS_2017_Code,221117,Biomass,PLFUELCT: biomass fuel types; aligned with GHGI Wood Electric Power -> 221117
+EPA_eGRID,NUCLEAR,NAICS_2017_Code,221113,Nuclear,PLFUELCT: nuclear fuel type; NAICS 221113 Nuclear Electric Power Generation
+EPA_eGRID,SOLAR,NAICS_2017_Code,221114,Solar,PLFUELCT: solar fuel type; NAICS 221114 Solar Electric Power Generation
+EPA_eGRID,WIND,NAICS_2017_Code,221115,Wind,PLFUELCT: wind fuel type; NAICS 221115 Wind Electric Power Generation
+EPA_eGRID,GEOTHERMAL,NAICS_2017_Code,221116,Geothermal,PLFUELCT: geothermal fuel type; NAICS 221116 Geothermal Electric Power Generation
+EPA_eGRID,HYDRO,NAICS_2017_Code,221111,Hydro,PLFUELCT: hydro fuel type; NAICS 221111 Hydroelectric Power Generation
+EPA_eGRID,OTHF,NAICS_2017_Code,221118,Other,PLFUELCT: other fuel (waste heat hydrogen purchased unknown); NAICS 221118 Other Electric Power Generation

--- a/bedrock/utils/mapping/location.py
+++ b/bedrock/utils/mapping/location.py
@@ -7,6 +7,7 @@ Functions related to accessing and modifying location codes
 
 import io
 import urllib.error
+from typing import Literal
 
 import numpy as np
 import pandas as pd
@@ -140,38 +141,72 @@ def get_all_state_FIPS_2(year: str = '2015') -> pd.DataFrame:
 
 
 def apply_county_FIPS(
-    df: pd.DataFrame, year: str = '2015', source_state_abbrev: bool = True
+    df: pd.DataFrame,
+    year: str = '2015',
+    source_state_abbrev: bool = True,
+    unmatched: Literal['null', 'national'] = 'null',
 ) -> pd.DataFrame:
     """
-    Applies FIPS codes by county to dataframe containing columns with State
-    and County
-    :param df: dataframe must contain columns with 'State' and 'County', but
-        not 'Location'
-    :param year: str, FIPS year, defaults to 2015
-    :param source_state_abbrev: True or False, the state column uses
-        abbreviations
-    :return dataframe with new column 'FIPS', blanks not removed
+    Assign county FIPS when state and county match the crosswalk; otherwise state FIPS
+    (``xx000``). Unmatched rows keep null ``Location`` unless ``unmatched='national'``.
     """
-    # If using 2 letter abbrevations, map to state names
-    if source_state_abbrev:
-        df['State'] = df['State'].map(abbrev_us_state).fillna(df['State'])
-    df['State'] = df['State'].apply(lambda x: clean_str_and_capitalize(str(x)))
-    if 'County' not in df:
-        df['County'] = ''
-    df['County'] = df['County'].apply(lambda x: clean_str_and_capitalize(str(x)))
+    if 'State' not in df.columns:
+        raise KeyError('apply_county_FIPS requires a State column')
 
-    # Pull and merge FIPS on state and county
-    mapping_FIPS = get_county_FIPS(year)
-    df = df.merge(mapping_FIPS, how='left')
+    out = df.copy()
+    state_raw = out['State'].astype(str).str.strip()
+    state_name = (
+        state_raw.map(abbrev_us_state).fillna(state_raw)
+        if source_state_abbrev
+        else state_raw
+    )
+    out['_state_key'] = state_name.map(clean_str_and_capitalize)
 
-    # Where no county match occurs, assign state FIPS instead
-    mapping_FIPS = get_state_FIPS()
-    mapping_FIPS = mapping_FIPS.drop(columns=['County'])
-    df = df.merge(mapping_FIPS, left_on='State', right_on='State', how='left')
-    df['Location'] = df['FIPS_x'].where(df['FIPS_x'].notnull(), df['FIPS_y'])
-    df = df.drop(columns=['FIPS_x', 'FIPS_y'])
+    if 'County' not in out.columns:
+        out['County'] = ''
+    out['_county_key'] = (
+        out['County'].fillna('').astype(str).str.strip().map(clean_str_and_capitalize)
+    )
 
-    return df
+    county_map = (
+        get_county_FIPS(year)
+        .assign(
+            _state_key=lambda d: d['State'].map(clean_str_and_capitalize),
+            _county_key=lambda d: d['County'].map(clean_str_and_capitalize),
+        )[['_state_key', '_county_key', 'FIPS']]
+        .rename(columns={'FIPS': 'FIPS_county'})
+    )
+    state_map = (
+        get_state_FIPS(year)
+        .assign(_state_key=lambda d: d['State'].map(clean_str_and_capitalize))[
+            ['_state_key', 'FIPS']
+        ]
+        .rename(columns={'FIPS': 'FIPS_state'})
+        .drop_duplicates(subset='_state_key')
+    )
+
+    out = out.merge(county_map, on=['_state_key', '_county_key'], how='left')
+    out = out.merge(state_map, on='_state_key', how='left')
+    out['Location'] = out['FIPS_county'].fillna(out['FIPS_state'])
+    out['State'] = out['_state_key']
+    out['County'] = out['_county_key']
+
+    missing = out['Location'].isna()
+    if missing.any() and unmatched == 'national':
+        n_missing = int(missing.sum())
+        states = sorted(state_raw.loc[missing].unique())
+        log.warning(
+            'Facilities without county or state FIPS (%s rows); assigning national FIPS. '
+            'States: %s',
+            n_missing,
+            states[:20],
+        )
+        out.loc[missing, 'Location'] = US_FIPS
+
+    return out.drop(
+        columns=['_state_key', '_county_key', 'FIPS_county', 'FIPS_state'],
+        errors='ignore',
+    )
 
 
 def update_geoscale(df: pd.DataFrame, to_scale: str) -> pd.DataFrame:

--- a/bedrock/utils/metadata/metadata.py
+++ b/bedrock/utils/metadata/metadata.py
@@ -255,6 +255,9 @@ def return_fbs_method_data(
             else:
                 meta['primary_source_meta'][k] = add_stewi_metadata(v['inventory_dict'])
             return True
+        if v.get('data_format') == 'FBS_outside_flowsa' and v.get('inventory_dict'):
+            meta['primary_source_meta'][k] = add_stewi_metadata(v['inventory_dict'])
+            return True
         return False
 
     # Create empty dictionary for storing meta data
@@ -420,17 +423,19 @@ def getMetadata(
     """
     from bedrock.extract.generateflowbyactivity import set_fba_name  # noqa: PLC0415
 
-    if category == "FlowByActivity":
+    if category == 'FlowByActivity':
         file_path = FBA_DIR
-    if category is None:
-        log.error('Category required, specify "FlowByActivity" or ' '"FlowBySector"')
-        category = 'FlowBySector'  # Default to avoid type errors
+    elif category is None:
+        log.error('Category required, specify "FlowByActivity" or "FlowBySector"')
+        category = 'FlowBySector'
         file_path = FBS_DIR
-    # if category is FBS ensure year is not added to source name when
-    # looking for metadata
-    if category == 'FlowBySector':
+    elif category.startswith('FlowBySector'):
         year = None
         file_path = FBS_DIR
+    else:
+        log.error('Unrecognized metadata category %s for %s', category, source)
+        file_path = FBS_DIR
+        year = None
 
     year_str = str(year) if isinstance(year, int) else year
     name = set_fba_name(source, year_str)

--- a/bedrock/utils/metadata/metadata.py
+++ b/bedrock/utils/metadata/metadata.py
@@ -248,9 +248,10 @@ def return_fbs_method_data(
 
     def process_primary_source(k: str, v: dict[str, Any], meta: dict[str, Any]) -> bool:
         if k == 'stewiFBS':
-            if v.get('local_inventory_name'):
+            local_inventory_name = v.get('local_inventory_name')
+            if isinstance(local_inventory_name, str):
                 meta['primary_source_meta'][k] = add_stewicombo_metadata(
-                    v.get('local_inventory_name')
+                    local_inventory_name
                 )
             else:
                 meta['primary_source_meta'][k] = add_stewi_metadata(v['inventory_dict'])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,6 @@ exclude = [
     'bedrock/extract/unep/',
     'bedrock/extract/usgs/',
     'scripts/*.py',
-    'bedrock/analysis/electricity/',
 ]
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,7 @@ exclude = [
     'bedrock/extract/unep/',
     'bedrock/extract/usgs/',
     'scripts/*.py',
+    'bedrock/analysis/electricity/',
 ]
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,6 @@ known-first-party = ["bedrock"]
 "bedrock/extract/statcan/*" = ["ALL"]
 "bedrock/extract/stateghgi/*" = ["ALL"]
 "bedrock/extract/stateio/*" = ["ALL"]
-"bedrock/extract/stewifbs/*" = ["ALL"]
 "bedrock/extract/unep/*" = ["ALL"]
 "bedrock/extract/usgs/*" = ["ALL"]
 
@@ -139,7 +138,6 @@ exclude = [
     'bedrock/extract/statcan/',
     'bedrock/extract/stateghgi/',
     'bedrock/extract/stateio/',
-    'bedrock/extract/stewifbs/',
     'bedrock/extract/unep/',
     'bedrock/extract/usgs/',
     'scripts/*.py',


### PR DESCRIPTION
cc: @catherinebirney @WesIngwersen 
Closes: #422

## What changed? Why?

1. National Cornerstone 2023 GHG (`GHG_national_Cornerstone_2023_egrid`) sources electricity-sector CO₂, CH₄, and N₂O from **stewi eGRID** plant-level air emissions instead of EPA GHGI `electric_power` activity sets on `EPA_GHGI_T_2_1`, `EPA_GHGI_T_3_8`, and `EPA_GHGI_T_3_9`. GHGI electric_power rows are retained in the method yaml but marked `__handled_by_EPA_eGRID__` so they do not double-count.

1. **`egrid_to_sector`** (`stewiFBS.py`) loads eGRID flow-by-facility and facility metadata via stewi, maps **plant primary fuel** (PLPRMFL) to PLFUELCT categories, assigns 2017 NAICS through `EPA_eGRID` (`NAICS_Crosswalk_EPA_eGRID.csv`), subsets stewi rows by yaml **`include_flow_names`** (CO₂, CH₄, N₂O) inside `prepare_stewi_fbs`, and builds FBS through the stewi path used by CAP_HAP/CRHW.

1. **`location.py`:** `apply_county_FIPS` uses case-insensitive crosswalk matching and state FIPS fallback; eGRID facility load uses `unmatched='national'` for territories without state FIPS (e.g. PR). Stewi FBS prep uses `update_geoscale` + `prepare_fbs()` so national methods collapse plant FIPS before geoscale rollup.

1. **`metadata.py`:** includes fix to metadata generation for these datasets.

1. **GHGI Cornerstone crosswalk** (`NAICS_Crosswalk_EPA_GHGI_Cornerstone.csv`): **Electrical Transmission and Distribution** and **Electrical Equipment** (EPA_GHGI_T_2_1) map to **221121** instead of **221100**. Note: `GHG_national_Cornerstone_2023` uses `Cornerstone_2025_target` `industry_spec` (`default: NAICS_3`, `221` in `NAICS_4`), so FBS rollup stays at electric sector grain (2211), not 221121—the crosswalk edit alone does not change core Cornerstone FBS totals.

**Method stub** (`GHG_national_Cornerstone_2023_egrid.yaml`):

- Adds `EPA_eGRID_electric` with inventory year 2023
- Extends `industry_spec.NAICS_6` with 221111–221118 and 221121/221122 for generator-type sectors

**Reviewer check (mass balance vs published eGRID US tab):** `bedrock/analysis/electricity/verify_egrid_to_sector_vs_national.py` runs `egrid_to_sector` with a minimal config and compares national FBS kg totals to stewi `eGRID_<year>_NationalTotals.csv` (within **0.1%**).

## FBS method comparison: `GHG_national_Cornerstone_2023` vs `GHG_national_Cornerstone_2023_egrid`

Compared local parquets (no regenerate):

| Role | File |
|------|------|
| Baseline | `GHG_national_Cornerstone_2023_v0.1_2ebb51f.parquet` (7,087 rows) |
| Test | `GHG_national_Cornerstone_2023_egrid_v0.2_c510445.parquet` (7,181 rows) |

### Electric generation: GHGI sector 2211 → eGRID generator NAICS

| | Cornerstone (kg) | `_egrid` (kg) |
|--|------------------|---------------|
| **EPA_GHGI_T_2_1, sector 2211, CO₂** | 1.41×10¹² | 0 |
| **EPA_GHGI_T_3_8, sector 2211, CH₄** | 5.36×10⁷ | 0 |
| **EPA_GHGI_T_3_9, sector 2211, N₂O** | 6.23×10⁷ | 0 |
| **eGRID, CO₂** | 0 | 1.46×10¹² |
| **eGRID, CH₄** | 0 | 1.07×10⁸ |
| **eGRID, N₂O** | 0 | 1.50×10⁷ |

National eGRID CO₂ is **~3.1%** above GHGI T_2_1 sector-2211 CO₂

**`_egrid` — eGRID CO₂, CH₄, N₂O by `SectorProducedBy`:**

| Sector | Fuel | CO₂ (kg) | CH₄ (kg) | N₂O (kg) |
|--------|------|----------|----------|----------|
| 221111 | Hydro | 2.8×10⁶ | 104 | 20 |
| 221112 | Fossil | 1.44×10¹² | 9.35×10⁷ | 1.30×10⁷ |
| 221113 | Nuclear | 2.45×10⁹ | 4.66×10⁴ | 4,655 |
| 221114 | Solar | 5.10×10⁷ | 993 | 100 |
| 221115 | Wind | 7.78×10⁵ | 21 | 3 |
| 221116 | Geothermal | 4.53×10⁸ | 0 | 0 |
| 221117 | Biomass | 1.38×10¹⁰ | 1.38×10⁷ | 1.95×10⁶ |
| 221118 | Other | 1.35×10⁹ | 6.64×10⁴ | 8,344 |
| **Total** | | **1.46×10¹²** | **1.07×10⁸** | **1.50×10⁷** |


### Non-electric GHGI (unchanged)

All GHGI mass **outside sector 2211\*** matches baseline. As does SF6 for T&D shows no change.

## TODO (follow-up, not in this PR)

- [ ] Promote eGRID into the **core** Cornerstone method: wire `EPA_eGRID_electric`, drop **Electric Power** from `NAICS_Crosswalk_EPA_GHGI_Cornerstone.csv` when generation moves to `EPA_eGRID` / `NAICS_Crosswalk_EPA_eGRID.csv` (221111–221118, 221122). Transmission and equipment → **221121** are already in the crosswalk.

## Testing

```
uv run python -m bedrock.analysis.electricity.verify_egrid_to_sector_vs_national
```
