### PR TITLE
feat(margins): load USEEIOR industry CPI when useeio_margins

### DIFF
--- a/bedrock/publish/cache_reset.py
+++ b/bedrock/publish/cache_reset.py
@@ -42,6 +42,7 @@ from bedrock.transform.iot.derive_PRO_to_PUR_ratio import (
     derive_phi_cornerstone_usa_panel,
 )
 from bedrock.utils.economic.inflation_helpers_cornerstone import (
+    clear_cornerstone_inflation_caches,
     derive_price_index_panel,
     get_price_index_ratio,
 )
@@ -79,6 +80,7 @@ UPSTREAM_CACHED_DERIVES: list[Callable[..., object]] = [
 
 
 def clear_all_publish_caches() -> None:
+    clear_cornerstone_inflation_caches()
     for fn in UPSTREAM_CACHED_DERIVES:
         if hasattr(fn, 'cache_clear'):
             fn.cache_clear()

--- a/bedrock/utils/economic/inflation_helpers_cornerstone.py
+++ b/bedrock/utils/economic/inflation_helpers_cornerstone.py
@@ -21,6 +21,9 @@ from bedrock.utils.config.usa_config import get_usa_config
 from bedrock.utils.economic.inflation_helpers_ceda import (
     obtain_inflation_factors_from_reference_data,
 )
+from bedrock.utils.economic.inflation_helpers_useeio import (
+    obtain_useeior_detail_industry_cpi_levels,
+)
 from bedrock.utils.math.formulas import (
     compute_commodity_mix_matrix,
     compute_Vnorm_matrix,
@@ -70,6 +73,22 @@ def _cornerstone_to_ceda_v7_parent() -> dict[str, str]:
 
 
 @functools.cache
+def _industry_price_index_levels() -> pd.DataFrame:
+    """Wide sector × year PI levels for cornerstone industry-ratio math.
+
+    ``useeio_margins``: USEEIOR v1.8.0 ``Detail_CPI_IO_17sch`` (GCS snapshot).
+    ``update_inflation_factors``: bedrock-derived industry PI.
+    Otherwise: bedrock BEA parquet (``BEA_PriceIndex``).
+    """
+    cfg = get_usa_config()
+    if cfg.useeio_margins:
+        return obtain_useeior_detail_industry_cpi_levels()
+    if cfg.update_inflation_factors:
+        return derive_industry_price_index()
+    return obtain_inflation_factors_from_reference_data()
+
+
+@functools.cache
 def get_cornerstone_industry_price_ratio(
     original_year: int, target_year: int
 ) -> pd.Series[float]:
@@ -79,15 +98,14 @@ def get_cornerstone_industry_price_ratio(
     parent's price ratio so that inflation is applied consistently.
     """
     cfg = get_usa_config()
+    price_index = _industry_price_index_levels()
     if cfg.update_inflation_factors:
-        price_index = derive_industry_price_index()
         target_codes = CORNERSTONE_INDUSTRIES
     else:
         # Reindex to commodities so downstream `diag(p) @ A @ diag(1/p)`
         # aligns positionally against a commodity-indexed A. INDUSTRIES and
         # COMMODITIES order diverges at 351/405 positions, so the target
         # list is load-bearing despite the function's name.
-        price_index = obtain_inflation_factors_from_reference_data()
         target_codes = CORNERSTONE_COMMODITIES
     pi_ratio: pd.Series[float] = price_index[target_year] / price_index[original_year]
 
@@ -129,9 +147,7 @@ def default_price_index_panel_years() -> tuple[int, ...]:
     """Years with price-index coverage for panel export (from IO base year onward)."""
     cfg = get_usa_config()
     base = cfg.usa_base_io_data_year
-    years = sorted(
-        int(y) for y in obtain_inflation_factors_from_reference_data().columns
-    )
+    years = sorted(int(y) for y in _industry_price_index_levels().columns)
     return tuple(y for y in years if y >= base)
 
 
@@ -568,12 +584,7 @@ def _cornerstone_indexed_industry_pi(year: int) -> pd.Series[float]:
     Codes with no parent in the upstream PI fall back to 100 (BEA convention
     2017 = 100); any ratio against another year that also falls back is 1.0.
     """
-    cfg = get_usa_config()
-    price_index = (
-        derive_industry_price_index()
-        if cfg.update_inflation_factors
-        else obtain_inflation_factors_from_reference_data()
-    )
+    price_index = _industry_price_index_levels()
 
     pi_year: pd.Series[float] = price_index[year]
     series = pi_year.reindex(CORNERSTONE_INDUSTRIES).astype(float)
@@ -586,3 +597,25 @@ def _cornerstone_indexed_industry_pi(year: int) -> pd.Series[float]:
         ):
             series.loc[child] = float(pi_year.loc[parent_code])
     return series.fillna(100.0)
+
+
+# Config-sensitive ``@functools.cache`` helpers (omit config from cache keys).
+_CONFIG_SENSITIVE_INFLATION_CACHES: tuple[ta.Callable[..., object], ...] = (
+    _industry_price_index_levels,
+    get_cornerstone_industry_price_ratio,
+    get_rho_inflation_ratio,
+    derive_price_index_panel,
+    get_price_index_ratio,
+    get_vnorm_adjusted_commodity_price_ratio,
+    _cornerstone_indexed_industry_pi,
+    get_summary_commodity_price_index,
+    get_sector_commodity_price_index,
+    derive_cornerstone_q_and_vnorm_for_year,
+    obtain_useeior_detail_industry_cpi_levels,
+)
+
+
+def clear_cornerstone_inflation_caches() -> None:
+    """Clear inflation helpers that depend on ``get_usa_config()`` dispatch."""
+    for fn in _CONFIG_SENSITIVE_INFLATION_CACHES:
+        fn.cache_clear()  # type: ignore[attr-defined]

--- a/bedrock/utils/economic/inflation_helpers_useeio.py
+++ b/bedrock/utils/economic/inflation_helpers_useeio.py
@@ -1,0 +1,84 @@
+"""USEEIOR industry CPI levels — separate from bedrock BEA / CEDA parquet.
+
+Loaded only when ``USAConfig.useeio_margins`` is true.
+
+Upstream (cornerstone-data/useeior)
+------------------------------------
+- Object: ``data/Detail_CPI_IO_17sch.rda`` → ``MultiYearIndustryCPI`` in Detail /
+  2017-schema ``loadIOData``.
+- Bedrock pin: tag ``v1.8.0`` (released 2025-11-11).
+- Last change to ``Detail_CPI_IO_17sch.rda`` on ``v1.8.0``: **2025-09-26**, commit
+  ``4007dad`` (*update GO, CPI, and Value added from annual update #7*).
+
+Bedrock packaging
+-----------------
+- GCS: ``extract/input-data/USEEIOR_v180_IndustryCPI/useeior_v1.8.0_Detail_CPI_IO_17sch.csv``
+- Local cache: ``bedrock/extract/input_data/USEEIOR_v180_IndustryCPI/`` (gitignored CSV)
+
+Cornerstone configs (``useeio_margins: false``) keep ``BEA_PriceIndex`` parquet.
+"""
+
+from __future__ import annotations
+
+import functools
+import os
+
+import pandas as pd
+
+from bedrock.utils.io.gcp import download_gcs_file_if_not_exists
+from bedrock.utils.io.gcp_paths import gcs_extract_input_path
+from bedrock.utils.io.local_extract_input_data import local_extract_input_dir
+
+# Distinct from ``BEA_PriceIndex`` (bedrock parquet) and ``update_inflation_factors``.
+USEEIOR_INDUSTRY_CPI_GCS_SOURCE = 'USEEIOR_v180_IndustryCPI'
+USEEIOR_DETAIL_CPI_IO_17SCH_FILENAME = 'useeior_v1.8.0_Detail_CPI_IO_17sch.csv'
+USEEIOR_DETAIL_CPI_IO_17SCH_GCS_PATH = gcs_extract_input_path(
+    USEEIOR_INDUSTRY_CPI_GCS_SOURCE
+)
+USEEIOR_DETAIL_CPI_TAG = 'v1.8.0'
+USEEIOR_DETAIL_CPI_UPSTREAM_PATH = 'data/Detail_CPI_IO_17sch.rda'
+USEEIOR_DETAIL_CPI_LAST_UPSTREAM_CHANGE = '2025-09-26'  # useeior 4007dad @ v1.8.0
+
+
+def _normalize_useeior_sector_index(index: pd.Index) -> pd.Index:
+    return pd.Index(
+        index.astype(str).str.replace('/US', '', regex=False).str.strip(),
+        name=index.name,
+    )
+
+
+@functools.cache
+def obtain_useeior_detail_industry_cpi_levels() -> pd.DataFrame:
+    """Sector × year industry CPI levels from pinned USEEIOR v1.8.0 export.
+
+    Returns a wide ``DataFrame``: index = BEA 2017 detail sector codes,
+    columns = int years, values = chain-type price index (2017 = 100).
+    """
+    local_path = os.path.join(
+        local_extract_input_dir(USEEIOR_INDUSTRY_CPI_GCS_SOURCE),
+        USEEIOR_DETAIL_CPI_IO_17SCH_FILENAME,
+    )
+    download_gcs_file_if_not_exists(
+        USEEIOR_DETAIL_CPI_IO_17SCH_FILENAME,
+        USEEIOR_DETAIL_CPI_IO_17SCH_GCS_PATH,
+        local_path,
+    )
+    if not os.path.isfile(local_path):
+        raise FileNotFoundError(
+            f'USEEIOR industry CPI not found at {local_path!r}. '
+            f'Expected GCS object gs://cornerstone-default/'
+            f'{USEEIOR_DETAIL_CPI_IO_17SCH_GCS_PATH}/'
+            f'{USEEIOR_DETAIL_CPI_IO_17SCH_FILENAME} or a local copy under '
+            f'bedrock/extract/input_data/{USEEIOR_INDUSTRY_CPI_GCS_SOURCE}/. '
+            f'Upstream: useeior {USEEIOR_DETAIL_CPI_UPSTREAM_PATH} @ '
+            f'tag {USEEIOR_DETAIL_CPI_TAG} (last changed '
+            f'{USEEIOR_DETAIL_CPI_LAST_UPSTREAM_CHANGE}).'
+        )
+
+    raw = pd.read_csv(local_path, index_col=0)
+    raw.index = _normalize_useeior_sector_index(raw.index)
+    year_cols: dict[int, pd.Series] = {}
+    for col in raw.columns:
+        year_cols[int(str(col).strip())] = pd.to_numeric(raw[col], errors='coerce')
+    out = pd.DataFrame(year_cols).sort_index(axis=1)
+    return out.astype(float)


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

To better align with the USEEIO supply chain factors, this PR pins the industry CPI dataset to useeior v1.8.0 `Detail_CPI_IO_17sch` when `useeio_margins: true`, leaving Cornerstone production unchanged. Some differences observed in Rho (price index) and Phi (PRO:PUR) for recent years (especially 2023 and 2024)

### Scope

| Piece | Behavior |
|-------|----------|
| **Gate** | `useeio_margins: true` only |
| **Data** | `extract/input-data/USEEIOR_v180_IndustryCPI/useeior_v1.8.0_Detail_CPI_IO_17sch.csv` on GCS (distinct prefix from `BEA_PriceIndex`) |
| **Upstream CPI** | useeior `data/Detail_CPI_IO_17sch.rda` — last changed **2025-09-26** (`4007dad`); pinned @ tag `v1.8.0` (2025-11-11). Documented in `inflation_helpers_useeio.py` |
| **Loader** | `obtain_useeior_detail_industry_cpi_levels()` in `inflation_helpers_useeio.py` |
| **Funnel** | `_industry_price_index_levels()` → `get_cornerstone_industry_price_ratio`, `_cornerstone_indexed_industry_pi`, `default_price_index_panel_years` |
| **Cache** | `clear_cornerstone_inflation_caches()` on publish config reset |

### GCS artifact

| Field | Value |
|-------|--------|
| GCS prefix | `extract/input-data/USEEIOR_v180_IndustryCPI/` |
| Object | `useeior_v1.8.0_Detail_CPI_IO_17sch.csv` |
| Source | useeior `v1.8.0` `data/Detail_CPI_IO_17sch.rda` → `MultiYearIndustryCPI` in `loadIOData` |
| Local cache | `bedrock/extract/input_data/USEEIOR_v180_IndustryCPI/` (gitignored CSV) |

GCS must host the CSV derived from useeior `v1.8.0` `Detail_CPI_IO_17sch.rda` at the prefix above.

### Impact on N / SEF (useeio configs only)

| Stage | Affected |
|-------|----------|
| Phi PRO leg | Yes |
| Rho export panel | Yes — industry levels match useeior on `useeio_margins` |
| Zenodo without-margins @ 2024 | Marginal (see validation — producer N diffs dominate sector gaps) |
| Cornerstone full model | No |

## Testing

```powershell
uv run pytest bedrock/utils/economic/__tests__/test_inflation_helpers_cornerstone.py -v
```

## Validation results (`useeio_phoebe_23`, after USEEIOR CPI)

### Industry CPI levels (`useeio_margins`) — manual, 2017→2024

Compared `get_cornerstone_industry_price_ratio(2017, 2024)` to `PI[2024]/PI[2017]` from the same USEEIOR v1.8.0 `Detail_CPI_IO_17sch` table (`obtain_useeior_detail_industry_cpi_levels()`).

| Metric | Result |
|--------|--------|
| Sectors with both ratios | **398** |
| med \|pct rel diff\| | **0%** |
| Sectors with exact ratio match | **397 / 398** |
| Outlier | **`331314`** — bedrock **1.0** (parent-code fill) vs useeior **1.466**; not a table mismatch |

On `useeio_margins`, bedrock industry CPI ratios match the pinned USEEIOR levels for all sectors except the known parent-fill case.

### Phi / Rho vs pinned phoebe workbook

Compared to parquet industry CPI on `useeio_margins` (manual `run_wiring_validation`, 2026-06-15):

| Check | Before (approx.) | After |
|-------|------------------|-------|
| Phi vs workbook @ 2024 med \|rel\| | ~0.75% | **0.12%** |
| Phi vs workbook @ 2024 fail @1% | ~179/405 | **18/405** |
| Phi vs workbook @ 2024 p90 \|rel\| | — | **0.57%** |
| Rho vs workbook @ 2024 med \|rel\| | ~5.1% | **0.20%** |
| Rho vs workbook @ 2024 fail @1% | ~348/405 | **80/405** |

Cornerstone configs (`useeio_margins: false`) still show ~5.1% Rho drift @ 2024 (parquet unchanged).

### Zenodo SEF @ 2024 (Reference USEEIO Code)

| Metric | Result |
|--------|--------|
| Sectors joined | **386** |
| med \|rel\| | **~1.33%** |
| fail @ 1% rtol | **~242 / 386** |

Industry CPI wiring (this change) tightens Phi/Rho vs the workbook; remaining Zenodo purchaser SEF parity is a separate gap (producer `N` vs workbook, margins, T/W/R CPI). Remaining Phi workbook tail (~18 sectors @ 1%) is largely `Sector_CPI_IO` (not wired).
