### PR TITLE
Add functions to load 2017 margins before and after redef

### DIFF
--- a/bedrock/extract/iot/io_2017.py
+++ b/bedrock/extract/iot/io_2017.py
@@ -276,14 +276,14 @@ _MARGINS_COLUMNS = [
     "Commodity Code",
     "Commodity Description",
     "Producers' Value",
-    "Transportation Costs",
+    "Transportation",
     "Wholesale",
     "Retail",
     "Purchasers' Value",
 ]
 _MARGINS_VALUE_COLUMNS = [
     "Producers' Value",
-    "Transportation Costs",
+    "Transportation",
     "Wholesale",
     "Retail",
     "Purchasers' Value",

--- a/bedrock/extract/iot/io_2017.py
+++ b/bedrock/extract/iot/io_2017.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import warnings
 
 import pandas as pd
 from typing_extensions import deprecated
@@ -266,6 +267,69 @@ def load_2017_Uimp_before_redef_usa() -> pd.DataFrame:
     )
     df.index = USA_2017_COMMODITY_INDEX
     df.columns = USA_2017_INDUSTRY_INDEX
+    return df
+
+
+_MARGINS_COLUMNS = [
+    "Industry Code",
+    "Industry Description",
+    "Commodity Code",
+    "Commodity Description",
+    "Producers' Value",
+    "Transportation Costs",
+    "Wholesale",
+    "Retail",
+    "Purchasers' Value",
+]
+_MARGINS_VALUE_COLUMNS = [
+    "Producers' Value",
+    "Transportation Costs",
+    "Wholesale",
+    "Retail",
+    "Purchasers' Value",
+]
+
+
+def _load_margins_excel(pth: str) -> pd.DataFrame:
+    """Read the Margins Excel file, suppressing the openpyxl header/footer warning."""
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="Cannot parse header or footer so it will be ignored",
+            category=UserWarning,
+        )
+        return pd.read_excel(
+            pth,
+            sheet_name="2017",
+            skiprows=5,
+            header=None,
+            names=_MARGINS_COLUMNS,
+            dtype={"Industry Code": str, "Commodity Code": str},
+        )
+
+
+@functools.cache
+def load_2017_margins_after_redef_usa() -> pd.DataFrame:
+    """
+    Margins table, (industry, commodity) x margin type, after redefinition, in producer price.
+    Columns: Producers' Value, Transportation Costs, Wholesale, Retail, Purchasers' Value.
+    unit is USD, original unit is million USD.
+    """
+    df = load_from_gcs(
+        name=USA_2017_DETAIL_IO_MATRIX_MAPPING["Margins"],
+        sub_bucket=GCS_USA_MAKE_USE_DIR,
+        local_dir=LOCAL_USA_MAKE_USE_DIR,
+        loader=_load_margins_excel,
+    ).set_index(["Industry Code", "Commodity Code"])
+    valid_industry = set(USA_2017_INDUSTRY_CODES) | set(USA_2017_FINAL_DEMAND_CODES)
+    valid_commodity = set(USA_2017_COMMODITY_CODES) | set(USA_2017_VALUE_ADDED_CODES)
+    mask = df.index.get_level_values("Industry Code").isin(
+        valid_industry
+    ) & df.index.get_level_values("Commodity Code").isin(valid_commodity)
+    df = (
+        df.loc[mask, _MARGINS_VALUE_COLUMNS].astype(float)
+        * MILLION_CURRENCY_TO_CURRENCY
+    )
     return df
 
 

--- a/bedrock/extract/iot/io_2017.py
+++ b/bedrock/extract/iot/io_2017.py
@@ -290,6 +290,18 @@ _MARGINS_VALUE_COLUMNS = [
 ]
 
 
+def load_2017_margins_usa() -> pd.DataFrame:
+    """2017 Margins before vs after BEA redefinitions from ``USAConfig``."""
+    stage = get_usa_config().iot_before_or_after_redefinition
+    if stage == "before":
+        return load_2017_margins_before_redef_usa()
+    if stage == "after":
+        return load_2017_margins_after_redef_usa()
+    raise ValueError(
+        "Invalid iot_before_or_after_redefinition; expected 'before' or 'after'."
+    )
+
+
 def _load_margins_excel(pth: str) -> pd.DataFrame:
     """Read the Margins Excel file, suppressing the openpyxl header/footer warning."""
     with warnings.catch_warnings():
@@ -308,15 +320,10 @@ def _load_margins_excel(pth: str) -> pd.DataFrame:
         )
 
 
-@functools.cache
-def load_2017_margins_after_redef_usa() -> pd.DataFrame:
-    """
-    Margins table, (industry, commodity) x margin type, after redefinition, in producer price.
-    Columns: Producers' Value, Transportation Costs, Wholesale, Retail, Purchasers' Value.
-    unit is USD, original unit is million USD.
-    """
+def _load_2017_margins_from_file(filename: str) -> pd.DataFrame:
+    """Shared loader for margins tables; applies index filtering and unit scaling."""
     df = load_from_gcs(
-        name=USA_2017_DETAIL_IO_MATRIX_MAPPING["Margins"],
+        name=filename,
         sub_bucket=GCS_USA_MAKE_USE_DIR,
         local_dir=LOCAL_USA_MAKE_USE_DIR,
         loader=_load_margins_excel,
@@ -326,11 +333,32 @@ def load_2017_margins_after_redef_usa() -> pd.DataFrame:
     mask = df.index.get_level_values("Industry Code").isin(
         valid_industry
     ) & df.index.get_level_values("Commodity Code").isin(valid_commodity)
-    df = (
+    return (
         df.loc[mask, _MARGINS_VALUE_COLUMNS].astype(float)
         * MILLION_CURRENCY_TO_CURRENCY
     )
-    return df
+
+
+@functools.cache
+def load_2017_margins_after_redef_usa() -> pd.DataFrame:
+    """
+    Margins table, (industry, commodity) x margin type, after redefinition, in producer price.
+    Columns: Producers' Value, Transportation, Wholesale, Retail, Purchasers' Value.
+    unit is USD, original unit is million USD.
+    """
+    return _load_2017_margins_from_file(USA_2017_DETAIL_IO_MATRIX_MAPPING["Margins"])
+
+
+@functools.cache
+def load_2017_margins_before_redef_usa() -> pd.DataFrame:
+    """
+    Margins table, (industry, commodity) x margin type, before redefinition, in producer price.
+    Columns: Producers' Value, Transportation, Wholesale, Retail, Purchasers' Value.
+    unit is USD, original unit is million USD.
+    """
+    return _load_2017_margins_from_file(
+        USA_2017_DETAIL_IO_BEFORE_REDEF_MATRIX_MAPPING["Margins"]
+    )
 
 
 def load_2017_Ytot_usa() -> pd.DataFrame:

--- a/bedrock/extract/iot/margins.py
+++ b/bedrock/extract/iot/margins.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import functools
+
+import pandas as pd
+
+from bedrock.extract.iot.constants import GCS_USA_MAKE_USE_DIR
+from bedrock.extract.iot.io_2017 import LOCAL_USA_MAKE_USE_DIR
+from bedrock.utils.economic.units import MILLION_CURRENCY_TO_CURRENCY
+from bedrock.utils.io.gcp import load_from_gcs
+from bedrock.utils.taxonomy.bea.matrix_mappings import USA_2017_DETAIL_IO_MATRIX_MAPPING
+from bedrock.utils.taxonomy.usa_taxonomy_correspondence_helpers import (
+    USA_2017_COMMODITY_INDEX,
+    USA_2017_INDUSTRY_INDEX,
+)
+
+MARGINS_SECTORS = ["Transportation", "Wholesale", "Retail"]
+
+
+@functools.cache
+def load_2017_margins_usa() -> pd.DataFrame:
+    """
+    Margins table, (commodity x industry) x margin component, after redefinitions,
+    in producer price. Columns are Producer's Price, Transportation, Wholesale,
+    Retail, and Purchaser's Price. unit is USD, original unit is million USD.
+
+    https://www.bea.gov/products/industry-economic-accounts/underlying-estimates
+        > Use Tables / After Redefinitions / Margin Details
+        > 2017: 402 Industries XLSX
+    Note: the margins table contains industries and final demand as columns.
+    """
+    df = (
+        load_from_gcs(
+            name=USA_2017_DETAIL_IO_MATRIX_MAPPING["Margins"],
+            sub_bucket=GCS_USA_MAKE_USE_DIR,
+            local_dir=LOCAL_USA_MAKE_USE_DIR,
+            loader=lambda pth: pd.read_excel(
+                pth,
+                sheet_name="2017",
+                skiprows=4,
+                dtype={"Commodity Code": str, "Industry Code": str},
+            ),
+        )
+        .rename(
+            columns={
+                "Unnamed: 4": "Producer's Price",
+                "Unnamed: 5": "Transportation",
+                "Unnamed: 8": "Purchaser's Price",
+            }
+        )
+        .fillna(0)
+        .set_index(["Commodity Code", "Industry Code"])
+        .loc[:, MARGINS_SECTORS + ["Producer's Price", "Purchaser's Price"]]
+        .reindex(  # drop final demand columns and value added rows
+            index=pd.MultiIndex.from_product(
+                [USA_2017_COMMODITY_INDEX, USA_2017_INDUSTRY_INDEX]
+            )
+        )
+        .fillna(0.0)
+    )
+
+    return df * MILLION_CURRENCY_TO_CURRENCY

--- a/bedrock/transform/iot/derive_margins_ratio.py
+++ b/bedrock/transform/iot/derive_margins_ratio.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from bedrock.extract.iot.margins import load_2017_margins_usa
+from bedrock.transform.eeio.derived_2017_helpers import EXPANDED_SECTORS_2012_TO_2017
+from bedrock.utils.taxonomy.usa_taxonomy_correspondence_helpers import (
+    USA_2017_COMMODITY_INDEX,
+    load_usa_2017_commodity__ceda_v7_correspondence,
+)
+
+
+def derive_2017_producer_to_purchaser_price_ratio_usa() -> pd.Series[float]:
+    """
+    Derive the ratio to convert EF from producer to purchaser price for each sector.
+    Formula: purchaser price = producer price + margin
+    Since original EF is in kgCO2e/USD_producer, ratio here is calculated as
+    (output_producer / (output_producer + margin)).
+    """
+    corresp = load_usa_2017_commodity__ceda_v7_correspondence()
+    corresp.columns.names = ["commodity"]
+
+    margin = corresp @ (
+        load_2017_margins_usa()
+        .groupby("commodity")
+        .sum()
+        .reindex(USA_2017_COMMODITY_INDEX)
+        .fillna(0.0)
+    )
+    # assume expanded_sectors will receive equal portion of value from aggregated sector
+    margin.loc[EXPANDED_SECTORS_2012_TO_2017, :] *= 1 / len(
+        EXPANDED_SECTORS_2012_TO_2017
+    )
+
+    return (margin["Producer's Price"] / margin["Purchaser's Price"]).replace(
+        [np.inf, -np.inf, np.nan], 1.0
+    )

--- a/bedrock/utils/taxonomy/bea/matrix_mappings.py
+++ b/bedrock/utils/taxonomy/bea/matrix_mappings.py
@@ -17,6 +17,7 @@ USA_2017_DETAIL_IO_BEFORE_REDEF_MATRIX_MAPPING = {
     "Make_detail_before_redef": "IOMake_Before_Redefinitions_2017_Detail.xlsx",
     "Use_detail_before_redef": "IOUse_Before_Redefinitions_PRO_2017_Detail.xlsx",
     "Import_detail_before_redef": "ImportMatrices_Before_Redefinitions_DET_2017.xlsx",
+    "Margins": "Margins_Before_Redefinitions_2017_DET.xlsx",
 }
 
 USA_2017_DETAIL_IO_SUT_MATRIX_NAMES = ta.Literal[

--- a/bedrock/utils/taxonomy/bea/matrix_mappings.py
+++ b/bedrock/utils/taxonomy/bea/matrix_mappings.py
@@ -4,6 +4,7 @@ USA_2017_DETAIL_IO_MATRIX_NAMES = ta.Literal[
     "Make_detail",
     "Use_detail",
     "Import_detail",
+    "Margins",
 ]
 USA_2017_DETAIL_IO_MATRIX_MAPPING = {
     "Make_detail": "IOMake After Redefinitions 2017 Detail.xlsx",


### PR DESCRIPTION
Closes: #428 

## What changed? Why?
matrix_mappings.py — Added "Margins" to `USA_2017_DETAIL_IO_MATRIX_NAMES` and to `USA_2017_DETAIL_IO_BEFORE_REDEF_MATRIX_MAPPING` so the existing `_load_2017_detail_make_use_usa `helper accepts it without a type error. 

io_2017.py — 

Added load_2017_margins_usa() following the same pattern as the other loaders which either calls 
`load_2017_margins_after_redef_usa` or `load_2017_margins_before_redef_usa` depending on model config
 - @functools.cache for memoization just for latter two functions
- Use common `_load_2017_margins_from_file(filename)` (same GCS bucket, same Excel loading logic) to load the appropriate file
- Scales from million USD → USD via MILLION_CURRENCY_TO_CURRENCY
- skip the 5 title/header rows, assign the column names manually
- set_index(["Industry Code", "Commodity Code"]) — creates a MultiIndex so each (industry, commodity) pair is a unique row
- dtype={"Industry Code": str, "Commodity Code": str} — both code columns preserved as strings
- warnings are handled by _load_margins_excel, which suppresses the openpyxl warning with a targeted filter scoped to that with block — it won't silence warnings anywhere else in the codebase. The loader reference in load_from_gcs is also cleaner now that it's a named function rather than a lambda.
- uses a multiindex that combines industry code and commodity code columns to make each row unique in df
- valid_industry — union of USA_2017_INDUSTRY_CODES and USA_2017_FINAL_DEMAND_CODES, covering all valid industry-side codes in the BEA taxonomy
- valid_commodity — union of USA_2017_COMMODITY_CODES and USA_2017_VALUE_ADDED_CODES, covering all valid commodity-side codes
- Both sets are applied as a combined & mask across their respective MultiIndex levels — the same intent as .loc[VALID_ROWS, VALID_COLS] in the single-index functions, just adapted for the MultiIndex structure here
 
 ## Testing
Manual calling and inspection of returned df
```
from bedrock.extract.iot.io_2017 import load_2017_margins_after_redef_usa
m = load_2017_margins_after_redef_usa()
```
and to test before redef loading
```
from bedrock.extract.iot.io_2017 import load_2017_margins_usa
from bedrock.utils.config.usa_config import set_global_usa_config

set_global_usa_config("useeio_phoebe_23")
m = load_2017_margins_usa()
```
