### PR TITLE
feat(eeio): add CEDA fallback A-matrix scaling method

### DIFF
--- a/bedrock/transform/eeio/cornerstone_year_scaling.py
+++ b/bedrock/transform/eeio/cornerstone_year_scaling.py
@@ -79,11 +79,12 @@ def scale_cornerstone_A(
     """Scale detail A element-wise using summary A ratios.
 
     When ``cfg.adjust_summary_A_and_q_dollar_year`` is set, the target-year summary A
-    is rebased into ``original_year`` USD via the ITA-based summary commodity
-    price ratio before the ratio is taken, so the structural cross-year ratio
-    is formed in a consistent dollar year. Otherwise the ratio is taken on the
-    raw target-year summary A (pre-realignment behavior). See plan
-    `.claude/plans/summary_a_dollar_year_realignment_plan.md`.
+    is rebased into ``original_year`` USD via the ITA-based (industry technology assumption)
+    summary commodity price ratio before the ratio is derived and taken, so the structural
+    cross-year ratio is formed in a consistent dollar year.
+
+    Since the target-year summary A is rebased into ``original_year`` USD, the resulting
+    detail A is in ``original_year`` USD.
     """
     A_summary_base = _get_summary_A(original_year, dom_or_imp_or_total)
     A_summary_target = _get_summary_A(target_year, dom_or_imp_or_total)

--- a/bedrock/transform/eeio/derived_cornerstone.py
+++ b/bedrock/transform/eeio/derived_cornerstone.py
@@ -549,8 +549,7 @@ def derive_cornerstone_Aq_scaled() -> SingleRegionAqMatrixSet:
     # so the structural cross-year ratio is formed entirely in 2017 USD; the
     # scaled detail A is then inflated 2017 → model_year. When the flag is off,
     # the ratio carries the raw target-year-vs-2017 price drift and no final
-    # inflation is applied (pre-realignment behavior). See
-    # `.claude/plans/summary_a_dollar_year_realignment_plan.md`.
+    # inflation is applied (pre-realignment behavior).
     if cfg.scale_a_matrix_with_summary_tables:
         Adom = scale_cornerstone_A(
             base.Adom,
@@ -616,6 +615,55 @@ def derive_cornerstone_Aq_scaled() -> SingleRegionAqMatrixSet:
         q = inflate_cornerstone_q_or_y_with_commodity_pi(
             base.scaled_q, original_year=detail_year, target_year=model_year
         )
+        return SingleRegionAqMatrixSet(
+            Adom=pt.DataFrame[CornerstoneAMatrix](Adom),  # type: ignore[arg-type]
+            Aimp=pt.DataFrame[CornerstoneAMatrix](Aimp),  # type: ignore[arg-type]
+            scaled_q=q,
+        )
+
+    # CEDA method: our fallback option as of CY26Q2.
+    # Scale to 2022 (io_year), then inflate to model_base_year.
+    # However, we are applying some subtle changes to this method:
+    # 1. scale detail A and q with dollar year adjusted summary numbers
+    # 2. inflate with commodity pi instead of industry pi
+    #
+    # Codepath of this approach is very similar to the scale_a_matrix_with_summary_tables approach,
+    # the only difference is which year to scale to.
+    #
+    # When `cfg.adjust_summary_A_and_q_dollar_year` is set, `scale_cornerstone_A`
+    # rebases the target-year summary A into 2017 USD before the ratio is taken,
+    # so the structural cross-year ratio is formed entirely in 2017 USD; the
+    # scaled detail A is then inflated 2017 → io_year. When the flag is off,
+    # the ratio carries the raw target-year-vs-2017 price drift and no final
+    # inflation is applied (pre-realignment behavior).
+    if cfg.scale_a_matrix_with_ceda_method_as_fallback:
+        Adom = scale_cornerstone_A(
+            base.Adom,
+            target_year=io_year,
+            original_year=detail_year,
+            dom_or_imp_or_total='dom',
+        )
+        Aimp = scale_cornerstone_A(
+            base.Aimp,
+            target_year=io_year,
+            original_year=detail_year,
+            dom_or_imp_or_total='imp',
+        )
+        q = scale_cornerstone_q(
+            base.scaled_q,
+            target_year=io_year,
+            original_year=detail_year,
+        )
+        if cfg.adjust_summary_A_and_q_dollar_year:
+            Adom = inflate_cornerstone_A_matrix_with_commodity_pi(
+                Adom, original_year=detail_year, target_year=model_year
+            )
+            Aimp = inflate_cornerstone_A_matrix_with_commodity_pi(
+                Aimp, original_year=detail_year, target_year=model_year
+            )
+            q = inflate_cornerstone_q_or_y_with_commodity_pi(
+                q, original_year=detail_year, target_year=model_year
+            )
         return SingleRegionAqMatrixSet(
             Adom=pt.DataFrame[CornerstoneAMatrix](Adom),  # type: ignore[arg-type]
             Aimp=pt.DataFrame[CornerstoneAMatrix](Aimp),  # type: ignore[arg-type]

--- a/bedrock/utils/config/configs/2025_usa_cornerstone_full_model_A_ceda_fallback_approach.yaml
+++ b/bedrock/utils/config/configs/2025_usa_cornerstone_full_model_A_ceda_fallback_approach.yaml
@@ -1,0 +1,16 @@
+# Fully impelmented Cornerstone 2025 model
+# Use Cornerstone 2023 GHG FBS (GHG_national_Cornerstone_2023) via new_ghg_method
+# Pipeline loads E from flowsa.
+# Transform B matrix with USEEIO method
+# Implement waste disaggregation.
+
+#####
+# Methodology selection
+#####
+use_cornerstone_2026_model_schema: True
+load_E_from_flowsa: true
+new_ghg_method: true
+use_E_data_year_for_x_in_B: True
+implement_waste_disaggregation: True
+scale_a_matrix_with_ceda_method_as_fallback: True
+adjust_summary_A_and_q_dollar_year: True

--- a/bedrock/utils/config/usa_config.py
+++ b/bedrock/utils/config/usa_config.py
@@ -77,6 +77,7 @@ class USAConfig(BaseModel):
     )
     implement_waste_disaggregation: bool = False  # DRI: jorge.vendries
     eeio_waste_disaggregation: ta.Optional[EEIOWasteDisaggConfig] = None
+    scale_a_matrix_with_ceda_method_as_fallback: bool = False  # DRI: mo.li
     scale_a_matrix_with_useeio_method: bool = False  # DRI: mo.li
     scale_a_matrix_with_summary_tables: bool = False  # DRI: mo.li
     scale_a_matrix_with_industry_price_index: bool = False  # DRI: mo.li


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

Add a new `scale_a_matrix_with_ceda_method_as_fallback` config flag and a corresponding branch in `derive_cornerstone_Aq_scaled()`. This is our fallback A-matrix method as of CY26Q2: scale detail A and q to `io_year` using summary-table ratios, then inflate to `model_base_year`.

It mirrors the existing `scale_a_matrix_with_summary_tables` codepath; the only difference is the structural scaling target (`io_year` instead of `model_year`). When `adjust_summary_A_and_q_dollar_year` is set, the scaled detail A/q are rebased into 2017 USD and inflated to `model_year` via commodity price index (`inflate_cornerstone_A_matrix_with_commodity_pi`) rather than industry pi.

Adds config `2025_usa_cornerstone_v0_3_A_ceda_fallback_approach.yaml` to exercise the new path, and tightens the `scale_cornerstone_A` / `derive_cornerstone_Aq_scaled` docstrings (drop stale plan-file references, clarify the resulting dollar year).

## Testing