### PR TITLE
Implement print to excel for PR3

### DIFF
--- a/bedrock/analysis/electricity/__tests__/test_disaggregation_matrices.py
+++ b/bedrock/analysis/electricity/__tests__/test_disaggregation_matrices.py
@@ -1,0 +1,186 @@
+"""Unit tests for PR3 electricity disaggregation analysis export."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest import mock
+
+import pandas as pd
+import pytest
+
+from bedrock.analysis.electricity.disaggregation_matrices import (
+    GO_WEIGHTS_FILENAME,
+    OUTPUT_FILENAME,
+    WEIGHTS_FILENAME,
+    PipelineStage,
+    _build_electricity_balance_summary,
+    _derive_y_after_waste_disagg,
+    assert_disaggregation_export_config,
+    write_electricity_disaggregation_intermediate_outputs,
+)
+from bedrock.transform.eeio.electricity_disaggregation import (
+    DISAGG_BALANCE_ATOL,
+    ELECTRICITY_AGGREGATE,
+)
+from bedrock.utils.schemas.cornerstone_schemas import ELECTRICITY_DISAGG_SECTORS
+
+
+def _minimal_stage(
+    label: str,
+    *,
+    sectors: list[str],
+    diagonal_go: float | dict[str, float] = 100.0,
+) -> PipelineStage:
+    idx = pd.Index(sectors, name="sector")
+    v = pd.DataFrame(0.0, index=idx, columns=idx)
+    if isinstance(diagonal_go, dict):
+        for sector, value in diagonal_go.items():
+            v.at[sector, sector] = value
+    else:
+        for sector in sectors:
+            v.at[sector, sector] = diagonal_go / len(sectors)
+    udom = pd.DataFrame(0.0, index=idx, columns=idx)
+    uimp = udom.copy()
+    va = pd.DataFrame(0.0, index=["V00100"], columns=idx)
+    y = pd.DataFrame(1.0, index=idx, columns=["F01000"])
+    extended_u = pd.DataFrame(1.0, index=idx, columns=list(idx) + ["F01000"])
+    intermediate = udom.copy()
+    return PipelineStage(
+        label=label,
+        v=v,
+        udom=udom,
+        uimp=uimp,
+        va=va,
+        y=y,
+        extended_u=extended_u,
+        intermediate=intermediate,
+    )
+
+
+def test_assert_disaggregation_export_config_requires_all_flags() -> None:
+    with mock.patch(
+        "bedrock.analysis.electricity.disaggregation_matrices.get_usa_config"
+    ) as cfg_mock:
+        cfg = mock.Mock(
+            implement_waste_disaggregation=True,
+            implement_electricity_reallocation=True,
+            implement_electricity_disaggregation=False,
+        )
+        cfg_mock.return_value = cfg
+        with pytest.raises(ValueError, match="implement_electricity_disaggregation"):
+            assert_disaggregation_export_config()
+
+
+def test_disaggregation_export_writes_expected_artifacts(tmp_path: Path) -> None:
+    sectors405 = ["111000", ELECTRICITY_AGGREGATE, "221200"]
+    sectors407 = [
+        "111000",
+        *list(ELECTRICITY_DISAGG_SECTORS),
+        "221200",
+    ]
+    stage1 = _minimal_stage("after_waste_disagg", sectors=sectors405, diagonal_go=300.0)
+    stage2 = _minimal_stage(
+        "after_electricity_reallocation", sectors=sectors405, diagonal_go=300.0
+    )
+    stage3 = _minimal_stage(
+        "after_electricity_disaggregation",
+        sectors=sectors407,
+        diagonal_go={s: 100.0 for s in ELECTRICITY_DISAGG_SECTORS},
+    )
+
+    with (
+        mock.patch(
+            "bedrock.analysis.electricity.disaggregation_matrices._build_stage_tables",
+            return_value=(stage1, stage2, stage3),
+        ),
+        mock.patch(
+            "bedrock.analysis.electricity.disaggregation_matrices.build_electricity_disagg_go_weights",
+            return_value=pd.Series(
+                {"221110": 0.5, "221121": 0.1, "221122": 0.4},
+            ),
+        ),
+        mock.patch(
+            "bedrock.analysis.electricity.disaggregation_matrices.build_electricity_disagg_weights",
+            return_value=mock.Mock(),
+        ),
+        mock.patch(
+            "bedrock.analysis.electricity.disaggregation_matrices.weights_to_csv",
+        ),
+        mock.patch(
+            "bedrock.analysis.electricity.disaggregation_matrices.assert_disaggregation_export_config",
+        ),
+    ):
+        dest = write_electricity_disaggregation_intermediate_outputs(
+            output_dir=tmp_path,
+            output_path=tmp_path / OUTPUT_FILENAME,
+        )
+
+    assert dest.exists()
+    assert (tmp_path / GO_WEIGHTS_FILENAME).exists()
+    assert (tmp_path / WEIGHTS_FILENAME).exists()
+
+    workbook = pd.ExcelFile(dest)
+    expected_sheets = {
+        "V_after_waste_disagg",
+        "U_after_waste_disagg",
+        "Y_after_waste_disagg",
+        "V_after_elec_reallocation",
+        "U_after_elec_reallocation",
+        "Y_after_elec_reallocation",
+        "V_after_elec_disaggregation",
+        "U_after_elec_disaggregation",
+        "Y_after_elec_disaggregation",
+        "totals_after_waste_disagg",
+        "totals_after_elec_realloc",
+        "totals_after_elec_disagg",
+        "totals_delta_realloc",
+        "totals_delta_disagg",
+        "electricity_balance",
+    }
+    assert expected_sheets.issubset(set(workbook.sheet_names))
+
+    v3 = pd.read_excel(dest, sheet_name="V_after_elec_disaggregation", index_col=0)
+    assert ELECTRICITY_AGGREGATE not in v3.index
+    assert ELECTRICITY_AGGREGATE not in v3.columns
+
+
+def test_electricity_balance_sheet_logic() -> None:
+    sectors405 = [ELECTRICITY_AGGREGATE]
+    sectors407 = list(ELECTRICITY_DISAGG_SECTORS)
+    stage2 = _minimal_stage("stage2", sectors=sectors405, diagonal_go=300.0)
+    stage3 = _minimal_stage(
+        "stage3",
+        sectors=sectors407,
+        diagonal_go={s: 100.0 for s in ELECTRICITY_DISAGG_SECTORS},
+    )
+
+    balance = _build_electricity_balance_summary(stage2, stage3)
+    x_row = balance.loc[balance["metric"] == "make_row_x"].iloc[0]
+    assert float(x_row["delta"]) == pytest.approx(0.0, abs=DISAGG_BALANCE_ATOL)
+    assert bool(x_row["passes"]) is True
+
+
+def test_derive_y_after_waste_disagg_skips_electricity_row_split() -> None:
+    fake_y = pd.DataFrame({"F01000": [1.0]}, index=pd.Index(["221100"], name="sector"))
+    with (
+        mock.patch(
+            "bedrock.analysis.electricity.disaggregation_matrices.load_2017_Ytot_usa",
+            return_value=fake_y,
+        ),
+        mock.patch(
+            "bedrock.analysis.electricity.disaggregation_matrices.commodity_corresp",
+            return_value=pd.DataFrame(
+                [[1.0]], index=pd.Index(["221100"]), columns=pd.Index(["221100"])
+            ),
+        ),
+        mock.patch(
+            "bedrock.analysis.electricity.disaggregation_matrices.get_waste_disagg_weights",
+            return_value=None,
+        ),
+        mock.patch(
+            "bedrock.transform.eeio.electricity_disaggregation.disaggregate_electricity_commodity_row_in_y",
+        ) as disagg_y_mock,
+    ):
+        out = _derive_y_after_waste_disagg()
+        disagg_y_mock.assert_not_called()
+        assert ELECTRICITY_AGGREGATE in out.index

--- a/bedrock/analysis/electricity/disaggregation_matrices.py
+++ b/bedrock/analysis/electricity/disaggregation_matrices.py
@@ -1,0 +1,360 @@
+"""Export three-stage electricity pipeline matrices for offline PR3 inspection.
+
+Replicates pipeline checkpoint logic read-only (waste → reallocation → disaggregation).
+If production orchestration changes, keep this module aligned manually — no production
+hooks are added for analysis.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+import pandas as pd
+
+from bedrock.analysis.electricity.reallocation_matrices import (
+    _delta_summary,
+    _extended_use_tables,
+    _totals_summary,
+    _with_publish_loc_suffix,
+)
+from bedrock.extract.disaggregation.disagg_weights import weights_to_csv
+from bedrock.extract.iot.io_2017 import load_2017_Ytot_usa
+from bedrock.transform.eeio.cornerstone_disagg_pipeline import (
+    derive_cornerstone_U_after_waste,
+    derive_cornerstone_V_after_waste,
+    derive_cornerstone_VA_after_waste,
+    derive_disagg_io_bundle,
+    derive_disagg_Ytot_with_trade,
+    get_waste_disagg_weights,
+)
+from bedrock.transform.eeio.cornerstone_expansion import commodity_corresp
+from bedrock.transform.eeio.electricity_disaggregation import (
+    DISAGG_BALANCE_ATOL,
+    ELECTRICITY_AGGREGATE,
+    build_electricity_disagg_go_weights,
+    build_electricity_disagg_weights,
+    reallocate_electricity_coproduction,
+)
+from bedrock.transform.eeio.waste_disaggregation import apply_waste_disagg_to_Ytot
+from bedrock.utils.config.usa_config import get_usa_config
+from bedrock.utils.math.formulas import compute_q, compute_x
+from bedrock.utils.schemas.cornerstone_schemas import ELECTRICITY_DISAGG_SECTORS
+from bedrock.utils.taxonomy.cornerstone.final_demand import FINAL_DEMANDS
+
+logger = logging.getLogger(__name__)
+
+_OUTPUT_DIR = Path(__file__).resolve().parent / "output"
+OUTPUT_FILENAME = "electricity_pipeline_stages_V_U_Y.xlsx"
+GO_WEIGHTS_FILENAME = "electricity_disagg_go_weights.csv"
+WEIGHTS_FILENAME = "electricity_disagg_weights.csv"
+
+
+@dataclass(frozen=True)
+class PipelineStage:
+    """One electricity pipeline checkpoint (V/U/VA/Y + extended Use)."""
+
+    label: str
+    v: pd.DataFrame
+    udom: pd.DataFrame
+    uimp: pd.DataFrame
+    va: pd.DataFrame
+    y: pd.DataFrame
+    extended_u: pd.DataFrame
+    intermediate: pd.DataFrame
+
+
+def assert_disaggregation_export_config() -> None:
+    """Require waste + reallocation + disaggregation flags (mirrors USAConfig validator)."""
+    cfg = get_usa_config()
+    missing = [
+        name
+        for name, enabled in (
+            ("implement_waste_disaggregation", cfg.implement_waste_disaggregation),
+            (
+                "implement_electricity_reallocation",
+                cfg.implement_electricity_reallocation,
+            ),
+            (
+                "implement_electricity_disaggregation",
+                cfg.implement_electricity_disaggregation,
+            ),
+        )
+        if not enabled
+    ]
+    if missing:
+        raise ValueError(
+            "Electricity disaggregation export requires all of: "
+            "implement_waste_disaggregation, implement_electricity_reallocation, "
+            f"implement_electricity_disaggregation; missing: {', '.join(missing)}"
+        )
+
+
+def _derive_y_after_waste_disagg() -> pd.DataFrame:
+    """Y after correspondence + waste only (no electricity row split).
+
+    Mirrors ``derive_disagg_Ytot_with_trade()`` lines 187–193 only.
+    """
+    ytot_orig = load_2017_Ytot_usa()
+    ytot = commodity_corresp() @ ytot_orig
+    ytot.index.name = "sector"
+    weights = get_waste_disagg_weights()
+    if weights is not None:
+        ytot = apply_waste_disagg_to_Ytot(ytot, weights)
+        ytot.index.name = "sector"
+    return ytot
+
+
+def _extended_use_for_stage(
+    *,
+    udom: pd.DataFrame,
+    uimp: pd.DataFrame,
+    va: pd.DataFrame,
+    y_fd: pd.DataFrame,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    return _extended_use_tables(udom=udom, uimp=uimp, va=va, y_fd=y_fd)
+
+
+def _column_total_use_plus_va(
+    udom: pd.DataFrame,
+    uimp: pd.DataFrame,
+    va: pd.DataFrame,
+    industry: str,
+) -> float:
+    return (
+        float(udom[industry].sum())
+        + float(uimp[industry].sum())
+        + float(va[industry].sum())
+    )
+
+
+def _commodity_row_sum(extended_u: pd.DataFrame, commodity: str) -> float:
+    if commodity not in extended_u.index:
+        return 0.0
+    return float(extended_u.loc[commodity].sum())
+
+
+def _build_stage_tables() -> tuple[PipelineStage, PipelineStage, PipelineStage]:
+    """Build waste, reallocation, and disaggregation checkpoints."""
+    v1 = derive_cornerstone_V_after_waste()
+    udom1, uimp1 = derive_cornerstone_U_after_waste()
+    va1 = derive_cornerstone_VA_after_waste()
+    y_waste = _derive_y_after_waste_disagg()
+    y_fd_stages_12 = y_waste[list(FINAL_DEMANDS)]
+    u1, intermediate1 = _extended_use_for_stage(
+        udom=udom1, uimp=uimp1, va=va1, y_fd=y_fd_stages_12
+    )
+    stage1 = PipelineStage(
+        label="after_waste_disagg",
+        v=v1,
+        udom=udom1,
+        uimp=uimp1,
+        va=va1,
+        y=y_waste,
+        extended_u=u1,
+        intermediate=intermediate1,
+    )
+
+    v2, udom2, uimp2, va2 = reallocate_electricity_coproduction(v1, udom1, uimp1, va1)
+    u2, intermediate2 = _extended_use_for_stage(
+        udom=udom2, uimp=uimp2, va=va2, y_fd=y_fd_stages_12
+    )
+    stage2 = PipelineStage(
+        label="after_electricity_reallocation",
+        v=v2,
+        udom=udom2,
+        uimp=uimp2,
+        va=va2,
+        y=y_waste,
+        extended_u=u2,
+        intermediate=intermediate2,
+    )
+
+    bundle = derive_disagg_io_bundle()
+    y3 = derive_disagg_Ytot_with_trade()
+    y_fd3 = y3[list(FINAL_DEMANDS)]
+    u3, intermediate3 = _extended_use_for_stage(
+        udom=bundle.Udom,
+        uimp=bundle.Uimp,
+        va=bundle.VA,
+        y_fd=y_fd3,
+    )
+    stage3 = PipelineStage(
+        label="after_electricity_disaggregation",
+        v=bundle.V,
+        udom=bundle.Udom,
+        uimp=bundle.Uimp,
+        va=bundle.VA,
+        y=y3,
+        extended_u=u3,
+        intermediate=intermediate3,
+    )
+    return stage1, stage2, stage3
+
+
+def _build_electricity_balance_summary(
+    stage2: PipelineStage,
+    stage3: PipelineStage,
+) -> pd.DataFrame:
+    """Preservation metrics at the reallocation → disaggregation boundary."""
+    agg = ELECTRICITY_AGGREGATE
+    elec = list(ELECTRICITY_DISAGG_SECTORS)
+    atol = DISAGG_BALANCE_ATOL
+
+    x2 = float(compute_x(V=stage2.v)[agg])
+    x3 = sum(float(compute_x(V=stage3.v)[s]) for s in elec)
+    q2 = float(compute_q(V=stage2.v)[agg])
+    q3 = sum(float(compute_q(V=stage3.v)[s]) for s in elec)
+    c221100 = _column_total_use_plus_va(stage2.udom, stage2.uimp, stage2.va, agg)
+    go_residual = x2 - c221100
+    q_use2 = _commodity_row_sum(stage2.extended_u, agg)
+    q_use3 = sum(_commodity_row_sum(stage3.extended_u, s) for s in elec)
+    va2 = float(stage2.va[agg].sum())
+    va3 = float(stage3.va[elec].sum().sum())
+    y2 = float(stage2.y.loc[agg].sum()) if agg in stage2.y.index else 0.0
+    y3 = float(stage3.y.loc[elec].sum().sum())
+
+    def _row(
+        metric: str,
+        stage2_val: float | str,
+        stage3_val: float | str,
+        *,
+        check_balance: bool = True,
+    ) -> dict[str, object]:
+        if not check_balance:
+            return {
+                "metric": metric,
+                "stage2_value": stage2_val,
+                "stage3_value": stage3_val,
+                "delta": "",
+                "passes": "",
+            }
+        s2 = float(stage2_val)
+        s3 = float(stage3_val)
+        delta = s3 - s2
+        return {
+            "metric": metric,
+            "stage2_value": s2,
+            "stage3_value": s3,
+            "delta": delta,
+            "passes": abs(delta) <= atol,
+        }
+
+    rows = [
+        _row("make_row_x", x2, x3),
+        _row("make_col_q", q2, q3),
+        _row(
+            "use_col_total_udom_uimp_va",
+            c221100,
+            "N/A (221100 removed)",
+            check_balance=False,
+        ),
+        _row("use_commodity_row_q_use", q_use2, q_use3),
+        _row("va_column_sum", va2, va3),
+        _row("y_row_sum", y2, y3),
+        _row(
+            "go_identity_residual_stage2",
+            go_residual,
+            "—",
+            check_balance=False,
+        ),
+    ]
+    return pd.DataFrame(rows)
+
+
+def _write_analysis_weight_csvs(output_dir: Path) -> None:
+    """Write GO/disagg weight CSVs to analysis output (not extract)."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    w = build_electricity_disagg_go_weights()
+    w.to_csv(output_dir / GO_WEIGHTS_FILENAME, header=["weight"])
+    weights = build_electricity_disagg_weights(w)
+    with (output_dir / WEIGHTS_FILENAME).open(
+        "w", encoding="utf-8", newline=""
+    ) as handle:
+        weights_to_csv(weights, handle)
+
+
+def write_electricity_disaggregation_intermediate_outputs(
+    *,
+    output_dir: Path | None = None,
+    output_path: Path | None = None,
+) -> Path:
+    """Write three-stage V/U/Y workbook and analysis weight CSVs."""
+    assert_disaggregation_export_config()
+    out_dir = output_dir or _OUTPUT_DIR
+    dest = output_path or (out_dir / OUTPUT_FILENAME)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
+    stage1, stage2, stage3 = _build_stage_tables()
+    _write_analysis_weight_csvs(out_dir)
+
+    summary1 = _totals_summary(
+        stage1.label,
+        v=stage1.v,
+        extended_u=stage1.extended_u,
+        va=stage1.va,
+        intermediate=stage1.intermediate,
+    )
+    summary2 = _totals_summary(
+        stage2.label,
+        v=stage2.v,
+        extended_u=stage2.extended_u,
+        va=stage2.va,
+        intermediate=stage2.intermediate,
+    )
+    summary3 = _totals_summary(
+        stage3.label,
+        v=stage3.v,
+        extended_u=stage3.extended_u,
+        va=stage3.va,
+        intermediate=stage3.intermediate,
+    )
+    delta_realloc = _delta_summary(summary1, summary2)
+    delta_disagg = _delta_summary(summary2, summary3)
+    balance = _build_electricity_balance_summary(stage2, stage3)
+
+    with pd.ExcelWriter(dest, engine="openpyxl") as writer:
+        _with_publish_loc_suffix(stage1.v).to_excel(
+            writer, sheet_name="V_after_waste_disagg", index=True
+        )
+        _with_publish_loc_suffix(stage1.extended_u).to_excel(
+            writer, sheet_name="U_after_waste_disagg", index=True
+        )
+        stage1.y.to_excel(writer, sheet_name="Y_after_waste_disagg", index=True)
+        _with_publish_loc_suffix(stage2.v).to_excel(
+            writer, sheet_name="V_after_elec_reallocation", index=True
+        )
+        _with_publish_loc_suffix(stage2.extended_u).to_excel(
+            writer, sheet_name="U_after_elec_reallocation", index=True
+        )
+        stage2.y.to_excel(writer, sheet_name="Y_after_elec_reallocation", index=True)
+        _with_publish_loc_suffix(stage3.v).to_excel(
+            writer, sheet_name="V_after_elec_disaggregation", index=True
+        )
+        _with_publish_loc_suffix(stage3.extended_u).to_excel(
+            writer, sheet_name="U_after_elec_disaggregation", index=True
+        )
+        stage3.y.to_excel(writer, sheet_name="Y_after_elec_disaggregation", index=True)
+        summary1.reset_index().to_excel(
+            writer, sheet_name="totals_after_waste_disagg", index=False
+        )
+        summary2.reset_index().to_excel(
+            writer, sheet_name="totals_after_elec_realloc", index=False
+        )
+        summary3.reset_index().to_excel(
+            writer, sheet_name="totals_after_elec_disagg", index=False
+        )
+        delta_realloc.reset_index().to_excel(
+            writer, sheet_name="totals_delta_realloc", index=False
+        )
+        delta_disagg.reset_index().to_excel(
+            writer, sheet_name="totals_delta_disagg", index=False
+        )
+        balance.to_excel(writer, sheet_name="electricity_balance", index=False)
+
+    logger.info(
+        "Wrote electricity disaggregation intermediate outputs (16 sheets + 2 CSVs) to %s",
+        dest.resolve(),
+    )
+    return dest

--- a/bedrock/analysis/electricity/output/.gitignore
+++ b/bedrock/analysis/electricity/output/.gitignore
@@ -1,1 +1,3 @@
 *.xlsx
+electricity_disagg_*.csv
+electricity_disagg_go_weights.csv

--- a/bedrock/analysis/electricity/write_221100_disaggregation_matrices.py
+++ b/bedrock/analysis/electricity/write_221100_disaggregation_matrices.py
@@ -1,0 +1,63 @@
+"""CLI: export three-stage electricity pipeline V / U / Y matrices (PR3 analysis).
+
+Invoke as::
+
+    uv run python -m bedrock.analysis.electricity.write_221100_disaggregation_matrices \\
+        --config_name 2025_usa_cornerstone_full_model_electricity_disaggregation.yaml
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import click
+
+import bedrock.utils.config.common as common
+from bedrock.analysis.electricity.disaggregation_matrices import (
+    assert_disaggregation_export_config,
+    write_electricity_disaggregation_intermediate_outputs,
+)
+from bedrock.utils.config.usa_config import set_global_usa_config
+
+logger = logging.getLogger(__name__)
+
+
+@click.command(
+    help=(
+        "Export three-stage electricity pipeline V, extended U, and Y "
+        "(waste → reallocation → disaggregation) to Excel."
+    )
+)
+@click.option(
+    "--config_name",
+    required=True,
+    type=str,
+    help=(
+        "USA config YAML with implement_waste_disaggregation, "
+        "implement_electricity_reallocation, and "
+        "implement_electricity_disaggregation enabled."
+    ),
+)
+def main(config_name: str) -> None:
+    t0 = time.time()
+    set_global_usa_config(config_name)
+    common.download_fba_on_api_error = True
+
+    try:
+        assert_disaggregation_export_config()
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    output_path = write_electricity_disaggregation_intermediate_outputs()
+
+    logger.info(
+        "[TIMING] 221100 disaggregation matrix export completed in %.1fs (output=%s)",
+        time.time() - t0,
+        output_path,
+    )
+    print(f"Wrote electricity disaggregation matrices to {output_path.resolve()}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

Adds a new analysis module for exporting three-stage electricity pipeline matrices (V, extended U, and Y) at each checkpoint — after waste disaggregation, after electricity reallocation, and after electricity disaggregation — to an Excel workbook for offline PR3 inspection.

The `disaggregation_matrices.py` module introduces a `PipelineStage` dataclass to hold per-checkpoint tables, a `_build_stage_tables()` function that replicates the waste → reallocation → disaggregation pipeline read-only, and `write_electricity_disaggregation_intermediate_outputs()` which writes a 16-sheet workbook alongside GO weight and disaggregation weight CSVs. An `electricity_balance` sheet is included to verify preservation of key metrics (gross output, commodity totals, value added, final demand) across the reallocation → disaggregation boundary.

A CLI entry point (`write_221100_disaggregation_matrices.py`) is provided to invoke the export with a config YAML that has all three pipeline flags enabled. Generated output files are excluded from version control via `.gitignore`.

## Testing

Unit tests cover:
- `assert_disaggregation_export_config` raises when any required flag is disabled
- `write_electricity_disaggregation_intermediate_outputs` writes the expected Excel workbook with all 16 sheets and both CSV files, and confirms the aggregate electricity sector (`221100`) is absent from the post-disaggregation V matrix
- `_build_electricity_balance_summary` correctly computes a zero delta and passing check for gross output row
- `_derive_y_after_waste_disagg` does not call the electricity row split function and preserves the aggregate electricity sector in the output index