### PR TITLE
feat(eeio): derive y_nab from Adom and scaled_q

### DIFF
--- a/bedrock/transform/eeio/derived_cornerstone.py
+++ b/bedrock/transform/eeio/derived_cornerstone.py
@@ -93,7 +93,7 @@ from bedrock.utils.economic.inflation_helpers_cornerstone import (
 )
 from bedrock.utils.math.disaggregation import disaggregate_vector
 from bedrock.utils.math.formulas import (
-    backcompute_y_from_q_and_Aq,
+    backcompute_y_from_q_and_A,
     compute_q,
     compute_Unorm_matrix,
     compute_Vnorm_matrix,
@@ -909,7 +909,7 @@ def derive_cornerstone_y_nab() -> pd.Series[float]:
     clipping would break the domestic Leontief identity.
     """
     aq = derive_cornerstone_Aq_scaled()
-    return backcompute_y_from_q_and_Aq(A=aq.Adom, q=aq.scaled_q)
+    return backcompute_y_from_q_and_A(A=aq.Adom, q=aq.scaled_q)
 
 
 def derive_cornerstone_ydom_and_yimp() -> SingleRegionYVectorSet:

--- a/bedrock/transform/eeio/derived_cornerstone.py
+++ b/bedrock/transform/eeio/derived_cornerstone.py
@@ -93,7 +93,7 @@ from bedrock.utils.economic.inflation_helpers_cornerstone import (
 )
 from bedrock.utils.math.disaggregation import disaggregate_vector
 from bedrock.utils.math.formulas import (
-    backcompute_y_from_q_and_A,
+    backcompute_y_from_A_and_q,
     compute_q,
     compute_Unorm_matrix,
     compute_Vnorm_matrix,
@@ -909,7 +909,7 @@ def derive_cornerstone_y_nab() -> pd.Series[float]:
     clipping would break the domestic Leontief identity.
     """
     aq = derive_cornerstone_Aq_scaled()
-    return backcompute_y_from_q_and_A(A=aq.Adom, q=aq.scaled_q)
+    return backcompute_y_from_A_and_q(A=aq.Adom, q=aq.scaled_q)
 
 
 def derive_cornerstone_ydom_and_yimp() -> SingleRegionYVectorSet:

--- a/bedrock/transform/eeio/derived_cornerstone.py
+++ b/bedrock/transform/eeio/derived_cornerstone.py
@@ -46,7 +46,6 @@ from bedrock.extract.iot.io_2017 import (
     load_2017_V_usa,
     load_2017_value_added_usa,
     load_2017_Ytot_usa,
-    load_summary_Uimp_usa,
 )
 from bedrock.transform.allocation.derived import derive_E_usa
 from bedrock.transform.eeio.cornerstone_bea_intermediates import (
@@ -94,12 +93,11 @@ from bedrock.utils.economic.inflation_helpers_cornerstone import (
 )
 from bedrock.utils.math.disaggregation import disaggregate_vector
 from bedrock.utils.math.formulas import (
+    backcompute_y_from_q_and_Aq,
     compute_q,
     compute_Unorm_matrix,
     compute_Vnorm_matrix,
     compute_x,
-    compute_y_for_national_accounting_balance,
-    compute_y_imp,
 )
 from bedrock.utils.math.handle_negatives import (
     handle_negative_matrix_values,
@@ -126,9 +124,6 @@ from bedrock.utils.taxonomy.bea.v2017_final_demand import (
     USA_2017_FINAL_DEMAND_EXPORT_CODE,
     USA_2017_FINAL_DEMAND_IMPORT_CODE,
     USA_2017_FINAL_DEMAND_PERSONAL_CONSUMPTION_EXPENDITURE_CODE,
-)
-from bedrock.utils.taxonomy.bea.v2017_industry_summary import (
-    USA_2017_SUMMARY_INDUSTRY_CODES,
 )
 from bedrock.utils.taxonomy.bea_v2017_to_ceda_v7_helpers import (
     get_bea_v2017_summary_to_cornerstone_corresp_df,
@@ -904,40 +899,17 @@ def derive_cornerstone_Y_and_trade_scaled() -> SingleRegionYtotAndTradeVectorSet
 
 @functools.cache
 def derive_cornerstone_y_nab() -> pd.Series[float]:
-    """Y for national accounting balance, year-scaled."""
-    cfg = get_usa_config()
-    detail_2017 = derive_cornerstone_Ytot_matrix_set()
+    """National-accounting final demand consistent with scaled ``Adom`` and ``q``.
 
-    y_nab_2017 = compute_y_for_national_accounting_balance(
-        y_tot=detail_2017.ytot,
-        y_imp=compute_y_imp(
-            imports=detail_2017.imports,
-            Uimp=derive_cornerstone_U_set().Uimp,
-        ),
-        exports=detail_2017.exports,
-    )
+    Enforces row balance ``q = Adom @ diag(q) + y_nab`` using the same
+    ``derive_cornerstone_Aq_scaled`` object whose ``scaled_q`` is snapshotted.
+    Any future change to ``scaled_q`` in that path propagates to ``y_nab``.
 
-    summary_Y = derive_summary_Ytot_usa_matrix_set(cfg.usa_io_data_year)
-    y_nab_summary = compute_y_for_national_accounting_balance(
-        y_tot=summary_Y.ytot,
-        y_imp=compute_y_imp(
-            imports=summary_Y.imports,
-            Uimp=load_summary_Uimp_usa(cfg.usa_io_data_year).loc[
-                USA_2017_SUMMARY_INDUSTRY_CODES, USA_2017_SUMMARY_INDUSTRY_CODES
-            ],
-        ),
-        exports=summary_Y.exports,
-    )
-
-    y_nab_scaled = _disaggregate_and_inflate_vector(
-        base=y_nab_summary,
-        weight=y_nab_2017,
-        corresp_df=get_bea_v2017_summary_to_cornerstone_corresp_df(),
-        original_year=cfg.usa_io_data_year,
-        target_year=cfg.model_base_year,
-    )
-
-    return handle_negative_vector_values(y_nab_scaled)
+    Negative values are retained so ``q ≈ L_dom @ y_nab`` holds numerically;
+    clipping would break the domestic Leontief identity.
+    """
+    aq = derive_cornerstone_Aq_scaled()
+    return backcompute_y_from_q_and_Aq(A=aq.Adom, q=aq.scaled_q)
 
 
 def derive_cornerstone_ydom_and_yimp() -> SingleRegionYVectorSet:

--- a/bedrock/utils/math/formulas.py
+++ b/bedrock/utils/math/formulas.py
@@ -254,7 +254,7 @@ def backcompute_q_from_L_and_y(
     return (L @ np.diag(y)).sum(axis=1)
 
 
-def backcompute_y_from_q_and_Aq(
+def backcompute_y_from_A_and_q(
     *, A: pd.DataFrame, q: pd.Series[float]
 ) -> pd.Series[float]:
     return q - A.multiply(q, axis=1).sum(axis=1)

--- a/bedrock/utils/validation/__tests__/test_eeio_diagnostics.py
+++ b/bedrock/utils/validation/__tests__/test_eeio_diagnostics.py
@@ -353,28 +353,27 @@ def test_compare_Uset_y_dom_and_q_usa(
 
 @pytest.mark.eeio_integration
 @pytest.mark.parametrize(
-    "modelType, use_domestic",
+    "modelType, use_domestic, pipeline",
     [
-        ("Commodity", False),
-    ],
-)  # TODO: add ("Commodity", True) test and industry parameters when Industry models become available [("Industry", False), ("Industry", True)]
-@pytest.mark.parametrize(
-    "pipeline",
-    [
+        ("Commodity", True, "cornerstone"),
         pytest.param(
+            "Commodity",
+            False,
+            "cornerstone",
+            marks=pytest.mark.xfail(
+                reason="Cornerstone total L·y still uses ytot/trade, not y_nab.",
+            ),
+        ),
+        pytest.param(
+            "Commodity",
+            False,
             "ceda",
             marks=pytest.mark.xfail(
                 reason="CEDA: scaled q≠L_total·y_total for ~298 commodity sectors (total Leontief identity).",
             ),
         ),
-        pytest.param(
-            "cornerstone",
-            marks=pytest.mark.xfail(
-                reason="Cornerstone: scaled q≠L_total·y_total for 323 sectors; A-matrix vs Y-inflation path mismatch.",
-            ),
-        ),
     ],
-)
+)  # TODO: add industry parameters when Industry models become available
 def test_compare_output_and_L_y(
     modelType: str,
     use_domestic: bool,
@@ -396,23 +395,17 @@ def test_compare_output_and_L_y(
             y = y_set.ytot + y_set.exports - y_set.imports
             L = formulas.compute_L_matrix(A=Aq.Adom + Aq.Aimp)
     else:
-        # Cornerstone total L·y uses year-scaled Adom+Aimp and scaled_q from
-        # derive_cornerstone_Aq_scaled, compared to L @ y where y = y_tot +
-        # exports − imports from derive_cornerstone_Y_and_trade_scaled (summary-
-        # disaggregated and inflated to model year). 323 of 392 commodities fail
-        # at 1% tolerance—a systemic scale mismatch between the A-matrix scaling
-        # pipeline and the Y/trade inflation path (see zero-weight disaggregation
-        # warning during Y scaling), not an isolated wiring error in this test.
         # Cornerstone scales A and q to model year; CEDA branch stays in 2017 detail.
         Aq = derive_cornerstone_Aq_scaled()
         # Output must match Aq scaling (scaled_q), not derive_cornerstone_q() from V.
         output = Aq.scaled_q if modelType == "Commodity" else derive_cornerstone_x()
         if use_domestic:
-            # Precomputed scaled y_nab (same path as derive_y_for_national_accounting_balance_usa).
+            # y_nab from backcompute_y_from_q_and_Aq(Adom, scaled_q); unclipped.
             y = derive_cornerstone_y_nab()
             L = formulas.compute_L_matrix(A=Aq.Adom)
         else:
-            # Total y from summary-disaggregated inflated trade, not raw Ytot_matrix_set.
+            # Total L·y still uses y from derive_cornerstone_Y_and_trade_scaled
+            # (summary-disaggregated BEA Y/trade), not IO-balanced y_nab.
             y_trade = derive_cornerstone_Y_and_trade_scaled()
             y = y_trade.ytot + y_trade.exports - y_trade.imports
             L = formulas.compute_L_matrix(A=Aq.Adom + Aq.Aimp)

--- a/bedrock/utils/validation/__tests__/test_eeio_diagnostics.py
+++ b/bedrock/utils/validation/__tests__/test_eeio_diagnostics.py
@@ -400,7 +400,7 @@ def test_compare_output_and_L_y(
         # Output must match Aq scaling (scaled_q), not derive_cornerstone_q() from V.
         output = Aq.scaled_q if modelType == "Commodity" else derive_cornerstone_x()
         if use_domestic:
-            # y_nab from backcompute_y_from_q_and_Aq(Adom, scaled_q); unclipped.
+            # y_nab from backcompute_y_from_A_and_q(Adom, scaled_q); unclipped.
             y = derive_cornerstone_y_nab()
             L = formulas.compute_L_matrix(A=Aq.Adom)
         else:


### PR DESCRIPTION
cc:
Closes: #456

## What changed? Why?

`y_nab_USA` for the Cornerstone full model (`2025_usa_cornerstone_full_model`) is derived from the same `derive_cornerstone_Aq_scaled()` object that produces snapshotted `scaled_q_USA` and `Adom_USA`, via `backcompute_y_from_q_and_Aq(Adom, scaled_q)`. That enforces IO row balance `q = Adom @ diag(q) + y_nab` and domestic Leontief consistency `q ≈ L_dom @ y_nab`.

The prior path built `y_nab` from BEA Y/trade disaggregation and inflation — parallel to the A/`q` pipeline and inconsistent with snapshotted `scaled_q` (323 commodity sectors failed `q ≈ L·y` at 1% tolerance on the domestic branch).

**`derive_cornerstone_y_nab`** — replaces the BEA disaggregation/inflation body with a three-line backcompute from `derive_cornerstone_Aq_scaled()`. Negative `y_nab` values are retained; `handle_negative_vector_values` breaks the domestic Leontief identity because `L_dom` is dense (24 clipped sectors caused 26 test failures during development).

**`test_compare_output_and_L_y`** — adds a passing Cornerstone domestic case (`Commodity`, `use_domestic=True`). Total Leontief cases (Cornerstone and CEDA) remain `xfail`; Cornerstone total still pairs scaled `Adom + Aimp` with BEA-derived `y` from `derive_cornerstone_Y_and_trade_scaled`.

**Unchanged:** `scaled_q`, `Adom`, `ytot`, `ydom`, `yimp`, `exports` derivation paths. CEDA v7 legacy path. `derive_y_for_national_accounting_balance_usa` router (Cornerstone branch still delegates to `derive_cornerstone_y_nab`).

### Follow-ups (not in this branch)

- **Snapshot bump** — `y_nab_USA` values change; `test_y_nab_usa_snapshot` fails until Phase A regeneration (GCS upload, `.SNAPSHOT_KEY`, `releases.py`, `usa_config.py` Literal). Required before merge if integration tests gate on snapshots.
- **#457** — [`457-refine-q-estimate`](https://github.com/cornerstone-data/bedrock/tree/457-refine-q-estimate) refines `scaled_q` via authoritative-`x` `V` scaling. `y_nab` couples to `derive_cornerstone_Aq_scaled()`, so refined `q` propagates automatically once wired into that path. Coordinate stack order if both land near the same snapshot cut.
- **Total L·y and Y snapshots** — reconcile `ytot`/`ydom`/`yimp`/`exports` with IO-balanced `y_nab`, or adjust MRIO multi-region `Y` assembly (`ydom + exports` vs `y_nab_USA` parquet).

## Testing

Domestic Cornerstone Leontief identity (passes, 0 failing sectors at 1% rtol):

```powershell
uv run pytest "bedrock/utils/validation/__tests__/test_eeio_diagnostics.py::test_compare_output_and_L_y[Commodity-True-cornerstone]" -m eeio_integration -v
```

Full diagnostics module (domestic passes; total cases xfail as expected):

```powershell
uv run pytest bedrock/utils/validation/__tests__/test_eeio_diagnostics.py -k test_compare_output_and_L_y -m eeio_integration -v
```

Snapshot integration (fails until `y_nab_USA` snapshot regeneration):

```powershell
uv run pytest bedrock/transform/__tests__/test_usa.py::test_y_nab_usa_snapshot -m eeio_integration -v
```
