### PR TITLE
Add BEA 2017 sector taxonomy and Cornerstone mappings

### DIFF
--- a/bedrock/utils/taxonomy/bea/v2017_commodity_sector.py
+++ b/bedrock/utils/taxonomy/bea/v2017_commodity_sector.py
@@ -1,9 +1,9 @@
 import typing as ta
 
-# Industry and special-product sectors only. Final-demand and value-added
+# Industry and special-product commodities only. Final-demand and value-added
 # sector codes (F010, F020, …, V003) live in v2017_final_demand and
 # v2017_value_added at detail granularity (F01000, V00100, …).
-BEA_2017_SECTOR_CODE = ta.Literal[
+BEA_2017_SECTOR_COMMODITY_CODE = ta.Literal[
     "11",  # Agriculture, forestry, fishing, and hunting
     "21",  # Mining
     "22",  # Utilities
@@ -23,11 +23,11 @@ BEA_2017_SECTOR_CODE = ta.Literal[
     "Other",  # Noncomparable imports and rest-of-the-world adjustment
 ]
 
-BEA_2017_SECTOR_CODES: ta.List[BEA_2017_SECTOR_CODE] = list(
-    ta.get_args(BEA_2017_SECTOR_CODE)
+BEA_2017_SECTOR_COMMODITY_CODES: ta.List[BEA_2017_SECTOR_COMMODITY_CODE] = list(
+    ta.get_args(BEA_2017_SECTOR_COMMODITY_CODE)
 )
 
-BEA_2017_SECTOR_CODE_DESC: ta.Dict[BEA_2017_SECTOR_CODE, str] = {
+BEA_2017_SECTOR_COMMODITY_CODE_DESC: ta.Dict[BEA_2017_SECTOR_COMMODITY_CODE, str] = {
     "11": "Agriculture, forestry, fishing, and hunting",
     "21": "Mining",
     "22": "Utilities",

--- a/bedrock/utils/taxonomy/bea/v2017_sector.py
+++ b/bedrock/utils/taxonomy/bea/v2017_sector.py
@@ -1,0 +1,48 @@
+import typing as ta
+
+# Industry and special-product sectors only. Final-demand and value-added
+# sector codes (F010, F020, …, V003) live in v2017_final_demand and
+# v2017_value_added at detail granularity (F01000, V00100, …).
+BEA_2017_SECTOR_CODE = ta.Literal[
+    "11",  # Agriculture, forestry, fishing, and hunting
+    "21",  # Mining
+    "22",  # Utilities
+    "23",  # Construction
+    "31G",  # Manufacturing
+    "42",  # Wholesale trade
+    "44RT",  # Retail trade
+    "48TW",  # Transportation and warehousing
+    "51",  # Information
+    "FIRE",  # Finance, insurance, real estate, rental, and leasing
+    "PROF",  # Professional and business services
+    "6",  # Educational services, health care, and social assistance
+    "7",  # Arts, entertainment, recreation, accommodation, and food services
+    "81",  # Other services, except government
+    "G",  # Government
+    "Used",  # Scrap, used and secondhand goods
+    "Other",  # Noncomparable imports and rest-of-the-world adjustment
+]
+
+BEA_2017_SECTOR_CODES: ta.List[BEA_2017_SECTOR_CODE] = list(
+    ta.get_args(BEA_2017_SECTOR_CODE)
+)
+
+BEA_2017_SECTOR_CODE_DESC: ta.Dict[BEA_2017_SECTOR_CODE, str] = {
+    "11": "Agriculture, forestry, fishing, and hunting",
+    "21": "Mining",
+    "22": "Utilities",
+    "23": "Construction",
+    "31G": "Manufacturing",
+    "42": "Wholesale trade",
+    "44RT": "Retail trade",
+    "48TW": "Transportation and warehousing",
+    "51": "Information",
+    "FIRE": "Finance, insurance, real estate, rental, and leasing",
+    "PROF": "Professional and business services",
+    "6": "Educational services, health care, and social assistance",
+    "7": "Arts, entertainment, recreation, accommodation, and food services",
+    "81": "Other services, except government",
+    "G": "Government",
+    "Used": "Scrap, used and secondhand goods",
+    "Other": "Noncomparable imports and rest-of-the-world adjustment",
+}

--- a/bedrock/utils/taxonomy/mappings/bea_v2017_sector__bea_v2017_commodity.py
+++ b/bedrock/utils/taxonomy/mappings/bea_v2017_sector__bea_v2017_commodity.py
@@ -8,9 +8,9 @@ from bedrock.utils.taxonomy.bea.v2017_commodity import (
     BEA_2017_COMMODITY_CODE,
     BEA_2017_COMMODITY_CODES,
 )
-from bedrock.utils.taxonomy.bea.v2017_sector import (
-    BEA_2017_SECTOR_CODE,
-    BEA_2017_SECTOR_CODES,
+from bedrock.utils.taxonomy.bea.v2017_commodity_sector import (
+    BEA_2017_SECTOR_COMMODITY_CODE,
+    BEA_2017_SECTOR_COMMODITY_CODES,
 )
 from bedrock.utils.taxonomy.utils import validate_mapping
 
@@ -29,18 +29,20 @@ def _sector_to_detail_from_crosswalk() -> dict[str, list[str]]:
     return grouped
 
 
-def load_bea_v2017_sector_to_bea_v2017_commodity() -> (
-    ta.Dict[BEA_2017_SECTOR_CODE, ta.List[BEA_2017_COMMODITY_CODE]]
+def load_bea_v2017_sector_commodity_to_bea_v2017_commodity() -> (
+    ta.Dict[BEA_2017_SECTOR_COMMODITY_CODE, ta.List[BEA_2017_COMMODITY_CODE]]
 ):
     grouped = _sector_to_detail_from_crosswalk()
-    mapping: ta.Dict[BEA_2017_SECTOR_CODE, ta.List[BEA_2017_COMMODITY_CODE]] = {
+    mapping: ta.Dict[
+        BEA_2017_SECTOR_COMMODITY_CODE, ta.List[BEA_2017_COMMODITY_CODE]
+    ] = {
         sector: grouped[sector]  # type: ignore[misc]
-        for sector in BEA_2017_SECTOR_CODES
+        for sector in BEA_2017_SECTOR_COMMODITY_CODES
     }
     validate_mapping(  # type: ignore[misc]
         mapping,
-        domain=set(BEA_2017_SECTOR_CODES),
+        domain=set(BEA_2017_SECTOR_COMMODITY_CODES),
         codomain=set(BEA_2017_COMMODITY_CODES),
-        dangerously_skip_empty_mapping_check=True,
+        dangerously_skip_empty_mapping_check=False,
     )
     return mapping

--- a/bedrock/utils/taxonomy/mappings/bea_v2017_sector__bea_v2017_commodity.py
+++ b/bedrock/utils/taxonomy/mappings/bea_v2017_sector__bea_v2017_commodity.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import functools
+import typing as ta
+
+from bedrock.utils.config.common import load_crosswalk
+from bedrock.utils.taxonomy.bea.v2017_commodity import (
+    BEA_2017_COMMODITY_CODE,
+    BEA_2017_COMMODITY_CODES,
+)
+from bedrock.utils.taxonomy.bea.v2017_sector import (
+    BEA_2017_SECTOR_CODE,
+    BEA_2017_SECTOR_CODES,
+)
+from bedrock.utils.taxonomy.utils import validate_mapping
+
+
+@functools.cache
+def _sector_to_detail_from_crosswalk() -> dict[str, list[str]]:
+    df = load_crosswalk("NAICS_to_BEA_Crosswalk_2017")
+    commodity_codes = set(BEA_2017_COMMODITY_CODES)
+    grouped = (
+        df.groupby("BEA_2017_Sector_Code", sort=False)["BEA_2017_Detail_Code"]
+        .apply(
+            lambda codes: sorted({str(c) for c in codes if str(c) in commodity_codes})
+        )
+        .to_dict()
+    )
+    return grouped
+
+
+def load_bea_v2017_sector_to_bea_v2017_commodity() -> (
+    ta.Dict[BEA_2017_SECTOR_CODE, ta.List[BEA_2017_COMMODITY_CODE]]
+):
+    grouped = _sector_to_detail_from_crosswalk()
+    mapping: ta.Dict[BEA_2017_SECTOR_CODE, ta.List[BEA_2017_COMMODITY_CODE]] = {
+        sector: grouped[sector]  # type: ignore[misc]
+        for sector in BEA_2017_SECTOR_CODES
+    }
+    validate_mapping(  # type: ignore[misc]
+        mapping,
+        domain=set(BEA_2017_SECTOR_CODES),
+        codomain=set(BEA_2017_COMMODITY_CODES),
+        dangerously_skip_empty_mapping_check=True,
+    )
+    return mapping

--- a/bedrock/utils/taxonomy/mappings/bea_v2017_sector__cornerstone_commodity.py
+++ b/bedrock/utils/taxonomy/mappings/bea_v2017_sector__cornerstone_commodity.py
@@ -1,29 +1,29 @@
 import typing as ta
 
-from bedrock.utils.taxonomy.bea.v2017_sector import (
-    BEA_2017_SECTOR_CODE,
-    BEA_2017_SECTOR_CODES,
+from bedrock.utils.taxonomy.bea.v2017_commodity_sector import (
+    BEA_2017_SECTOR_COMMODITY_CODE,
+    BEA_2017_SECTOR_COMMODITY_CODES,
 )
 from bedrock.utils.taxonomy.cornerstone.commodities import COMMODITIES, COMMODITY
 from bedrock.utils.taxonomy.mappings.bea_v2017_commodity__cornerstone_commodity import (
     load_bea_v2017_commodity_to_cornerstone_commodity,
 )
 from bedrock.utils.taxonomy.mappings.bea_v2017_sector__bea_v2017_commodity import (
-    load_bea_v2017_sector_to_bea_v2017_commodity,
+    load_bea_v2017_sector_commodity_to_bea_v2017_commodity,
 )
 from bedrock.utils.taxonomy.utils import traverse, validate_mapping
 
 
-def load_bea_v2017_sector_to_cornerstone_commodity() -> (
-    ta.Dict[BEA_2017_SECTOR_CODE, ta.List[COMMODITY]]
+def load_bea_v2017_sector_commodity_to_cornerstone_commodity() -> (
+    ta.Dict[BEA_2017_SECTOR_COMMODITY_CODE, ta.List[COMMODITY]]
 ):
     mapping = traverse(
-        load_bea_v2017_sector_to_bea_v2017_commodity(),
+        load_bea_v2017_sector_commodity_to_bea_v2017_commodity(),
         load_bea_v2017_commodity_to_cornerstone_commodity(),
     )
     validate_mapping(  # type: ignore[misc]
         mapping,
-        domain=set(BEA_2017_SECTOR_CODES),
+        domain=set(BEA_2017_SECTOR_COMMODITY_CODES),
         codomain=set(COMMODITIES),
         dangerously_skip_empty_mapping_check=True,
     )

--- a/bedrock/utils/taxonomy/mappings/bea_v2017_sector__cornerstone_commodity.py
+++ b/bedrock/utils/taxonomy/mappings/bea_v2017_sector__cornerstone_commodity.py
@@ -21,7 +21,7 @@ def load_bea_v2017_sector_commodity_to_cornerstone_commodity() -> (
         load_bea_v2017_sector_commodity_to_bea_v2017_commodity(),
         load_bea_v2017_commodity_to_cornerstone_commodity(),
     )
-    validate_mapping(  # type: ignore[misc]
+    validate_mapping(
         mapping,
         domain=set(BEA_2017_SECTOR_COMMODITY_CODES),
         codomain=set(COMMODITIES),

--- a/bedrock/utils/taxonomy/mappings/bea_v2017_sector__cornerstone_commodity.py
+++ b/bedrock/utils/taxonomy/mappings/bea_v2017_sector__cornerstone_commodity.py
@@ -1,0 +1,30 @@
+import typing as ta
+
+from bedrock.utils.taxonomy.bea.v2017_sector import (
+    BEA_2017_SECTOR_CODE,
+    BEA_2017_SECTOR_CODES,
+)
+from bedrock.utils.taxonomy.cornerstone.commodities import COMMODITIES, COMMODITY
+from bedrock.utils.taxonomy.mappings.bea_v2017_commodity__cornerstone_commodity import (
+    load_bea_v2017_commodity_to_cornerstone_commodity,
+)
+from bedrock.utils.taxonomy.mappings.bea_v2017_sector__bea_v2017_commodity import (
+    load_bea_v2017_sector_to_bea_v2017_commodity,
+)
+from bedrock.utils.taxonomy.utils import traverse, validate_mapping
+
+
+def load_bea_v2017_sector_to_cornerstone_commodity() -> (
+    ta.Dict[BEA_2017_SECTOR_CODE, ta.List[COMMODITY]]
+):
+    mapping = traverse(
+        load_bea_v2017_sector_to_bea_v2017_commodity(),
+        load_bea_v2017_commodity_to_cornerstone_commodity(),
+    )
+    validate_mapping(  # type: ignore[misc]
+        mapping,
+        domain=set(BEA_2017_SECTOR_CODES),
+        codomain=set(COMMODITIES),
+        dangerously_skip_empty_mapping_check=True,
+    )
+    return mapping


### PR DESCRIPTION
cc:
Closes: #445

## What changed? Why?

BEA trade margins index margin-bearing industries at the **sector** level (wholesale, retail, transport, and peer industry buckets). Bedrock already types **detail** (~405) and **summary** (~71) BEA 2017 codes and maps detail commodities to Cornerstone, but industry sector codes were not in the taxonomy package. That blocked typed mappings and `validate_mapping` / `traverse` composition for margin work ([#429](https://github.com/cornerstone-data/bedrock/issues/429)).

This change adds:

- **`bedrock/utils/taxonomy/bea/v2017_sector.py`** — `BEA_2017_SECTOR_CODE` for 17 industry and special-product sectors (`11` … `81`, `G`, `Used`, `Other`), aligned with `v2012_sector.py`. 
- **`bedrock/utils/taxonomy/mappings/bea_v2017_sector__bea_v2017_commodity.py`** — sector → detail commodities via `load_crosswalk("NAICS_to_BEA_Crosswalk_2017")`, filtered to `BEA_2017_COMMODITY_CODES`.
- **`bedrock/utils/taxonomy/mappings/bea_v2017_sector__cornerstone_commodity.py`** — sector → Cornerstone commodities via `traverse` over the existing detail commodity → Cornerstone mapping (`load_bea_v2017_sector_to_cornerstone_commodity()`).

`Other` retains crosswalk commodities but an empty Cornerstone list because `S00300` / `S00900` are dropped upstream.


## Testing

Coverage checks (manual, pre-merge): reverse the sector→commodity and sector→Cornerstone mappings and confirm **every** `BEA_2017_COMMODITY_CODE` (402) and **every** `COMMODITY` (405) maps to **exactly one** sector — no orphans and no code appearing under multiple sectors.

