### PR TITLE
feat(publish): Phi year panel and dollar-year SEF alignment

### DIFF
--- a/bedrock/analysis/margins/README.md
+++ b/bedrock/analysis/margins/README.md
@@ -1,0 +1,39 @@
+# Margins and Phi analysis
+
+Manual validation scripts for BEA margins, PRO:PUR (Phi), and supply-chain emission
+factors. Outputs land in `output/` (gitignored).
+
+## Tracked scripts
+
+| Script | Purpose |
+|--------|---------|
+| `compare_phi_to_reference.py` | Bedrock Phi vs pinned USEEIO workbook (IO year + 2024) and CEDA workbook |
+| `compare_margin_approaches.py` | PRO:PUR across useeior / Cornerstone / CEDA margin configs at IO year and 2024 |
+| `compare_sef_zenodo_useeio_code.py` | Bedrock SEF without-margins vs [Zenodo v1.4.0](https://doi.org/10.5281/zenodo.17202747) on Reference USEEIO Code | `output/sef_zenodo_useeio_code_comparison.csv` |
+
+```powershell
+uv run python -m bedrock.analysis.margins.compare_phi_to_reference
+uv run python -m bedrock.analysis.margins.compare_margin_approaches
+uv run python -m bedrock.analysis.margins.compare_sef_zenodo_useeio_code `
+    --config_name useeio_phoebe_23 --dollar_year 2024
+```
+
+Run after SEF publish at target dollar year (e.g. `--dollar_year 2024` on
+`useeio_phoebe_23`). Uses purchaser Phi with useeior-style Rho margin inflation when
+`useeio_margins` is active.
+
+## Optional local scripts (not required in CI)
+
+| Script | Purpose |
+|--------|---------|
+| `compare_margins_bedrock_vs_useeior.py` | Bedrock `getMarginsTable` parity vs exported `model$Margins` (needs R export) |
+| `compare_phi_useeior_filter_parity.py` | Phi sensitivity to documented vs imports-bug margin filters |
+| `check_useeior_export_parity.py` | PRO column parity vs useeior CSV |
+
+Keep one-off probes (`_probe_*`, `diagnose_*`, `explore_*`) out of this folder unless
+promoted to a repeatable check with a stable output contract.
+
+## Related CI
+
+- `bedrock/publish/__tests__/test_sef_vs_useeio_baseline.py` — Phi@2017 vs phoebe workbook
+- `bedrock/utils/economic/__tests__/test_inflation_helpers_cornerstone.py` — Rho ratio helper

--- a/bedrock/analysis/margins/compare_margin_approaches.py
+++ b/bedrock/analysis/margins/compare_margin_approaches.py
@@ -63,8 +63,8 @@ def _ratio_from_margins(margins: pd.DataFrame) -> pd.Series:
 
 def _comparison_years() -> tuple[int, ...]:
     with temp_usa_config('useeio_phoebe_23', cache_bearing_modules=_CACHE_MODULES):
-        base_year = get_usa_config().usa_base_io_data_year
-    years = [base_year]
+        base_year = int(get_usa_config().usa_base_io_data_year)
+    years: list[int] = [base_year]
     if _PANEL_YEAR not in years:
         years.append(_PANEL_YEAR)
     return tuple(years)
@@ -72,7 +72,9 @@ def _comparison_years() -> tuple[int, ...]:
 
 def _ceda_ratios_on_cornerstone() -> pd.Series:
     _ceda_corresp = load_ceda_v7_commodity__cornerstone_commodity_correspondence()
-    _ceda_corresp_norm = _ceda_corresp.div(_ceda_corresp.sum(axis=1), axis=0).fillna(0.0)
+    _ceda_corresp_norm = _ceda_corresp.div(_ceda_corresp.sum(axis=1), axis=0).fillna(
+        0.0
+    )
     with temp_usa_config('v8_ceda_2025_usa', cache_bearing_modules=_CACHE_MODULES):
         ratio_ceda_by_sector = derive_phi_ceda_usa()
     return _ceda_corresp_norm @ ratio_ceda_by_sector
@@ -81,9 +83,7 @@ def _ceda_ratios_on_cornerstone() -> pd.Series:
 def _ratios_by_scenario(year: int, *, ratio_ceda: pd.Series) -> dict[str, pd.Series]:
     print(f'Computing margin ratios for {year}...')
     with temp_usa_config('useeio_phoebe_23', cache_bearing_modules=_CACHE_MODULES):
-        ratio_useeio = _ratio_from_margins(
-            derive_margins_cornerstone_usa_at_year(year)
-        )
+        ratio_useeio = _ratio_from_margins(derive_margins_cornerstone_usa_at_year(year))
     with temp_usa_config(
         '2025_usa_cornerstone_full_model', cache_bearing_modules=_CACHE_MODULES
     ):
@@ -97,9 +97,7 @@ def _ratios_by_scenario(year: int, *, ratio_ceda: pd.Series) -> dict[str, pd.Ser
     }
 
 
-def _plot_year(
-    long_df: pd.DataFrame, active_sectors: list[str], year: int
-) -> str:
+def _plot_year(long_df: pd.DataFrame, active_sectors: list[str], year: int) -> str:
     plot_df = long_df[long_df['year'] == year]
     n_scenarios = len(_CORNERSTONE_SCENARIOS)
     n_sectors = len(active_sectors)
@@ -115,9 +113,14 @@ def _plot_year(
                 'ratio',
             ].dropna()
             if len(data) < 2:
+                y_vals = (
+                    data.to_numpy(dtype=float)
+                    if len(data)
+                    else np.array([1.0], dtype=float)
+                )
                 ax.scatter(
                     [g_idx + (s_idx - (n_scenarios - 1) / 2) * violin_width],
-                    data.values if len(data) else [1.0],
+                    y_vals,
                     color=_COLORS[scenario],
                     s=20,
                     zorder=3,
@@ -167,7 +170,9 @@ def main() -> None:
     ratio_ceda = _ceda_ratios_on_cornerstone()
     ratio_columns: dict[str, pd.Series] = {}
     for year in years:
-        for scenario, series in _ratios_by_scenario(year, ratio_ceda=ratio_ceda).items():
+        for scenario, series in _ratios_by_scenario(
+            year, ratio_ceda=ratio_ceda
+        ).items():
             ratio_columns[f'{scenario}_{year}'] = series
 
     ratio_df = pd.DataFrame(ratio_columns)
@@ -199,7 +204,9 @@ def main() -> None:
         lambda s: (s - 1.0).abs().max() > 1e-6
     )
     active_sectors = non_unity[non_unity].index.tolist()
-    print(f'\n{len(active_sectors)} of {len(sector_map)} sectors have non-unity ratios.')
+    print(
+        f'\n{len(active_sectors)} of {len(sector_map)} sectors have non-unity ratios.'
+    )
 
     for year in years:
         plot_path = _plot_year(long_df, active_sectors, year)

--- a/bedrock/analysis/margins/compare_margin_approaches.py
+++ b/bedrock/analysis/margins/compare_margin_approaches.py
@@ -1,14 +1,19 @@
-"""Compare commodity-level PRO:PUR ratios across all margin model approaches.
+"""Compare commodity-level PRO:PUR ratios across margin model approaches and years.
 
-Scenarios and the production function each routes through:
+Scenarios (each at ``derive_margins_cornerstone_usa_at_year(year)`` unless noted):
 
-  useeio       — derive_margins_cornerstone_usa() with useeio_margins=True
-  cornerstone  — derive_margins_cornerstone_usa() with cornerstone_industry_avg_margins=True
-  ceda         — derive_phi_ceda_usa() with ceda_margins=True
+  useeio       — ``useeio_phoebe_23`` with ``useeio_margins`` (Rho PRO inflation)
+  cornerstone  — ``2025_usa_cornerstone_full_model`` with industry-avg margins
+                   (V-norm commodity PI on PRO)
+  ceda         — ``derive_phi_ceda_usa`` mapped to Cornerstone commodities (IO year)
+
+Usage::
+
+    uv run python -m bedrock.analysis.margins.compare_margin_approaches
 
 Outputs:
-  output/plots/margin_approach_comparison.png  — violin plots for useeio/cornerstone/ceda
-  output/margin_approach_comparison.csv        — Cornerstone commodity ratio table
+  output/plots/margin_approach_comparison_<year>.png
+  output/margin_approach_comparison.csv
 """
 
 from __future__ import annotations
@@ -24,15 +29,29 @@ PLOTS = os.path.join(OUT, 'plots')
 os.makedirs(PLOTS, exist_ok=True)
 
 from bedrock.transform.iot.derive_PRO_to_PUR_ratio import (  # noqa: E402
-    derive_margins_cornerstone_usa,
+    derive_margins_cornerstone_usa_at_year,
     derive_phi_ceda_usa,
 )
 from bedrock.utils.config.config_controllers import temp_usa_config  # noqa: E402
+from bedrock.utils.config.usa_config import get_usa_config  # noqa: E402
 from bedrock.utils.taxonomy.mappings.bea_v2017_sector__cornerstone_commodity import (  # noqa: E402
     load_bea_v2017_sector_commodity_to_cornerstone_commodity,
 )
 from bedrock.utils.taxonomy.usa_taxonomy_correspondence_helpers import (  # noqa: E402
     load_ceda_v7_commodity__cornerstone_commodity_correspondence,
+)
+
+_PANEL_YEAR = 2024
+_CORNERSTONE_SCENARIOS = ('useeio', 'cornerstone', 'ceda')
+_COLORS = {
+    'useeio': 'tab:orange',
+    'cornerstone': 'tab:green',
+    'ceda': 'tab:blue',
+}
+
+_CACHE_MODULES = (
+    'bedrock.extract.iot.io_2017',
+    'bedrock.transform.iot.derive_PRO_to_PUR_ratio',
 )
 
 
@@ -42,138 +61,154 @@ def _ratio_from_margins(margins: pd.DataFrame) -> pd.Series:
     )
 
 
-_CACHE_MODULES = (
-    'bedrock.extract.iot.io_2017',
-    'bedrock.transform.iot.derive_PRO_to_PUR_ratio',
-)
+def _comparison_years() -> tuple[int, ...]:
+    with temp_usa_config('useeio_phoebe_23', cache_bearing_modules=_CACHE_MODULES):
+        base_year = get_usa_config().usa_base_io_data_year
+    years = [base_year]
+    if _PANEL_YEAR not in years:
+        years.append(_PANEL_YEAR)
+    return tuple(years)
 
-# --- compute ratios ---
 
-print('Computing USEEIO ratios...')
-with temp_usa_config('useeio_phoebe_23', cache_bearing_modules=_CACHE_MODULES):
-    ratio_useeio = _ratio_from_margins(derive_margins_cornerstone_usa())
+def _ceda_ratios_on_cornerstone() -> pd.Series:
+    _ceda_corresp = load_ceda_v7_commodity__cornerstone_commodity_correspondence()
+    _ceda_corresp_norm = _ceda_corresp.div(_ceda_corresp.sum(axis=1), axis=0).fillna(0.0)
+    with temp_usa_config('v8_ceda_2025_usa', cache_bearing_modules=_CACHE_MODULES):
+        ratio_ceda_by_sector = derive_phi_ceda_usa()
+    return _ceda_corresp_norm @ ratio_ceda_by_sector
 
-print('Computing Cornerstone ratios...')
-with temp_usa_config(
-    '2025_usa_cornerstone_full_model', cache_bearing_modules=_CACHE_MODULES
-):
-    ratio_cornerstone = _ratio_from_margins(derive_margins_cornerstone_usa())
 
-print('Computing CEDA ratios...')
-with temp_usa_config('v8_ceda_2025_usa', cache_bearing_modules=_CACHE_MODULES):
-    ratio_ceda_by_sector = derive_phi_ceda_usa()
-
-# Map CEDA v7 sector ratios → Cornerstone commodities.
-# The correspondence is (Cornerstone × CEDA_v7); row-normalize so that
-# Cornerstone commodities spanning multiple CEDA sectors get an average ratio.
-_ceda_corresp = load_ceda_v7_commodity__cornerstone_commodity_correspondence()
-_ceda_corresp_norm = _ceda_corresp.div(_ceda_corresp.sum(axis=1), axis=0).fillna(0.0)
-ratio_ceda = _ceda_corresp_norm @ ratio_ceda_by_sector
-
-# --- Cornerstone commodity comparison table ---
-ratio_df = pd.DataFrame(
-    {
+def _ratios_by_scenario(year: int, *, ratio_ceda: pd.Series) -> dict[str, pd.Series]:
+    print(f'Computing margin ratios for {year}...')
+    with temp_usa_config('useeio_phoebe_23', cache_bearing_modules=_CACHE_MODULES):
+        ratio_useeio = _ratio_from_margins(
+            derive_margins_cornerstone_usa_at_year(year)
+        )
+    with temp_usa_config(
+        '2025_usa_cornerstone_full_model', cache_bearing_modules=_CACHE_MODULES
+    ):
+        ratio_cornerstone = _ratio_from_margins(
+            derive_margins_cornerstone_usa_at_year(year)
+        )
+    return {
         'useeio': ratio_useeio,
         'cornerstone': ratio_cornerstone,
         'ceda': ratio_ceda,
     }
-)
-ratio_df.index.name = 'commodity'
 
-CORNERSTONE_SCENARIOS = ['useeio', 'cornerstone', 'ceda']
-COLORS = {
-    'useeio': 'tab:orange',
-    'cornerstone': 'tab:green',
-    'ceda': 'tab:blue',
-}
 
-# --- group commodities by BEA sector ---
-sector_map = load_bea_v2017_sector_commodity_to_cornerstone_commodity()
+def _plot_year(
+    long_df: pd.DataFrame, active_sectors: list[str], year: int
+) -> str:
+    plot_df = long_df[long_df['year'] == year]
+    n_scenarios = len(_CORNERSTONE_SCENARIOS)
+    n_sectors = len(active_sectors)
+    group_width = 0.8
+    violin_width = group_width / n_scenarios
 
-rows = []
-for sector, commodities in sector_map.items():
-    for commodity in commodities:
-        if commodity not in ratio_df.index:
-            continue
-        for scenario in CORNERSTONE_SCENARIOS:
-            rows.append(
-                {
-                    'sector': sector,
-                    'commodity': commodity,
-                    'scenario': scenario,
-                    'ratio': ratio_df.loc[commodity, scenario],
-                }
+    fig, ax = plt.subplots(figsize=(max(10, n_sectors * 2.5), 6))
+
+    for g_idx, sector in enumerate(active_sectors):
+        for s_idx, scenario in enumerate(_CORNERSTONE_SCENARIOS):
+            data = plot_df.loc[
+                (plot_df['sector'] == sector) & (plot_df['scenario'] == scenario),
+                'ratio',
+            ].dropna()
+            if len(data) < 2:
+                ax.scatter(
+                    [g_idx + (s_idx - (n_scenarios - 1) / 2) * violin_width],
+                    data.values if len(data) else [1.0],
+                    color=_COLORS[scenario],
+                    s=20,
+                    zorder=3,
+                )
+                continue
+            pos = g_idx + (s_idx - (n_scenarios - 1) / 2) * violin_width
+            parts = ax.violinplot(
+                data,
+                positions=[pos],
+                widths=violin_width * 0.9,
+                showmedians=True,
+                showextrema=False,
             )
-long_df = pd.DataFrame(rows)
+            for pc in parts['bodies']:  # type: ignore[attr-defined]
+                pc.set_facecolor(_COLORS[scenario])
+                pc.set_alpha(0.6)
+            parts['cmedians'].set_color(_COLORS[scenario])
+            parts['cmedians'].set_linewidth(1.5)
 
-non_unity = long_df.groupby('sector')['ratio'].apply(
-    lambda s: (s - 1.0).abs().max() > 1e-6
-)
-active_sectors = non_unity[non_unity].index.tolist()
-plot_df = long_df[long_df['sector'].isin(active_sectors)]
+    ax.axhline(
+        1.0, color='black', linewidth=0.8, linestyle='--', alpha=0.5, label='ratio = 1'
+    )
+    ax.set_xticks(range(n_sectors))
+    ax.set_xticklabels(active_sectors, rotation=45, ha='right', fontsize=9)
+    ax.set_ylabel('PRO:PUR ratio')
+    ax.set_title(
+        f'PRO:PUR ratio by BEA sector and margin approach ({year} USD margins)\n'
+        '(Cornerstone commodities; CEDA column is IO-year only)'
+    )
+    ax.grid(True, axis='y', linestyle=':', alpha=0.4)
 
-print(f'\n{len(active_sectors)} of {len(sector_map)} sectors have non-unity ratios.')
+    legend_handles = [
+        plt.Rectangle((0, 0), 1, 1, fc=_COLORS[s], alpha=0.6, label=s)
+        for s in _CORNERSTONE_SCENARIOS
+    ]
+    ax.legend(handles=legend_handles, loc='upper right', fontsize=8)
 
-# --- violin plot ---
-n_scenarios = len(CORNERSTONE_SCENARIOS)
-n_sectors = len(active_sectors)
-group_width = 0.8
-violin_width = group_width / n_scenarios
+    fig.tight_layout()
+    plot_path = os.path.join(PLOTS, f'margin_approach_comparison_{year}.png')
+    fig.savefig(plot_path, dpi=150)
+    plt.close(fig)
+    return plot_path
 
-fig, ax = plt.subplots(figsize=(max(10, n_sectors * 2.5), 6))
 
-for g_idx, sector in enumerate(active_sectors):
-    for s_idx, scenario in enumerate(CORNERSTONE_SCENARIOS):
-        data = plot_df.loc[
-            (plot_df['sector'] == sector) & (plot_df['scenario'] == scenario), 'ratio'
-        ].dropna()
-        if len(data) < 2:
-            ax.scatter(
-                [g_idx + (s_idx - (n_scenarios - 1) / 2) * violin_width],
-                data.values if len(data) else [1.0],
-                color=COLORS[scenario],
-                s=20,
-                zorder=3,
-            )
-            continue
-        pos = g_idx + (s_idx - (n_scenarios - 1) / 2) * violin_width
-        parts = ax.violinplot(
-            data,
-            positions=[pos],
-            widths=violin_width * 0.9,
-            showmedians=True,
-            showextrema=False,
-        )
-        for pc in parts['bodies']:  # type: ignore[attr-defined]
-            pc.set_facecolor(COLORS[scenario])
-            pc.set_alpha(0.6)
-        parts['cmedians'].set_color(COLORS[scenario])
-        parts['cmedians'].set_linewidth(1.5)
+def main() -> None:
+    years = _comparison_years()
+    ratio_ceda = _ceda_ratios_on_cornerstone()
+    ratio_columns: dict[str, pd.Series] = {}
+    for year in years:
+        for scenario, series in _ratios_by_scenario(year, ratio_ceda=ratio_ceda).items():
+            ratio_columns[f'{scenario}_{year}'] = series
 
-ax.axhline(
-    1.0, color='black', linewidth=0.8, linestyle='--', alpha=0.5, label='ratio = 1'
-)
-ax.set_xticks(range(n_sectors))
-ax.set_xticklabels(active_sectors, rotation=45, ha='right', fontsize=9)
-ax.set_ylabel('PRO:PUR ratio')
-ax.set_title(
-    'PRO:PUR ratio by BEA sector and margin approach\n(Cornerstone commodities)'
-)
-ax.grid(True, axis='y', linestyle=':', alpha=0.4)
+    ratio_df = pd.DataFrame(ratio_columns)
+    ratio_df.index.name = 'commodity'
 
-legend_handles = [
-    plt.Rectangle((0, 0), 1, 1, fc=COLORS[s], alpha=0.6, label=s)
-    for s in CORNERSTONE_SCENARIOS
-]
-ax.legend(handles=legend_handles, loc='upper right', fontsize=8)
+    sector_map = load_bea_v2017_sector_commodity_to_cornerstone_commodity()
+    rows: list[dict[str, object]] = []
+    for year in years:
+        for sector, commodities in sector_map.items():
+            for commodity in commodities:
+                if commodity not in ratio_df.index:
+                    continue
+                for scenario in _CORNERSTONE_SCENARIOS:
+                    col = f'{scenario}_{year}'
+                    if col not in ratio_df.columns:
+                        continue
+                    rows.append(
+                        {
+                            'year': year,
+                            'sector': sector,
+                            'commodity': commodity,
+                            'scenario': scenario,
+                            'ratio': ratio_df.loc[commodity, col],
+                        }
+                    )
+    long_df = pd.DataFrame(rows)
 
-fig.tight_layout()
-plot_path = os.path.join(PLOTS, 'margin_approach_comparison.png')
-fig.savefig(plot_path, dpi=150)
-plt.close(fig)
-print(f'Plot saved to: {plot_path}')
+    non_unity = long_df.groupby('sector')['ratio'].apply(
+        lambda s: (s - 1.0).abs().max() > 1e-6
+    )
+    active_sectors = non_unity[non_unity].index.tolist()
+    print(f'\n{len(active_sectors)} of {len(sector_map)} sectors have non-unity ratios.')
 
-# --- CSVs ---
-csv_path = os.path.join(OUT, 'margin_approach_comparison.csv')
-ratio_df.to_csv(csv_path)
-print(f'Cornerstone table saved to: {csv_path}')
+    for year in years:
+        plot_path = _plot_year(long_df, active_sectors, year)
+        print(f'Plot saved to: {plot_path}')
+
+    csv_path = os.path.join(OUT, 'margin_approach_comparison.csv')
+    ratio_df.to_csv(csv_path)
+    print(f'Cornerstone table saved to: {csv_path}')
+
+
+if __name__ == '__main__':
+    main()

--- a/bedrock/analysis/margins/compare_phi_to_reference.py
+++ b/bedrock/analysis/margins/compare_phi_to_reference.py
@@ -164,8 +164,8 @@ def _scatter_comparison(
 
 def _useeio_comparison_years() -> tuple[int, ...]:
     with temp_usa_config('useeio_phoebe_23', cache_bearing_modules=_CACHE_MODULES):
-        base_year = get_usa_config().usa_base_io_data_year
-    years = [base_year]
+        base_year = int(get_usa_config().usa_base_io_data_year)
+    years: list[int] = [base_year]
     if _USEEIO_PANEL_YEAR not in years:
         years.append(_USEEIO_PANEL_YEAR)
     return tuple(years)

--- a/bedrock/analysis/margins/compare_phi_to_reference.py
+++ b/bedrock/analysis/margins/compare_phi_to_reference.py
@@ -1,15 +1,18 @@
 """Compare model-computed Phi (PRO:PUR ratio) against external reference data.
 
-USEEIO: bedrock Phi at BEA detail commodity level vs the Phi sheet in the pinned
-        USEEIO Excel workbook, column = model_base_year.
-CEDA:   bedrock Phi at CEDA v7 sector level vs the 'Purchaser - producer
-        conversion' sheet in the CEDA 2025 Excel workbook (header row 5,
-        data row 6).
+USEEIO: ``derive_phi_cornerstone_usa_at_year`` vs the Phi sheet in the pinned
+        USEEIO Excel workbook at ``usa_base_io_data_year`` and 2024.
+CEDA:   ``derive_phi_ceda_usa`` vs the 'Purchaser - producer conversion' sheet
+        in the CEDA 2025 Excel workbook (IO-year only; no year panel).
+
+Usage::
+
+    uv run python -m bedrock.analysis.margins.compare_phi_to_reference
 
 Outputs:
-  output/plots/phi_comparison.png   — side-by-side scatter plots
-  output/phi_comparison_useeio.csv  — USEEIO sector-level comparison table
-  output/phi_comparison_ceda.csv    — CEDA sector-level comparison table
+  output/plots/phi_comparison.png
+  output/phi_comparison_useeio_<year>.csv
+  output/phi_comparison_ceda.csv
 """
 
 from __future__ import annotations
@@ -26,9 +29,8 @@ PLOTS = os.path.join(OUT, 'plots')
 os.makedirs(PLOTS, exist_ok=True)
 
 from bedrock.transform.iot.derive_PRO_to_PUR_ratio import (  # noqa: E402
-    _margins_by_commodity,
-    _useeio_margins_filters,
     derive_phi_ceda_usa,
+    derive_phi_cornerstone_usa_at_year,
 )
 from bedrock.utils.config.config_controllers import temp_usa_config  # noqa: E402
 from bedrock.utils.config.usa_config import get_usa_config  # noqa: E402
@@ -51,6 +53,12 @@ _CEDA_GS_URI = (
     'gs://cornerstone-default/snapshots/CEDA_2025/CEDA 2025 (updated 2025-11-12).xlsx'
 )
 _GCS_PREFIX = 'gs://cornerstone-default/'
+_USEEIO_PANEL_YEAR = 2024
+
+_CACHE_MODULES = (
+    'bedrock.extract.iot.io_2017',
+    'bedrock.transform.iot.derive_PRO_to_PUR_ratio',
+)
 
 
 def _xlsx_local_path(gs_uri: str) -> str:
@@ -109,14 +117,9 @@ def _load_ceda_phi_reference(local_path: str) -> pd.Series:
     return phi.dropna()
 
 
-def _compute_useeio_phi_model() -> pd.Series:
-    """PRO:PUR at BEA detail commodity level under the active USEEIO config."""
-    margins = _margins_by_commodity(
-        _useeio_margins_filters, abs_negative_producers_value=True
-    )
-    phi = (margins["Producers' Value"] / margins["Purchasers' Value"]).replace(
-        [np.inf, -np.inf, np.nan], 1
-    )
+def _compute_useeio_phi_model(year: int) -> pd.Series:
+    """Phi from the publish margins path at *year* USD."""
+    phi = derive_phi_cornerstone_usa_at_year(year).astype(float)
     phi.index.name = 'sector'
     return phi
 
@@ -144,10 +147,11 @@ def _scatter_comparison(
     if len(x) > 1:
         corr = float(x.corr(y))
         mae = float((y - x).abs().mean())
+        med_rel = float(((y - x) / x.replace(0.0, np.nan)).abs().median())
         ax.text(
             0.04,
             0.92,
-            f'n={len(x)}  r={corr:.3f}  MAE={mae:.4f}',
+            f'n={len(x)}  r={corr:.3f}  MAE={mae:.4f}  med|rel|={med_rel:.3f}',
             transform=ax.transAxes,
             fontsize=7.5,
         )
@@ -158,62 +162,84 @@ def _scatter_comparison(
     ).reindex(common)
 
 
-_CACHE_MODULES = (
-    'bedrock.extract.iot.io_2017',
-    'bedrock.transform.iot.derive_PRO_to_PUR_ratio',
-)
+def _useeio_comparison_years() -> tuple[int, ...]:
+    with temp_usa_config('useeio_phoebe_23', cache_bearing_modules=_CACHE_MODULES):
+        base_year = get_usa_config().usa_base_io_data_year
+    years = [base_year]
+    if _USEEIO_PANEL_YEAR not in years:
+        years.append(_USEEIO_PANEL_YEAR)
+    return tuple(years)
 
-# ─── USEEIO ──────────────────────────────────────────────────────────────────
-print('Computing USEEIO model Phi...')
-with temp_usa_config('useeio_phoebe_23', cache_bearing_modules=_CACHE_MODULES):
-    phi_useeio_model = _compute_useeio_phi_model()
-    useeio_year = get_usa_config().model_base_year
 
-print('Loading USEEIO reference Phi...')
-_pin = load_useeio_baseline_pin_overrides(_PIN_JSON)
-_useeio_gs_uri = _pin['useeio_baseline_xlsx_gs_uri']
-_useeio_local = _xlsx_local_path(_useeio_gs_uri)
-ensure_useeio_xlsx_local(
-    _useeio_gs_uri, _pin['useeio_baseline_xlsx_sha256'], _useeio_local
-)
-phi_useeio_ref = _load_useeio_phi_reference(_useeio_local, useeio_year)
+def main() -> None:
+    useeio_years = _useeio_comparison_years()
+    useeio_model_by_year: dict[int, pd.Series] = {}
+    print('Computing USEEIO model Phi...')
+    with temp_usa_config('useeio_phoebe_23', cache_bearing_modules=_CACHE_MODULES):
+        for year in useeio_years:
+            print(f'  year {year}...')
+            useeio_model_by_year[year] = _compute_useeio_phi_model(year)
 
-# ─── CEDA ────────────────────────────────────────────────────────────────────
-print('Computing CEDA model Phi...')
-with temp_usa_config('v8_ceda_2025_usa', cache_bearing_modules=_CACHE_MODULES):
-    phi_ceda_model = derive_phi_ceda_usa()
+    print('Loading USEEIO reference Phi...')
+    pin = load_useeio_baseline_pin_overrides(_PIN_JSON)
+    useeio_gs_uri = pin['useeio_baseline_xlsx_gs_uri']
+    useeio_local = _xlsx_local_path(useeio_gs_uri)
+    ensure_useeio_xlsx_local(
+        useeio_gs_uri, pin['useeio_baseline_xlsx_sha256'], useeio_local
+    )
+    useeio_ref_by_year = {
+        year: _load_useeio_phi_reference(useeio_local, year) for year in useeio_years
+    }
 
-print('Loading CEDA reference Phi...')
-_ceda_local = _ensure_ceda_xlsx_local()
-phi_ceda_ref = _load_ceda_phi_reference(_ceda_local)
+    print('Computing CEDA model Phi...')
+    with temp_usa_config('v8_ceda_2025_usa', cache_bearing_modules=_CACHE_MODULES):
+        phi_ceda_model = derive_phi_ceda_usa()
 
-# ─── Comparison summary ───────────────────────────────────────────────────────
-print(
-    f'\nUSEEIO: {len(phi_useeio_model.dropna())} model sectors, '
-    f'{len(phi_useeio_ref)} reference sectors'
-)
-print(
-    f'CEDA: {len(phi_ceda_model)} model sectors, {len(phi_ceda_ref)} reference sectors'
-)
+    print('Loading CEDA reference Phi...')
+    ceda_local = _ensure_ceda_xlsx_local()
+    phi_ceda_ref = _load_ceda_phi_reference(ceda_local)
 
-# ─── Plots ────────────────────────────────────────────────────────────────────
-fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 5))
-df_useeio = _scatter_comparison(
-    ax1, phi_useeio_model, phi_useeio_ref, f'USEEIO Phi ({useeio_year})'
-)
-df_ceda = _scatter_comparison(ax2, phi_ceda_model, phi_ceda_ref, 'CEDA Phi')
-fig.suptitle('PRO:PUR Phi — model (bedrock) vs external reference', fontsize=11)
-fig.tight_layout()
-plot_path = os.path.join(PLOTS, 'phi_comparison.png')
-fig.savefig(plot_path, dpi=150)
-plt.close(fig)
-print(f'\nPlot saved to: {plot_path}')
+    n_axes = len(useeio_years) + 1
+    fig, axes = plt.subplots(1, n_axes, figsize=(5 * n_axes, 5))
+    if n_axes == 1:
+        axes = [axes]
 
-# ─── CSVs ─────────────────────────────────────────────────────────────────────
-useeio_csv = os.path.join(OUT, 'phi_comparison_useeio.csv')
-df_useeio.to_csv(useeio_csv)
-print(f'USEEIO CSV: {useeio_csv}')
+    useeio_tables: dict[int, pd.DataFrame] = {}
+    for ax, year in zip(axes, useeio_years, strict=False):
+        model = useeio_model_by_year[year]
+        ref = useeio_ref_by_year[year]
+        print(
+            f'\nUSEEIO {year}: {len(model.dropna())} model sectors, '
+            f'{len(ref)} reference sectors'
+        )
+        useeio_tables[year] = _scatter_comparison(
+            ax, model, ref, f'USEEIO Phi ({year})'
+        )
 
-ceda_csv = os.path.join(OUT, 'phi_comparison_ceda.csv')
-df_ceda.to_csv(ceda_csv)
-print(f'CEDA CSV: {ceda_csv}')
+    print(
+        f'\nCEDA: {len(phi_ceda_model)} model sectors, '
+        f'{len(phi_ceda_ref)} reference sectors'
+    )
+    df_ceda = _scatter_comparison(
+        axes[-1], phi_ceda_model, phi_ceda_ref, 'CEDA Phi (IO year)'
+    )
+
+    fig.suptitle('PRO:PUR Phi — model (bedrock) vs external reference', fontsize=11)
+    fig.tight_layout()
+    plot_path = os.path.join(PLOTS, 'phi_comparison.png')
+    fig.savefig(plot_path, dpi=150)
+    plt.close(fig)
+    print(f'\nPlot saved to: {plot_path}')
+
+    for year, table in useeio_tables.items():
+        path = os.path.join(OUT, f'phi_comparison_useeio_{year}.csv')
+        table.to_csv(path)
+        print(f'USEEIO CSV ({year}): {path}')
+
+    ceda_csv = os.path.join(OUT, 'phi_comparison_ceda.csv')
+    df_ceda.to_csv(ceda_csv)
+    print(f'CEDA CSV: {ceda_csv}')
+
+
+if __name__ == '__main__':
+    main()

--- a/bedrock/analysis/margins/compare_sef_zenodo_useeio_code.py
+++ b/bedrock/analysis/margins/compare_sef_zenodo_useeio_code.py
@@ -1,0 +1,208 @@
+"""Compare bedrock SEF export to Zenodo v1.4.0 on Reference USEEIO Code.
+
+Zenodo publishes NAICS-6 rows mapped to ``Reference USEEIO Code`` (BEA detail).
+Rows whose reference field lists **multiple** codes (comma-separated, e.g.
+``230301, 233230``) are dropped. Remaining rows collapse to one value per
+reference code (mean across NAICS rows sharing the same code). Bedrock joins on
+the same USEEIO commodity codes.
+
+Usage (PowerShell, repo root)::
+
+    uv run python -m bedrock.analysis.margins.compare_sef_zenodo_useeio_code \\
+        --config_name useeio_phoebe_23 --dollar_year 2024
+
+Optional: ``--zenodo-xlsx PATH`` (defaults to cached download under
+``bedrock/utils/snapshots/data/zenodo_sef_v1.4.0/``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import urllib.request
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+_PKG_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _PKG_DIR.parents[3]
+_ZENODO_RECORD_ID = 17202747
+_ZENODO_FILENAME = 'SupplyChainGHGEmissionFactorsv1.4.0.xlsx'
+_ZENODO_DOI = '10.5281/zenodo.17202747'
+_CACHE_DIR = (
+    _REPO_ROOT / 'bedrock' / 'utils' / 'snapshots' / 'data' / 'zenodo_sef_v1.4.0'
+)
+_DEFAULT_OUTPUT = _PKG_DIR / 'output' / 'sef_zenodo_useeio_code_comparison.csv'
+
+_REF_CODE_COL = 'Reference USEEIO Code'
+_ZENODO_WITHOUT_COL = 'Supply Chain Emission Factors without Margins'
+_BEDROCK_CODE_COL = 'Cornerstone Commodity Code'
+_BEDROCK_WITHOUT_COL = 'Supply Chain Emission Factors without Margins'
+
+
+def _zenodo_xlsx_cache_path() -> Path:
+    return _CACHE_DIR / _ZENODO_FILENAME
+
+
+def ensure_zenodo_xlsx_local(path: Path | None = None) -> Path:
+    """Download Zenodo v1.4.0 SEF workbook when missing locally."""
+    local = path or _zenodo_xlsx_cache_path()
+    if local.is_file():
+        return local
+    local.parent.mkdir(parents=True, exist_ok=True)
+    api_url = f'https://zenodo.org/api/records/{_ZENODO_RECORD_ID}'
+    logger.info('fetching Zenodo record metadata: %s', api_url)
+    with urllib.request.urlopen(api_url, timeout=120) as resp:
+        meta = json.load(resp)
+    files = meta.get('files', [])
+    match = next((f for f in files if f.get('key') == _ZENODO_FILENAME), None)
+    if match is None:
+        raise FileNotFoundError(
+            f'{_ZENODO_FILENAME!r} not found on Zenodo record {_ZENODO_RECORD_ID}'
+        )
+    download_url = match['links']['self']
+    logger.info('downloading %s -> %s', download_url, local)
+    with urllib.request.urlopen(download_url, timeout=600) as resp:
+        local.write_bytes(resp.read())
+    return local
+
+
+def _reference_code_lists_multiple_codes(value: object) -> bool:
+    return ',' in str(value).strip()
+
+
+def load_zenodo_without_margins_by_reference_code(xlsx_path: Path) -> pd.Series:
+    """Zenodo without-margins SEF indexed by Reference USEEIO Code."""
+    raw = pd.read_excel(xlsx_path, sheet_name='CO2e', engine='openpyxl')
+    if _REF_CODE_COL not in raw.columns:
+        raise KeyError(
+            f'CO2e sheet missing {_REF_CODE_COL!r}; columns={list(raw.columns)!r}'
+        )
+    if _ZENODO_WITHOUT_COL not in raw.columns:
+        raise KeyError(
+            f'CO2e sheet missing {_ZENODO_WITHOUT_COL!r}; columns={list(raw.columns)!r}'
+        )
+    df = raw[[_REF_CODE_COL, _ZENODO_WITHOUT_COL]].copy()
+    df[_REF_CODE_COL] = df[_REF_CODE_COL].astype(str).str.strip()
+    df[_ZENODO_WITHOUT_COL] = pd.to_numeric(df[_ZENODO_WITHOUT_COL], errors='coerce')
+    df = df.dropna(subset=[_REF_CODE_COL, _ZENODO_WITHOUT_COL])
+
+    multi_code_rows = df[_REF_CODE_COL].map(_reference_code_lists_multiple_codes)
+    n_multi_code = int(multi_code_rows.sum())
+    if n_multi_code > 0:
+        logger.info(
+            'excluding %d Zenodo rows whose Reference USEEIO Code lists multiple codes',
+            n_multi_code,
+        )
+    df = df.loc[~multi_code_rows]
+
+    out = (
+        df.groupby(_REF_CODE_COL, sort=True)[_ZENODO_WITHOUT_COL]
+        .mean()
+        .astype(float)
+    )
+    out.index.name = 'useeio_code'
+    return out
+
+
+def load_bedrock_without_margins(sef_csv: Path) -> pd.Series:
+    table = pd.read_csv(sef_csv)
+    if _BEDROCK_CODE_COL not in table.columns:
+        raise KeyError(f'SEF CSV missing {_BEDROCK_CODE_COL!r}')
+    codes = table[_BEDROCK_CODE_COL].astype(str).str.strip().str.removesuffix('/US')
+    values = pd.to_numeric(table[_BEDROCK_WITHOUT_COL], errors='coerce')
+    return pd.Series(values.values, index=codes, name='bedrock_without_margins')
+
+
+def compare_series(
+    bedrock: pd.Series,
+    zenodo: pd.Series,
+) -> pd.DataFrame:
+    common = bedrock.index.intersection(zenodo.index)
+    out = pd.DataFrame(
+        {
+            'useeio_code': common,
+            'bedrock_without_margins': bedrock.reindex(common).astype(float),
+            'zenodo_without_margins': zenodo.reindex(common).astype(float),
+        }
+    )
+    out['abs_diff'] = out['bedrock_without_margins'] - out['zenodo_without_margins']
+    denom = out['zenodo_without_margins'].replace(0.0, np.nan)
+    out['perc_diff'] = out['abs_diff'] / denom
+    return out.sort_values('useeio_code').reset_index(drop=True)
+
+
+def _publish_sef(config_name: str, dollar_year: int) -> Path:
+    import bedrock.utils.config.common as common
+    from bedrock.publish.cache_reset import clear_all_publish_caches
+    from bedrock.publish.emission_factors.writer import write_emission_factors
+    from bedrock.utils.config.settings import GIT_HASH_LONG
+    from bedrock.utils.config.usa_config import set_global_usa_config
+
+    if not GIT_HASH_LONG:
+        raise RuntimeError('GIT_HASH_LONG is not set')
+    out_dir = (
+        _REPO_ROOT / 'bedrock' / 'publish' / 'output' / GIT_HASH_LONG / config_name
+    )
+    clear_all_publish_caches()
+    set_global_usa_config(config_name)
+    common.download_fba_on_api_error = True
+    paths = write_emission_factors(
+        str(out_dir),
+        config_name=config_name,
+        dollar_year=dollar_year,
+        purchaser_price=True,
+    )
+    return Path(paths['co2e'])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--config_name', default='useeio_phoebe_23')
+    parser.add_argument('--dollar_year', type=int, default=2024)
+    parser.add_argument('--sef-csv', type=Path, default=None)
+    parser.add_argument('--zenodo-xlsx', type=Path, default=None)
+    parser.add_argument('--output-csv', type=Path, default=_DEFAULT_OUTPUT)
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format='%(levelname)s %(message)s')
+
+    zenodo_path = ensure_zenodo_xlsx_local(args.zenodo_xlsx)
+    zenodo = load_zenodo_without_margins_by_reference_code(zenodo_path)
+
+    if args.sef_csv is None:
+        sef_path = _publish_sef(args.config_name, args.dollar_year)
+    else:
+        sef_path = args.sef_csv
+    logger.info('bedrock SEF: %s', sef_path)
+
+    bedrock = load_bedrock_without_margins(sef_path)
+    comparison = compare_series(bedrock, zenodo)
+
+    args.output_csv.parent.mkdir(parents=True, exist_ok=True)
+    comparison.to_csv(args.output_csv, index=False)
+
+    perc = comparison['perc_diff'].dropna()
+    logger.info(
+        'joined sectors=%d bedrock-only=%d zenodo-only=%d',
+        len(comparison),
+        len(bedrock.index.difference(zenodo.index)),
+        len(zenodo.index.difference(bedrock.index)),
+    )
+    if not perc.empty:
+        logger.info(
+            'perc_diff vs Zenodo (Reference USEEIO Code): median=%.4f std=%.4f',
+            float(perc.median()),
+            float(perc.std()),
+        )
+    logger.info('wrote %s', args.output_csv)
+    logger.info('Zenodo source: https://doi.org/%s', _ZENODO_DOI)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/bedrock/analysis/margins/compare_sef_zenodo_useeio_code.py
+++ b/bedrock/analysis/margins/compare_sef_zenodo_useeio_code.py
@@ -26,6 +26,12 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
+import bedrock.utils.config.common as common
+from bedrock.publish.cache_reset import clear_all_publish_caches
+from bedrock.publish.emission_factors.writer import write_emission_factors
+from bedrock.utils.config.settings import GIT_HASH_LONG
+from bedrock.utils.config.usa_config import set_global_usa_config
+
 logger = logging.getLogger(__name__)
 
 _PKG_DIR = Path(__file__).resolve().parent
@@ -100,11 +106,7 @@ def load_zenodo_without_margins_by_reference_code(xlsx_path: Path) -> pd.Series:
         )
     df = df.loc[~multi_code_rows]
 
-    out = (
-        df.groupby(_REF_CODE_COL, sort=True)[_ZENODO_WITHOUT_COL]
-        .mean()
-        .astype(float)
-    )
+    out = df.groupby(_REF_CODE_COL, sort=True)[_ZENODO_WITHOUT_COL].mean().astype(float)
     out.index.name = 'useeio_code'
     return out
 
@@ -137,12 +139,6 @@ def compare_series(
 
 
 def _publish_sef(config_name: str, dollar_year: int) -> Path:
-    import bedrock.utils.config.common as common
-    from bedrock.publish.cache_reset import clear_all_publish_caches
-    from bedrock.publish.emission_factors.writer import write_emission_factors
-    from bedrock.utils.config.settings import GIT_HASH_LONG
-    from bedrock.utils.config.usa_config import set_global_usa_config
-
     if not GIT_HASH_LONG:
         raise RuntimeError('GIT_HASH_LONG is not set')
     out_dir = (

--- a/bedrock/publish/README.md
+++ b/bedrock/publish/README.md
@@ -19,9 +19,9 @@ shareable file formats, mirroring the shape of `useeior`'s
   configs via `bedrock.publish.emission_factors`. Emits a long-form CO2e
   table (`CornerstoneSupplyChainGHG_CO2e_USD<year>.csv`) with three
   supply-chain factor columns (without margins, margins, with margins).
-  Purchaser-price adjustment applies PRO:PUR (Phi) from
-  `derive_phi_cornerstone_usa()` and rebases denominators from
-  `model_base_year` to `--dollar_year` via commodity price indices.
+  Purchaser-price adjustment applies PRO:PUR (Phi) at ``--dollar_year``
+  after rebasing producer N from ``model_base_year`` to ``--dollar_year``
+  via commodity price indices (matches supply-chain-factors ``Phi[currency_year]``).
   Margin SEF column remains zero until `N_margin` is wired.
   CLI: `--purchaser_price` / `--no-purchaser_price` (default on).
 - **Supply-chain factors (R repo)**: not ported. Upstream counterpart:
@@ -33,9 +33,8 @@ shareable file formats, mirroring the shape of `useeior`'s
   `B_imp` lands.
 - **`Phi` sheet**: emitted when `useeio_margins` or
   `cornerstone_industry_avg_margins` is active (`get_Phi()` in
-  `model_objects.py`). Values are at **`model_base_year` only** (one
-  column per config, e.g. 2017 for `useeio_phoebe_23`); not a full
-  year panel like useeior's `Phi` matrix yet.
+  `model_objects.py`). Sector × year panel for years with BEA price-index
+  coverage from ``usa_base_io_data_year`` onward (~2017–2025).
 - **Useeior-only valuation matrices** (`Rho`, `Tau`) and long-form
   metadata (`demands`, `SectorCrosswalk`): registered as placeholders.
 
@@ -175,7 +174,8 @@ used by the XLSX publisher).
 | Artifact | Automated test | Year / basis |
 |----------|----------------|--------------|
 | `Phi` sheet vs pinned phoebe USEEIO workbook | `test_published_phi_matches_useeio_workbook` (`eeio_integration`) | Workbook **`Phi` column `model_base_year`** only (2017 on phoebe pin) |
-| SEF CSV wiring (Phi × CPI on `N`) | `test_sef_phi_wiring` (`eeio_integration`) | Export at `--dollar_year` (test uses 2024); **Phi stays at `model_base_year` (2017)** |
-| SEF vs [supply-chain-factors](https://github.com/cornerstone-data/supply-chain-factors) or Zenodo NAICS publish | None in bedrock | Not in scope for Phi PR (#449) |
+| SEF CSV wiring (Phi × CPI on `N`) | `test_sef_phi_wiring` (`eeio_integration`) | Export at `--dollar_year` (test uses 2024); **Phi at `dollar_year`** after CPI |
+| Phi panel vs phoebe workbook | `test_published_phi_matches_useeio_workbook` (`eeio_integration`) | Column **2017** (1% rtol); full panel in Excel |
+| SEF vs Zenodo v1.4.0 on Reference USEEIO Code | `bedrock.analysis.margins.compare_sef_zenodo_useeio_code` (manual) | Collapses NAICS rows; not CI |
 
 Default `uv run pytest` excludes `eeio_integration`; run `-m eeio_integration` for workbook Phi parity and SEF wiring tests.

--- a/bedrock/publish/README.md
+++ b/bedrock/publish/README.md
@@ -35,8 +35,12 @@ shareable file formats, mirroring the shape of `useeior`'s
   `cornerstone_industry_avg_margins` is active (`get_Phi()` in
   `model_objects.py`). Sector × year panel for years with BEA price-index
   coverage from ``usa_base_io_data_year`` onward (~2017–2025).
-- **Useeior-only valuation matrices** (`Rho`, `Tau`) and long-form
-  metadata (`demands`, `SectorCrosswalk`): registered as placeholders.
+- **`Rho` sheet**: emitted under the same margin flags (`get_Rho()` in
+  `model_objects.py`). Sector × year panel, always useeior convention:
+  sector 1:1 ``PI[IO]/PI[y]`` from ``derive_price_index_panel`` (independent
+  of which margin inflation path ``get_price_index_ratio`` uses).
+- **Useeior-only valuation matrices** (`Tau`) and long-form metadata
+  (`demands`, `SectorCrosswalk`): registered as placeholders.
 
 ## Known divergence from useeior (B units)
 

--- a/bedrock/publish/__tests__/test_sef_phi_wiring.py
+++ b/bedrock/publish/__tests__/test_sef_phi_wiring.py
@@ -36,7 +36,7 @@ def test_sef_applies_phi_and_dollar_year() -> None:
         n_producer = get_N().loc[GREENHOUSE_GASES_INDICATOR].astype(float)
         pi = get_vnorm_adjusted_commodity_price_ratio(cfg.model_base_year, dollar_year)
         n_producer_cpi = n_producer / pi.reindex(n_producer.index, fill_value=1.0)
-        phi = phi_for_sectors(n_producer.index)
+        phi = phi_for_sectors(n_producer.index, year=dollar_year)
 
         for _, row in table.iterrows():
             code = str(row['Cornerstone Commodity Code']).removesuffix('/US')

--- a/bedrock/publish/__tests__/test_sef_vs_useeio_baseline.py
+++ b/bedrock/publish/__tests__/test_sef_vs_useeio_baseline.py
@@ -11,11 +11,7 @@ import pytest
 import bedrock.utils.config.common as common
 from bedrock.publish.__tests__._helpers import clear_all_caches, teardown
 from bedrock.publish.model_objects import PUBLISH_LOCATION, get_Phi
-from bedrock.utils.config.usa_config import (
-    get_usa_config,
-    reset_usa_config,
-    set_global_usa_config,
-)
+from bedrock.utils.config.usa_config import reset_usa_config, set_global_usa_config
 from bedrock.utils.validation.useeio_excel_baseline import (
     _local_cache_path,
     ensure_useeio_xlsx_local,
@@ -74,10 +70,10 @@ def _load_workbook_phi(xlsx_path: str, year: int) -> pd.Series:
 
 
 @pytest.mark.eeio_integration
-def test_published_phi_matches_useeio_workbook() -> None:
+@pytest.mark.parametrize('year', [2017])
+def test_published_phi_matches_useeio_workbook(year: int) -> None:
     try:
         pin = _setup_phoebe_with_useeio_pin()
-        cfg = get_usa_config()
         xlsx = _local_cache_path(pin['useeio_baseline_xlsx_gs_uri'])
         ensure_useeio_xlsx_local(
             pin['useeio_baseline_xlsx_gs_uri'],
@@ -86,10 +82,14 @@ def test_published_phi_matches_useeio_workbook() -> None:
         )
         bedrock_phi_df = get_Phi()
         assert bedrock_phi_df is not None
-        bedrock_phi = bedrock_phi_df[str(cfg.model_base_year)].astype(float)
+        year_str = str(year)
+        assert (
+            year_str in bedrock_phi_df.columns
+        ), f'bedrock Phi panel missing column {year_str!r}'
+        bedrock_phi = bedrock_phi_df[year_str].astype(float)
         bedrock_phi.index = _strip_loc_suffix(bedrock_phi.index)
 
-        ref_phi = _load_workbook_phi(xlsx, cfg.model_base_year)
+        ref_phi = _load_workbook_phi(xlsx, year)
         common_sectors = bedrock_phi.index.intersection(ref_phi.index)
         assert len(common_sectors) > 100
         np.testing.assert_allclose(

--- a/bedrock/publish/cache_reset.py
+++ b/bedrock/publish/cache_reset.py
@@ -36,6 +36,10 @@ from bedrock.transform.eeio.derived_cornerstone import (
     derive_cornerstone_y_nab,
     derive_cornerstone_Ytot_matrix_set,
 )
+from bedrock.transform.iot.derive_PRO_to_PUR_ratio import (
+    derive_margins_cornerstone_usa_at_year,
+    derive_phi_cornerstone_usa_at_year,
+)
 
 UPSTREAM_CACHED_DERIVES: list[Callable[..., object]] = [
     derive_B_usa_non_finetuned,
@@ -61,6 +65,8 @@ UPSTREAM_CACHED_DERIVES: list[Callable[..., object]] = [
     derive_cornerstone_y_nab,
     load_2017_margins_before_redef_usa,
     load_2017_margins_after_redef_usa,
+    derive_margins_cornerstone_usa_at_year,
+    derive_phi_cornerstone_usa_at_year,
 ]
 
 

--- a/bedrock/publish/cache_reset.py
+++ b/bedrock/publish/cache_reset.py
@@ -41,6 +41,10 @@ from bedrock.transform.iot.derive_PRO_to_PUR_ratio import (
     derive_phi_cornerstone_usa_at_year,
     derive_phi_cornerstone_usa_panel,
 )
+from bedrock.utils.economic.inflation_helpers_cornerstone import (
+    derive_price_index_panel,
+    get_price_index_ratio,
+)
 
 UPSTREAM_CACHED_DERIVES: list[Callable[..., object]] = [
     derive_B_usa_non_finetuned,
@@ -69,6 +73,8 @@ UPSTREAM_CACHED_DERIVES: list[Callable[..., object]] = [
     derive_margins_cornerstone_usa_at_year,
     derive_phi_cornerstone_usa_at_year,
     derive_phi_cornerstone_usa_panel,
+    derive_price_index_panel,
+    get_price_index_ratio,
 ]
 
 

--- a/bedrock/publish/cache_reset.py
+++ b/bedrock/publish/cache_reset.py
@@ -39,6 +39,7 @@ from bedrock.transform.eeio.derived_cornerstone import (
 from bedrock.transform.iot.derive_PRO_to_PUR_ratio import (
     derive_margins_cornerstone_usa_at_year,
     derive_phi_cornerstone_usa_at_year,
+    derive_phi_cornerstone_usa_panel,
 )
 
 UPSTREAM_CACHED_DERIVES: list[Callable[..., object]] = [
@@ -67,6 +68,7 @@ UPSTREAM_CACHED_DERIVES: list[Callable[..., object]] = [
     load_2017_margins_after_redef_usa,
     derive_margins_cornerstone_usa_at_year,
     derive_phi_cornerstone_usa_at_year,
+    derive_phi_cornerstone_usa_panel,
 ]
 
 

--- a/bedrock/publish/emission_factors/placeholders.py
+++ b/bedrock/publish/emission_factors/placeholders.py
@@ -35,7 +35,7 @@ def adjust_publish_matrix(
         out = out.div(price_ratio_for_columns.values, axis=1)
 
     if purchaser_price:
-        phi = phi_for_sectors(out.columns)
+        phi = phi_for_sectors(out.columns, year=dollar_year)
         out = out.mul(phi.reindex(out.columns, fill_value=1.0).values, axis=1)
 
     return out

--- a/bedrock/publish/excel/writer.py
+++ b/bedrock/publish/excel/writer.py
@@ -85,6 +85,7 @@ from bedrock.publish.model_objects import (
     get_Ndom,
     get_Phi,
     get_q,
+    get_Rho,
     get_U,
     get_Udom,
     get_V,
@@ -295,7 +296,7 @@ def _build_matrix_registry(config_name: str) -> list[SheetSpec]:
         SheetSpec('N', get_N),
         SheetSpec('N_d', get_Ndom),
         SheetSpec('N_m', lambda: None),  # requires B_imp
-        SheetSpec('Rho', lambda: None),
+        SheetSpec('Rho', get_Rho),
         SheetSpec('Phi', get_Phi),
         SheetSpec('Tau', lambda: None),
         # --- outputs (useeior writes these after the matrices block) ---

--- a/bedrock/publish/model_objects.py
+++ b/bedrock/publish/model_objects.py
@@ -226,6 +226,24 @@ def get_Phi() -> pd.DataFrame | None:
     return out
 
 
+@functools.cache
+def get_Rho() -> pd.DataFrame | None:
+    """useeior-style Rho panel per sector (Excel ``Rho`` sheet)."""
+    from bedrock.transform.iot.derive_PRO_to_PUR_ratio import margins_phi_active
+    from bedrock.utils.economic.inflation_helpers_cornerstone import (
+        default_price_index_panel_years,
+        derive_price_index_panel,
+    )
+
+    if not margins_phi_active():
+        return None
+    sectors = get_N().columns
+    panel = derive_price_index_panel(default_price_index_panel_years())
+    out = panel.reindex(sectors).astype(float)
+    out.index.name = 'sector'
+    return out
+
+
 _CACHED_GETTERS: tuple[Callable[[], pd.DataFrame | pd.Series | None], ...] = (
     get_V,
     get_U,
@@ -243,6 +261,7 @@ _CACHED_GETTERS: tuple[Callable[[], pd.DataFrame | pd.Series | None], ...] = (
     get_N,
     get_Ndom,
     get_Phi,
+    get_Rho,
     get_q,
 )
 

--- a/bedrock/publish/model_objects.py
+++ b/bedrock/publish/model_objects.py
@@ -210,21 +210,18 @@ def get_q() -> pd.Series:
 
 @functools.cache
 def get_Phi() -> pd.DataFrame | None:
-    """Producer-to-purchaser ratio per sector for ``model_base_year`` (Excel ``Phi`` sheet)."""
+    """Producer-to-purchaser ratio panel per sector (Excel ``Phi`` sheet)."""
     from bedrock.transform.iot.derive_PRO_to_PUR_ratio import (
+        default_phi_panel_years,
+        derive_phi_cornerstone_usa_panel,
         margins_phi_active,
-        phi_for_sectors,
     )
 
     if not margins_phi_active():
         return None
-    cfg = get_usa_config()
     sectors = get_N().columns
-    phi = phi_for_sectors(sectors)
-    out = pd.DataFrame(
-        {str(cfg.model_base_year): phi.astype(float).values},
-        index=phi.index,
-    )
+    panel = derive_phi_cornerstone_usa_panel(default_phi_panel_years())
+    out = panel.reindex(sectors).astype(float)
     out.index.name = 'sector'
     return out
 

--- a/bedrock/transform/iot/__tests__/test_phi_helpers.py
+++ b/bedrock/transform/iot/__tests__/test_phi_helpers.py
@@ -28,11 +28,14 @@ class TestMarginsPhiActive:
     'bedrock.transform.iot.derive_PRO_to_PUR_ratio.margins_phi_active',
     return_value=True,
 )
-@patch('bedrock.transform.iot.derive_PRO_to_PUR_ratio.derive_phi_cornerstone_usa')
+@patch(
+    'bedrock.transform.iot.derive_PRO_to_PUR_ratio.derive_phi_cornerstone_usa_at_year'
+)
 def test_apply_phi_to_ef_vector(mock_phi: MagicMock, _mock_active: MagicMock) -> None:
     mock_phi.return_value = pd.Series({'1111A0': 0.5, '221100': 0.8})
     ef = pd.Series({'1111A0': 10.0, '221100': 20.0, '311111': 2.0})
-    got = apply_phi_to_ef_vector(ef)
+    got = apply_phi_to_ef_vector(ef, year=2024)
+    mock_phi.assert_called_once_with(2024)
     assert got['1111A0'] == 5.0
     assert got['221100'] == 16.0
     assert got['311111'] == 2.0

--- a/bedrock/transform/iot/derive_PRO_to_PUR_ratio.py
+++ b/bedrock/transform/iot/derive_PRO_to_PUR_ratio.py
@@ -21,6 +21,9 @@ import pandas as pd
 from bedrock.extract.iot.io_2017 import load_2017_margins_usa
 from bedrock.transform.eeio.derived_2017_helpers import EXPANDED_SECTORS_2012_TO_2017
 from bedrock.utils.config.usa_config import USAConfig, get_usa_config
+from bedrock.utils.economic.inflation_helpers_ceda import (
+    obtain_inflation_factors_from_reference_data,
+)
 from bedrock.utils.economic.inflation_helpers_cornerstone import (
     get_rho_inflation_ratio,
     get_sector_commodity_price_ratio,
@@ -358,19 +361,51 @@ def derive_phi_cornerstone_usa() -> pd.Series[float]:
     return derive_phi_cornerstone_usa_at_year(get_usa_config().model_base_year)
 
 
+def default_phi_panel_years() -> tuple[int, ...]:
+    """Years with price-index coverage for Phi panel export (from IO base year onward)."""
+    cfg = get_usa_config()
+    base = cfg.usa_base_io_data_year
+    years = sorted(
+        int(y) for y in obtain_inflation_factors_from_reference_data().columns
+    )
+    return tuple(y for y in years if y >= base)
+
+
+@functools.cache
+def derive_phi_cornerstone_usa_panel(years: tuple[int, ...]) -> pd.DataFrame:
+    """Sector × year Phi panel; column labels are year strings."""
+    if not years:
+        raise ValueError('years must be non-empty')
+    series_by_year = {
+        str(year): derive_phi_cornerstone_usa_at_year(year) for year in years
+    }
+    return pd.DataFrame(series_by_year)
+
+
 def margins_phi_active(cfg: USAConfig | None = None) -> bool:
     """Return whether margins-based Phi should be applied for *cfg*."""
     c = cfg or get_usa_config()
     return bool(c.useeio_margins or c.cornerstone_industry_avg_margins)
 
 
-def phi_for_sectors(sector_index: pd.Index) -> pd.Series[float]:
-    """Phi aligned to *sector_index*; identity when margins methodology is inactive."""
+def phi_for_sectors(
+    sector_index: pd.Index,
+    *,
+    year: int | None = None,
+) -> pd.Series[float]:
+    """Phi aligned to *sector_index* at *year* USD; identity when margins inactive."""
     if not margins_phi_active():
         return pd.Series(1.0, index=sector_index, dtype=float)
-    return derive_phi_cornerstone_usa().reindex(sector_index, fill_value=1.0)
+    phi_year = year if year is not None else get_usa_config().model_base_year
+    return derive_phi_cornerstone_usa_at_year(phi_year).reindex(
+        sector_index, fill_value=1.0
+    )
 
 
-def apply_phi_to_ef_vector(ef: pd.Series[float]) -> pd.Series[float]:
-    """Convert producer-price EFs to purchaser price via sector Phi."""
-    return ef * phi_for_sectors(ef.index)
+def apply_phi_to_ef_vector(
+    ef: pd.Series[float],
+    *,
+    year: int | None = None,
+) -> pd.Series[float]:
+    """Convert producer-price EFs to purchaser price via sector Phi at *year*."""
+    return ef * phi_for_sectors(ef.index, year=year)

--- a/bedrock/transform/iot/derive_PRO_to_PUR_ratio.py
+++ b/bedrock/transform/iot/derive_PRO_to_PUR_ratio.py
@@ -21,13 +21,10 @@ import pandas as pd
 from bedrock.extract.iot.io_2017 import load_2017_margins_usa
 from bedrock.transform.eeio.derived_2017_helpers import EXPANDED_SECTORS_2012_TO_2017
 from bedrock.utils.config.usa_config import USAConfig, get_usa_config
-from bedrock.utils.economic.inflation_helpers_ceda import (
-    obtain_inflation_factors_from_reference_data,
-)
 from bedrock.utils.economic.inflation_helpers_cornerstone import (
-    get_rho_inflation_ratio,
+    default_price_index_panel_years,
+    get_price_index_ratio,
     get_sector_commodity_price_ratio,
-    get_vnorm_adjusted_commodity_price_ratio,
 )
 from bedrock.utils.taxonomy.bea.v2017_final_demand import USA_2017_FINAL_DEMAND_CODES
 from bedrock.utils.taxonomy.usa_taxonomy_correspondence_helpers import (
@@ -266,30 +263,6 @@ def _inflate_margin_trade_components(
     return out
 
 
-def _inflate_margins_bedrock_style(
-    df: pd.DataFrame, *, original_year: int, target_year: int
-) -> pd.DataFrame:
-    """Inflate producer margin with V-norm commodity PI (Cornerstone convention)."""
-    out = df.copy()
-    commodity_pi = get_vnorm_adjusted_commodity_price_ratio(original_year, target_year)
-    out["Producers' Value"] *= commodity_pi.reindex(out.index, fill_value=1.0)
-    return _inflate_margin_trade_components(
-        out, original_year=original_year, target_year=target_year
-    )
-
-
-def _inflate_margins_useeior_style(
-    df: pd.DataFrame, *, original_year: int, target_year: int
-) -> pd.DataFrame:
-    """Inflate producer margin with per-sector Rho (useeior convention)."""
-    out = df.copy()
-    rho = get_rho_inflation_ratio(original_year, target_year)
-    out["Producers' Value"] *= rho.reindex(out.index, fill_value=1.0)
-    return _inflate_margin_trade_components(
-        out, original_year=original_year, target_year=target_year
-    )
-
-
 def _inflate_margins_to_year(df: pd.DataFrame, *, target_year: int) -> pd.DataFrame:
     """Inflate margin components from ``usa_base_io_data_year`` to *target_year*."""
     cfg = get_usa_config()
@@ -298,12 +271,11 @@ def _inflate_margins_to_year(df: pd.DataFrame, *, target_year: int) -> pd.DataFr
     original_year = cfg.usa_base_io_data_year
     if original_year == target_year:
         return df
-    if cfg.useeio_margins:
-        return _inflate_margins_useeior_style(
-            df, original_year=original_year, target_year=target_year
-        )
-    return _inflate_margins_bedrock_style(
-        df, original_year=original_year, target_year=target_year
+    out = df.copy()
+    pro_ratio = get_price_index_ratio(original_year, target_year)
+    out["Producers' Value"] *= pro_ratio.reindex(out.index, fill_value=1.0)
+    return _inflate_margin_trade_components(
+        out, original_year=original_year, target_year=target_year
     )
 
 
@@ -363,12 +335,7 @@ def derive_phi_cornerstone_usa() -> pd.Series[float]:
 
 def default_phi_panel_years() -> tuple[int, ...]:
     """Years with price-index coverage for Phi panel export (from IO base year onward)."""
-    cfg = get_usa_config()
-    base = cfg.usa_base_io_data_year
-    years = sorted(
-        int(y) for y in obtain_inflation_factors_from_reference_data().columns
-    )
-    return tuple(y for y in years if y >= base)
+    return default_price_index_panel_years()
 
 
 @functools.cache

--- a/bedrock/transform/iot/derive_PRO_to_PUR_ratio.py
+++ b/bedrock/transform/iot/derive_PRO_to_PUR_ratio.py
@@ -13,6 +13,7 @@ unless otherwise specified
 from __future__ import annotations
 
 import dataclasses
+import functools
 
 import numpy as np
 import pandas as pd
@@ -21,6 +22,7 @@ from bedrock.extract.iot.io_2017 import load_2017_margins_usa
 from bedrock.transform.eeio.derived_2017_helpers import EXPANDED_SECTORS_2012_TO_2017
 from bedrock.utils.config.usa_config import USAConfig, get_usa_config
 from bedrock.utils.economic.inflation_helpers_cornerstone import (
+    get_rho_inflation_ratio,
     get_sector_commodity_price_ratio,
     get_vnorm_adjusted_commodity_price_ratio,
 )
@@ -249,14 +251,68 @@ def derive_phi_ceda_usa() -> pd.Series[float]:
     return phi
 
 
-def derive_margins_cornerstone_usa() -> pd.DataFrame:
+def _inflate_margin_trade_components(
+    df: pd.DataFrame, *, original_year: int, target_year: int
+) -> pd.DataFrame:
+    """Scale transportation, wholesale, and retail margin columns to *target_year*."""
+    sector_pi = get_sector_commodity_price_ratio(original_year, target_year)
+    out = df.copy()
+    out['Transportation'] *= sector_pi['48TW']
+    out['Wholesale'] *= sector_pi['42']
+    out['Retail'] *= sector_pi['44RT']
+    return out
+
+
+def _inflate_margins_bedrock_style(
+    df: pd.DataFrame, *, original_year: int, target_year: int
+) -> pd.DataFrame:
+    """Inflate producer margin with V-norm commodity PI (Cornerstone convention)."""
+    out = df.copy()
+    commodity_pi = get_vnorm_adjusted_commodity_price_ratio(original_year, target_year)
+    out["Producers' Value"] *= commodity_pi.reindex(out.index, fill_value=1.0)
+    return _inflate_margin_trade_components(
+        out, original_year=original_year, target_year=target_year
+    )
+
+
+def _inflate_margins_useeior_style(
+    df: pd.DataFrame, *, original_year: int, target_year: int
+) -> pd.DataFrame:
+    """Inflate producer margin with per-sector Rho (useeior convention)."""
+    out = df.copy()
+    rho = get_rho_inflation_ratio(original_year, target_year)
+    out["Producers' Value"] *= rho.reindex(out.index, fill_value=1.0)
+    return _inflate_margin_trade_components(
+        out, original_year=original_year, target_year=target_year
+    )
+
+
+def _inflate_margins_to_year(df: pd.DataFrame, *, target_year: int) -> pd.DataFrame:
+    """Inflate margin components from ``usa_base_io_data_year`` to *target_year*."""
+    cfg = get_usa_config()
+    if not (cfg.useeio_margins or cfg.cornerstone_industry_avg_margins):
+        return df
+    original_year = cfg.usa_base_io_data_year
+    if original_year == target_year:
+        return df
+    if cfg.useeio_margins:
+        return _inflate_margins_useeior_style(
+            df, original_year=original_year, target_year=target_year
+        )
+    return _inflate_margins_bedrock_style(
+        df, original_year=original_year, target_year=target_year
+    )
+
+
+@functools.cache
+def derive_margins_cornerstone_usa_at_year(target_year: int) -> pd.DataFrame:
     """
     Margins aggregated to Cornerstone commodity taxonomy, summed over all industries.
-    Routes before/after BEA redefinitions via ``USAConfig.iot_before_or_after_redefinition``.
-    Applies the active pipeline's ``MarginsFilters`` before aggregation.
 
-    When both ``useeio_margins`` and ``cornerstone_industry_avg_margins`` are set,
-    inflates from ``usa_base_io_data_year`` to ``model_base_year``.
+    Margin components inflate from ``usa_base_io_data_year`` to *target_year* when
+    a margins methodology flag is active. PRO inflation follows the useeior ``Rho``
+    path when ``useeio_margins`` is set; otherwise the V-norm commodity PI path
+    (``cornerstone_industry_avg_margins``).
 
     Returns a DataFrame indexed by Cornerstone ``COMMODITIES`` with columns:
     ``Producers' Value``, ``Transportation``, ``Wholesale``, ``Retail``,
@@ -269,42 +325,37 @@ def derive_margins_cornerstone_usa() -> pd.DataFrame:
         abs_negative_producers_value=cfg.useeio_margins,
         abs_negative_margin_columns=cfg.cornerstone_industry_avg_margins,
     )
-
-    if cfg.useeio_margins or cfg.cornerstone_industry_avg_margins:
-        original_year = cfg.usa_base_io_data_year
-        target_year = cfg.model_base_year
-        if original_year != target_year:
-            commodity_pi = get_vnorm_adjusted_commodity_price_ratio(
-                original_year, target_year
-            )
-            df["Producers' Value"] *= commodity_pi.reindex(df.index, fill_value=1.0)
-
-            sector_pi = get_sector_commodity_price_ratio(original_year, target_year)
-            df['Transportation'] *= sector_pi['48TW']
-            df['Wholesale'] *= sector_pi['42']
-            df['Retail'] *= sector_pi['44RT']
-
+    df = _inflate_margins_to_year(df, target_year=target_year)
     df["Purchasers' Value"] = (
         df["Producers' Value"] + df['Transportation'] + df['Wholesale'] + df['Retail']
     )
-
     return df
 
 
-def derive_phi_cornerstone_usa() -> pd.Series:
-    """
-    Phi (Producer-to-purchaser price ratio) per Cornerstone commodity for
-    model_base_year.
+def derive_margins_cornerstone_usa() -> pd.DataFrame:
+    """Margins at ``model_base_year`` (alias for :func:`derive_margins_cornerstone_usa_at_year`)."""
+    return derive_margins_cornerstone_usa_at_year(get_usa_config().model_base_year)
 
-    Computed as ``Producers' Value / Purchasers' Value`` from the margins table.
-    Rows where the purchaser price is zero (``inf`` / ``nan``) are set to ``1.0``
-    (no margin adjustment). Routes before/after BEA redefinitions via
-    ``USAConfig.iot_before_or_after_redefinition``.
-    """
-    margins = derive_margins_cornerstone_usa()
+
+def _phi_from_margins(margins: pd.DataFrame) -> pd.Series[float]:
     return (margins["Producers' Value"] / margins["Purchasers' Value"]).replace(
         [np.inf, -np.inf, np.nan], 1.0
     )
+
+
+@functools.cache
+def derive_phi_cornerstone_usa_at_year(target_year: int) -> pd.Series[float]:
+    """
+    Phi (PRO:PUR) per Cornerstone commodity for *target_year* USD margins.
+
+    Rows where purchaser price is zero (``inf`` / ``nan``) are set to ``1.0``.
+    """
+    return _phi_from_margins(derive_margins_cornerstone_usa_at_year(target_year))
+
+
+def derive_phi_cornerstone_usa() -> pd.Series[float]:
+    """Phi at ``model_base_year``."""
+    return derive_phi_cornerstone_usa_at_year(get_usa_config().model_base_year)
 
 
 def margins_phi_active(cfg: USAConfig | None = None) -> bool:

--- a/bedrock/utils/config/configs/useeio_phoebe_23_cornerstone_margins.yaml
+++ b/bedrock/utils/config/configs/useeio_phoebe_23_cornerstone_margins.yaml
@@ -1,0 +1,39 @@
+# Sensitivity from useeio_phoebe_23: Cornerstone industry-average margins.
+# Identical rebuild to useeio_phoebe_23 except margin inflation uses
+# cornerstone_industry_avg_margins (V-norm commodity PI on PRO) instead of
+# useeio_margins (sector Rho on PRO). B, L, N, and GHG flags are unchanged.
+
+#####
+# Model base settings
+#####
+model_base_year: 2017
+iot_before_or_after_redefinition: before
+
+#####
+# Data selection
+#####
+usa_io_data_year: 2017
+usa_ghg_data_year: 2023
+
+#####
+# Methodology selection
+#####
+use_cornerstone_2026_model_schema: true
+load_E_from_flowsa: true
+use_E_data_year_for_x_in_B: true
+implement_waste_disaggregation: true
+
+scale_a_matrix_with_useeio_method: true
+
+use_useeio_schema: true
+deflate_x_to_detail_io_year_for_B: true
+use_ghg_national_2023_m2: true
+skip_scrap_adjustment_in_vnorm: true
+
+new_ghg_method: false
+
+#####
+# Margins (single change vs useeio_phoebe_23)
+#####
+useeio_margins: false
+cornerstone_industry_avg_margins: true

--- a/bedrock/utils/economic/__tests__/test_inflation_helpers_cornerstone.py
+++ b/bedrock/utils/economic/__tests__/test_inflation_helpers_cornerstone.py
@@ -5,8 +5,20 @@ from bedrock.transform.eeio.derived_cornerstone import (
 )
 from bedrock.utils.config.usa_config import get_usa_config
 from bedrock.utils.economic.inflation_helpers_cornerstone import (
+    get_cornerstone_industry_price_ratio,
+    get_rho_inflation_ratio,
     get_vnorm_adjusted_commodity_price_ratio,
 )
+
+
+def test_rho_inflation_ratio_is_inverse_of_industry_price_ratio() -> None:
+    """useeior PRO margin scaling uses PI[orig]/PI[targ], not PI[targ]/PI[orig]."""
+    original_year, target_year = 2017, 2024
+    industry = get_cornerstone_industry_price_ratio(original_year, target_year)
+    rho = get_rho_inflation_ratio(original_year, target_year)
+    product = (industry * rho).replace([float("inf"), float("-inf")], float("nan"))
+    max_dev = (product - 1.0).abs().max()
+    assert max_dev < 1e-9, f"expected industry * rho == 1, max deviation {max_dev:.2e}"
 
 
 def test_vnorm_commodity_price_ratio_is_identity_at_year_to_self() -> None:

--- a/bedrock/utils/economic/inflation_helpers_cornerstone.py
+++ b/bedrock/utils/economic/inflation_helpers_cornerstone.py
@@ -108,22 +108,74 @@ def get_cornerstone_industry_price_ratio(
 
 @functools.cache
 def get_rho_inflation_ratio(original_year: int, target_year: int) -> pd.Series[float]:
-    """Sector-specific USD inflation factor from *original_year* to *target_year*.
+    """Sector 1:1 price-index ratio ``PI[original] / PI[target]``.
 
     Matches useeior ``Rho[target] / Rho[original]`` when ``Rho[y]`` is the
     per-sector ``IO_year / y`` ratio from the model commodity CPI table
-    (``calculateProducerbyPurchaserPriceRatio`` PRO scaling). Implemented as
-    ``PI[original] / PI[target]`` on the same 1:1 sector index as
-    ``get_cornerstone_industry_price_ratio``.
+    (``calculateProducerbyPurchaserPriceRatio``). Implemented on the same
+    1:1 sector index as ``get_cornerstone_industry_price_ratio``.
 
-    Independent of margins, Phi, and ``N``; sourced only from the configured
-    industry price-index panel.
+    This is the ``useeio_margins`` branch of ``get_price_index_ratio``; kept
+    as a named primitive for sector-level index math and tests.
     """
     if original_year == target_year:
         return get_cornerstone_industry_price_ratio(original_year, target_year)
     forward = get_cornerstone_industry_price_ratio(original_year, target_year)
     ratio = 1.0 / forward
     return ratio.where(np.isfinite(ratio), 1.0).fillna(1.0)
+
+
+def default_price_index_panel_years() -> tuple[int, ...]:
+    """Years with price-index coverage for panel export (from IO base year onward)."""
+    cfg = get_usa_config()
+    base = cfg.usa_base_io_data_year
+    years = sorted(
+        int(y) for y in obtain_inflation_factors_from_reference_data().columns
+    )
+    return tuple(y for y in years if y >= base)
+
+
+@functools.cache
+def derive_price_index_panel(years: tuple[int, ...]) -> pd.DataFrame:
+    """Sector × year Rho panel (useeior convention).
+
+    Per-sector ``PI[IO_year] / PI[y]`` on cornerstone commodity codes (sector
+    1:1). Same definition regardless of margin config; feeds Excel ``Rho``.
+    Margin inflation uses ``get_price_index_ratio``, which may differ under
+    ``cornerstone_industry_avg_margins``.
+
+    Column labels are year strings.
+    """
+    if not years:
+        raise ValueError('years must be non-empty')
+    io_year = get_usa_config().usa_base_io_data_year
+    series_by_year: dict[str, pd.Series[float]] = {
+        str(year): get_rho_inflation_ratio(io_year, year) for year in years
+    }
+    return pd.DataFrame(series_by_year)
+
+
+@functools.cache
+def get_price_index_ratio(original_year: int, target_year: int) -> pd.Series[float]:
+    """Cross-year price-index ratio for the active config construction.
+
+    ``useeio_margins``: sector 1:1 ``PI[original] / PI[target]`` (Rho approach).
+
+    ``cornerstone_industry_avg_margins``: V-norm commodity
+    ``PI[target] / PI[original]``.
+
+    Used when inflating PRO margins and (in follow-up work) rebasing ``N`` for
+    publish. Distinct from the Excel ``Rho`` panel (``derive_price_index_panel``),
+    which always uses the useeior sector 1:1 convention.
+    """
+    cfg = get_usa_config()
+    if cfg.useeio_margins:
+        return get_rho_inflation_ratio(original_year, target_year)
+    if cfg.cornerstone_industry_avg_margins:
+        return get_vnorm_adjusted_commodity_price_ratio(original_year, target_year)
+    return pd.Series(
+        1.0, index=pd.Index(CORNERSTONE_COMMODITIES, dtype=object), dtype=float
+    )
 
 
 def inflate_cornerstone_A_matrix_with_industry_pi(

--- a/bedrock/utils/economic/inflation_helpers_cornerstone.py
+++ b/bedrock/utils/economic/inflation_helpers_cornerstone.py
@@ -106,6 +106,26 @@ def get_cornerstone_industry_price_ratio(
     return ratio
 
 
+@functools.cache
+def get_rho_inflation_ratio(original_year: int, target_year: int) -> pd.Series[float]:
+    """Sector-specific USD inflation factor from *original_year* to *target_year*.
+
+    Matches useeior ``Rho[target] / Rho[original]`` when ``Rho[y]`` is the
+    per-sector ``IO_year / y`` ratio from the model commodity CPI table
+    (``calculateProducerbyPurchaserPriceRatio`` PRO scaling). Implemented as
+    ``PI[original] / PI[target]`` on the same 1:1 sector index as
+    ``get_cornerstone_industry_price_ratio``.
+
+    Independent of margins, Phi, and ``N``; sourced only from the configured
+    industry price-index panel.
+    """
+    if original_year == target_year:
+        return get_cornerstone_industry_price_ratio(original_year, target_year)
+    forward = get_cornerstone_industry_price_ratio(original_year, target_year)
+    ratio = 1.0 / forward
+    return ratio.where(np.isfinite(ratio), 1.0).fillna(1.0)
+
+
 def inflate_cornerstone_A_matrix_with_industry_pi(
     A: pd.DataFrame, original_year: int, target_year: int
 ) -> pd.DataFrame:

--- a/bedrock/utils/validation/analysis/combinations.py
+++ b/bedrock/utils/validation/analysis/combinations.py
@@ -73,6 +73,7 @@ COMBINATIONS: dict[str, ComboSpec] = {
             'useeio_phoebe_23_restore_cornerstone_B': 'useeio_phoebe_23',
             'useeio_phoebe_23_restore_cornerstone_A': 'useeio_phoebe_23',
             'useeio_phoebe_23_restore_iot_redefinition': 'useeio_phoebe_23',
+            'useeio_phoebe_23_cornerstone_margins': 'useeio_phoebe_23',
             '2025_usa_cornerstone_full_model': 'useeio_phoebe_23',
         },
     ),

--- a/bedrock/utils/validation/diagnostics_helpers.py
+++ b/bedrock/utils/validation/diagnostics_helpers.py
@@ -680,10 +680,10 @@ def pull_efs_for_diagnostics() -> EfsForDiagnostics:
 
         if n_new_inflated is not None:
             n_base = ta.cast('pd.Series[float]', n_new_inflated.squeeze())
-            phi_year_new = new_base_year
+            phi_year_new = int(new_base_year)
         else:
             n_base = ta.cast('pd.Series[float]', N_new.squeeze())
-            phi_year_new = config.usa_detail_original_year
+            phi_year_new = int(config.usa_detail_original_year)
         n_new_purchaser = apply_phi_to_ef_vector(n_base, year=phi_year_new).to_frame()
         n_old_purchaser = apply_phi_to_ef_vector(
             ta.cast('pd.Series[float]', N_old_inflated.squeeze()),

--- a/bedrock/utils/validation/diagnostics_helpers.py
+++ b/bedrock/utils/validation/diagnostics_helpers.py
@@ -680,11 +680,14 @@ def pull_efs_for_diagnostics() -> EfsForDiagnostics:
 
         if n_new_inflated is not None:
             n_base = ta.cast('pd.Series[float]', n_new_inflated.squeeze())
+            phi_year_new = new_base_year
         else:
             n_base = ta.cast('pd.Series[float]', N_new.squeeze())
-        n_new_purchaser = apply_phi_to_ef_vector(n_base).to_frame()
+            phi_year_new = config.usa_detail_original_year
+        n_new_purchaser = apply_phi_to_ef_vector(n_base, year=phi_year_new).to_frame()
         n_old_purchaser = apply_phi_to_ef_vector(
-            ta.cast('pd.Series[float]', N_old_inflated.squeeze())
+            ta.cast('pd.Series[float]', N_old_inflated.squeeze()),
+            year=new_base_year,
         ).to_frame()
         logger.info(
             '[TIMING] N_new_purchaser and N_old_purchaser (Phi on new/old N) '


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

[#464](https://github.com/cornerstone-data/bedrock/pull/464) wires Phi at **`model_base_year`** into SEF export, a single-column Excel `Phi` sheet, and diagnostics `N_*_purchaser` columns. [supply-chain-factors](https://github.com/cornerstone-data/supply-chain-factors) / useeior apply **`Phi[currency_year]`** on factors already in the target dollar year. That split blocked alignment with Zenodo v1.4.0 SEFs (USD 2024).

This PR (on `by_integrate_phi2` → `by_integrate_phi`) adds:

1. **Config-gated price-index API** — `get_price_index_ratio` and `derive_price_index_panel` centralize the Rho vs V-norm PRO inflation choice; Excel **`Rho`** sheet; margin inflation calls the gated helper.
2. **Phi year panel** — sector × year margins and Phi; SEF and Excel use **`Phi[dollar_year]`** after CPI rebase.
3. **Manual validation** — analysis scripts including Zenodo SEF compare on Reference USEEIO Code.

### Price-index API (`inflation_helpers_cornerstone.py`) — Layer 1

| Symbol | Role |
|--------|------|
| `get_rho_inflation_ratio` | Sector 1:1 ``PI[orig]/PI[targ]`` primitive (useeior Rho math); not config-gated |
| `get_price_index_ratio(orig, targ)` | **Gated** cross-year ratio: Rho branch when `useeio_margins`; V-norm commodity ``PI[targ]/PI[orig]`` when `cornerstone_industry_avg_margins` |
| `derive_price_index_panel(years)` | Sector × year Rho panel for Excel; always useeior ``PI[IO]/PI[y]`` |
| `default_price_index_panel_years()` | Years from IO base year through BEA PI table |

`get_price_index_ratio` is the single entry point for PRO margin inflation. Excel ``Rho`` always uses the useeior panel; under ``cornerstone_industry_avg_margins`` margin inflation still uses V-norm ``PI[targ]/PI[orig]``. **Layer 2 (follow-up):** gate `N` rebase in `adjust_publish_matrix` through the same helper.

### Transform (`derive_PRO_to_PUR_ratio.py`)

- `derive_margins_cornerstone_usa_at_year(target_year)` — margins inflated from `usa_base_io_data_year` to *target_year*.
- `_inflate_margins_to_year` — **Rho on PRO** (`get_rho_inflation_ratio`) when `useeio_margins`; **vnorm commodity PI on PRO** when `cornerstone_industry_avg_margins`; shared T/W/R sector CPI in both paths.
- `derive_phi_cornerstone_usa_at_year(target_year)`, `derive_phi_cornerstone_usa_panel(years)`, `default_phi_panel_years()`.
- `phi_for_sectors(..., year=)` and `apply_phi_to_ef_vector(..., year=)` — explicit Phi year (default remains `model_base_year`).

### Publish (delta vs #464)

| #464 | This PR |
|------|---------|
| `phi_for_sectors` at `model_base_year` | `phi_for_sectors(..., year=dollar_year)` in `adjust_publish_matrix` |
| `get_Phi()` single column | `get_Phi()` sector × year panel (~2017–2025) |
| `Rho` placeholder | `get_Rho()` sector × year panel from `derive_price_index_panel` |
| — | `get_price_index_ratio` / `derive_price_index_panel` in `inflation_helpers_cornerstone.py` |

N rebase in `adjust_publish_matrix` still uses vnorm commodity CPI (unchanged from #464).

### Diagnostics (delta vs #464)

- `N_new_purchaser`: Phi at `model_base_year` when `N_new_inflated` exists, else `usa_detail_original_year`.
- `N_old_purchaser`: unchanged — Phi at `model_base_year` on workbook N inflated to `model_base_year`.

### Analysis (`bedrock/analysis/margins/`)

| Script | Purpose |
|--------|---------|
| `compare_phi_to_reference` | Phi vs pinned USEEIO workbook (IO year + 2024) and CEDA |
| `compare_margin_approaches` | PRO:PUR across useeior / Cornerstone / CEDA at IO year + 2024 |
| `compare_sef_zenodo_useeio_code` | Bedrock SEF without-margins vs [Zenodo v1.4.0](https://doi.org/10.5281/zenodo.17202747) on Reference USEEIO Code |

Zenodo rows whose reference field lists multiple comma-separated codes are dropped; remaining NAICS rows collapse by reference code (mean). Manual only; not CI.

### Parity results (manual)

| Check | Result |
|-------|--------|
| Phi@2017 vs phoebe workbook | ~0% median rel error (CI, inherited from #464 + panel column) |
| Phi@2023 vs phoebe workbook | ~**0.04%** median rel error — PI parquet vs workbook CPI barely diverges |
| Phi@2024 vs phoebe workbook | ~**0.75%** median rel error; max ~19% tail (T/W/R CPI + PI drift on recent years) |
| Zenodo SEF @ `--dollar_year 2024` | **386** joined sectors, median `perc_diff` ~**1.3%** (was ~8.4% before Rho PRO gating on this branch) |

Phi@2023 tighter than Phi@2024 supports **bedrock parquet PI vs workbook `MultiYearIndustryCPI` diverging more on the latest years**, not a broken Rho recipe. Workbook Phi CI stays at **2017 only** (1% rtol): 2023 is ~0.04% median but ~23/405 sectors exceed 1% rtol; 2024 is worse (~0.75% median, 179/405 at 1% rtol). Zenodo v1.4.0 is USD 2024 only — no apples-to-apples SEF compare at 2023.

### Remaining gaps vs useeior (follow-up)

| Step | useeior / workbook | bedrock (`useeio_margins`) |
|------|-------------------|---------------------------|
| PRO inflation | Rho | Rho — aligned |
| T / W / R inflation | `Sector_CPI_IO` | ITA Paasche sector CPI |
| N rebase to `dollar_year` | `N %*% diag(Rho[currency_year])` | vnorm commodity PI (from #464) |

## Validation scope (this PR)

| Check | Coverage |
|-------|----------|
| `test_sef_phi_wiring` | **Updated:** `Phi(dollar_year)` at `--dollar_year` 2024 |
| `test_published_phi_matches_useeio_workbook` | Phi panel column **2017** only (1% rtol) |
| `test_rho_inflation_ratio_is_inverse_of_industry_price_ratio` | Rho helper math |
| `compare_sef_zenodo_useeio_code` | Manual — full bedrock SEF vs Zenodo |

**Covered by #464 (not re-tested here):** basic `phi_for_sectors` / `apply_phi_to_ef_vector`, Excel `Phi` sheet emission, diagnostics purchaser columns at `model_base_year`, `test_phi_helpers`, `test_excel_writer`.

**Not in scope:** NAICS-6 publish, margins SEF column, `Tau`, N rebase on Rho, workbook-N-through-publish script.

## Testing

```powershell
uv run pytest bedrock/transform/iot/__tests__/test_phi_helpers.py bedrock/publish/__tests__/test_excel_writer.py -v

uv run pytest bedrock/publish/__tests__/test_sef_phi_wiring.py -m eeio_integration -v

uv run pytest bedrock/publish/__tests__/test_sef_vs_useeio_baseline.py -m eeio_integration -v

uv run pytest bedrock/utils/economic/__tests__/test_inflation_helpers_cornerstone.py -v
```

Analysis (manual):

```powershell
uv run python -m bedrock.analysis.margins.compare_phi_to_reference
uv run python -m bedrock.analysis.margins.compare_margin_approaches
uv run python -m bedrock.analysis.margins.compare_sef_zenodo_useeio_code --config_name useeio_phoebe_23 --dollar_year 2024
```

Output: `bedrock/analysis/margins/output/sef_zenodo_useeio_code_comparison.csv`
