### PR TITLE
fix(validation): atol floor for zero-q Leontief diagnostics

### DIFF
--- a/bedrock/analysis/comp_make_use/compare_make_use_by_stages.py
+++ b/bedrock/analysis/comp_make_use/compare_make_use_by_stages.py
@@ -202,8 +202,9 @@ def write_results_csv(
 def _print_result(output: str, result: DiagnosticResult) -> None:
     status = "PASS" if result.passed else "FAIL"
     print(
-        f"{output} (x_V vs Use-side output): max_rel_diff={result.max_rel_diff:.4g}, "
-        f"failures>{result.tolerance:.0%}={len(result.failing_sectors)} — {status}"
+        f"{output} (x_V vs Use-side output): max normalized residual="
+        f"{result.max_rel_diff:.4g} (pass if <= 1.0, rtol={result.tolerance:.0%}), "
+        f"failing sectors={len(result.failing_sectors)} — {status}"
     )
     if not result.passed:
         for sector in result.failing_sectors:

--- a/bedrock/utils/validation/__tests__/test_eeio_diagnostics.py
+++ b/bedrock/utils/validation/__tests__/test_eeio_diagnostics.py
@@ -30,6 +30,7 @@ from bedrock.utils.validation.eeio_diagnostics import (
     compare_output_vs_leontief_x_demand,
     format_diagnostic_result,
     run_all_diagnostics,
+    validate_result,
 )
 
 
@@ -132,6 +133,39 @@ class TestDiagnosticResult:
 
         assert result.tolerance == 0.0
         assert result.max_rel_diff == 0.0
+
+
+class TestValidateResult:
+    """Tests for zero-denominator handling in validate_result."""
+
+    def test_zero_value_tiny_residual_passes(self) -> None:
+        """Sectors with q=0 compare absolute residual against atol, not rel_diff."""
+        value = pd.Series({"S00402": 0.0, "1111A0": 100.0})
+        value_check = pd.Series({"S00402": 7.6e-6, "1111A0": 100.5})
+
+        result = validate_result("zero q", value, value_check, tolerance=0.01)
+
+        assert result.passed is True
+        assert result.failing_sectors == []
+        assert result.max_rel_diff <= 1.0
+
+    def test_zero_value_large_residual_fails(self) -> None:
+        value = pd.Series({"S00402": 0.0})
+        value_check = pd.Series({"S00402": 1.0})
+
+        result = validate_result("zero q", value, value_check, tolerance=0.01)
+
+        assert result.passed is False
+        assert result.failing_sectors == ["S00402"]
+
+    def test_nonzero_value_uses_relative_tolerance(self) -> None:
+        value = pd.Series({"1111A0": 100.0})
+        value_check = pd.Series({"1111A0": 102.0})
+
+        result = validate_result("rel", value, value_check, tolerance=0.01)
+
+        assert result.passed is False
+        assert result.failing_sectors == ["1111A0"]
 
 
 class TestFormatDiagnosticResult:

--- a/bedrock/utils/validation/__tests__/test_eeio_diagnostics.py
+++ b/bedrock/utils/validation/__tests__/test_eeio_diagnostics.py
@@ -35,7 +35,12 @@ from bedrock.utils.validation.eeio_diagnostics import (
 
 
 class TestDiagnosticResult:
-    """Tests for the DiagnosticResult dataclass."""
+    """Tests for the DiagnosticResult dataclass (field storage and validation).
+
+    ``max_rel_diff`` values in these fixtures are arbitrary; they are not
+    required to satisfy ``validate_result``'s pass rule (normalized residual
+    <= 1.0). See ``TestValidateResult`` for that semantics.
+    """
 
     def test_basic_passing_result(self) -> None:
         """Test basic instantiation with a passing result."""
@@ -69,7 +74,7 @@ class TestDiagnosticResult:
         assert "11" in result.failing_sectors
         assert "21" in result.failing_sectors
         assert "31" in result.failing_sectors
-        assert result.max_rel_diff > result.tolerance
+        assert result.max_rel_diff == 0.05
 
     def test_result_with_details_dataframe(self) -> None:
         """Test a result with a details DataFrame."""
@@ -136,7 +141,7 @@ class TestDiagnosticResult:
 
 
 class TestValidateResult:
-    """Tests for zero-denominator handling in validate_result."""
+    """Tests for ``validate_result`` pass/fail semantics (normalized residual)."""
 
     def test_zero_value_tiny_residual_passes(self) -> None:
         """Sectors with q=0 compare absolute residual against atol, not rel_diff."""
@@ -185,8 +190,8 @@ class TestFormatDiagnosticResult:
 
         assert "Diagnostic: Row sum check" in formatted
         assert "Status: PASSED" in formatted
-        assert "Tolerance: 0.0100" in formatted
-        assert "Max relative difference: 0.0050" in formatted
+        assert "Tolerance (rtol): 0.0100" in formatted
+        assert "Max normalized residual: 0.0050 (pass if <= 1.0)" in formatted
         assert "Failing sectors: None" in formatted
 
     def test_format_failed_result_with_sectors(self) -> None:
@@ -357,11 +362,12 @@ def test_compare_Uset_y_dom_and_q_usa(
     else:
         # Cornerstone checks q (from V / Make) against U_dom row sums plus domestic
         # final demand y_d = y_tot − y_imp + exports, all in 2017-detail nominal
-        # units mapped to CS commodities. Thirteen sectors fail at 1% tolerance,
-        # concentrated in mining/petroleum and new waste codes (562*, S00402): the
+        # units mapped to CS commodities. Thirteen sectors fail at 1% rtol,
+        # concentrated in mining/petroleum and waste codes (562*, S00402): the
         # BEA→Cornerstone correspondence and waste disaggregation split parent GO
-        # across children without preserving the national-accounts identity sector-
-        # by-sector. rel_diff blows up to inf where remapped q is near zero.
+        # across children without preserving the national-accounts identity
+        # sector-by-sector. Near-zero q on special codes (e.g. S00402) is a
+        # separate issue from the L·y atol fix in validate_result.
         U_set = derive_cornerstone_U_with_negatives()
         y_set = derive_cornerstone_Ytot_matrix_set()
         # No derive_cornerstone_y_imp wrapper; inline compute_y_imp as in

--- a/bedrock/utils/validation/eeio_diagnostics.py
+++ b/bedrock/utils/validation/eeio_diagnostics.py
@@ -22,6 +22,10 @@ from bedrock.utils.schemas.single_region_types import SingleRegionYtotAndTradeVe
 
 logger = logging.getLogger(__name__)
 
+# Absolute floor for |value| in relative-error diagnostics. Sectors with q ≈ 0
+# (e.g. S00402 used goods) compare |diff| against atol instead of (diff / q).
+_VALIDATE_RESULT_ATOL = 1e-4
+
 
 @dc.dataclass
 class DiagnosticResult:
@@ -201,12 +205,15 @@ def validate_result(
     value_check: pd.Series[float],
     *,
     tolerance: float = 0.01,
+    atol: float = _VALIDATE_RESULT_ATOL,
     include_details: bool = False,
 ) -> DiagnosticResult:
     """
-    Helper function to compare and format validation results
-    Pass/fail: |(c - x) / x| <= tolerance for all sectors. Where x = 0, rel_diff
-    is treated as 0.
+    Helper function to compare and format validation results.
+
+    Pass/fail uses ``|diff| <= tolerance * |value| + atol`` (same form as
+    ``numpy.isclose``). Where ``|value|`` is near zero, ``atol`` bounds the
+    absolute residual instead of dividing by zero.
 
     Parameters
     ----------
@@ -216,7 +223,9 @@ def validate_result(
     value_check - computed value to compare against original
         Float series obtained from calcualtion
     tolerance
-        Tolerance for |rel_diff|; default 0.05.
+        Relative tolerance for |rel_diff|; default 0.01.
+    atol
+        Absolute tolerance added to the allowed residual; default 1e-4.
     include_details
         If True, attach a details DataFrame (sector, expected, actual, rel_diff).
 
@@ -226,32 +235,36 @@ def validate_result(
         Standardized result with pass/fail, max_rel_diff, failing_sectors, optional details.
 
     """
-    rel_diff = (value - value_check) / value
-    rel_diff = rel_diff.fillna(0.0)  # convert NaN (e.g., div by 0) to 0s
-    rel_diff_abs = np.abs(rel_diff)
+    abs_diff = (value - value_check).abs()
+    value_abs = value.abs()
+    allowed = tolerance * value_abs + atol
 
-    failing_sectors = rel_diff_abs[rel_diff_abs > tolerance]
-    passing_sectors = rel_diff_abs[rel_diff_abs <= tolerance]
-    max_rd = float(np.max(rel_diff_abs))
+    with np.errstate(divide="ignore", invalid="ignore"):
+        normalized = abs_diff / allowed
+    normalized = normalized.replace([np.inf, -np.inf], np.nan).fillna(0.0)
+
+    failing_sectors = normalized.index[normalized > 1.0]
+    passing_sectors = normalized.index[normalized <= 1.0]
+    max_rd = float(normalized.max()) if len(normalized) else 0.0
 
     details = None
     if include_details:
         data = {
-            "failing sectors": list(getattr(failing_sectors, "index", [])),
-            "passing sectors": list(getattr(passing_sectors, "index", [])),
-            "failing values": np.array(failing_sectors).tolist(),
+            "failing sectors": list(getattr(failing_sectors, "index", failing_sectors)),
+            "passing sectors": list(getattr(passing_sectors, "index", passing_sectors)),
+            "failing values": normalized.loc[failing_sectors].tolist(),
             "max_rel_diff": max_rd,
         }
 
         details = pd.DataFrame({key: pd.Series(value) for key, value in data.items()})
 
-    passed = len(value) == len(passing_sectors)
+    passed = len(failing_sectors) == 0
     return DiagnosticResult(
         name=name,
         passed=passed,
         tolerance=tolerance,
         max_rel_diff=max_rd,
-        failing_sectors=list(getattr(failing_sectors, "index", [])),
+        failing_sectors=list(failing_sectors.astype(str)),
         details=details,
     )
 
@@ -267,8 +280,8 @@ def compare_commodity_output_to_domestics_use_plus_exports(
     """
     Compares the total commodity output against the summation of model domestic Use (U_D) and production demand (y_d, including exports)
 
-    Pass/fail: |(c - x) / x| <= tolerance for all sectors. Where x = 0, rel_diff
-    is treated as 0.
+    Pass/fail: ``|diff| <= tolerance * |value| + atol`` for all sectors (see
+    ``validate_result``).
 
     Parameters
     ----------
@@ -322,8 +335,8 @@ def compare_output_vs_leontief_x_demand(
     """
     Compares the total sector output (commodity or industry) against
     the model result calculation of L @ y.
-    Pass/fail: |(c - x) / x| <= tolerance for all sectors. Where x = 0, rel_diff
-    is treated as 0.
+    Pass/fail: ``|diff| <= tolerance * |value| + atol`` for all sectors (see
+    ``validate_result``).
 
     Parameters
     ----------

--- a/bedrock/utils/validation/eeio_diagnostics.py
+++ b/bedrock/utils/validation/eeio_diagnostics.py
@@ -35,8 +35,12 @@ class DiagnosticResult:
     Attributes:
         name: Descriptive name of the diagnostic check.
         passed: Whether the diagnostic check passed.
-        tolerance: The tolerance threshold used for the check.
-        max_rel_diff: Maximum relative difference observed.
+        tolerance: Relative tolerance (rtol) passed to ``validate_result``;
+            scales the allowed residual as ``tolerance * |value| + atol``.
+        max_rel_diff: Worst-case normalized residual from ``validate_result``:
+            ``max(|diff| / (tolerance * |value| + atol))`` over sectors.
+            Values <= 1.0 are within tolerance; > 1.0 fail. Not directly
+            comparable to ``tolerance``. Structural errors may set this to inf.
         failing_sectors: List of sector identifiers that failed the check.
         details: Optional DataFrame with detailed diagnostic information.
     """
@@ -74,14 +78,14 @@ def format_diagnostic_result(result: DiagnosticResult) -> str:
         ...     name="Row sum check",
         ...     passed=False,
         ...     tolerance=0.01,
-        ...     max_rel_diff=0.05,
+        ...     max_rel_diff=1.5,
         ...     failing_sectors=["11", "21"]
         ... )
         >>> print(format_diagnostic_result(result))
         Diagnostic: Row sum check
         Status: FAILED
-        Tolerance: 0.0100
-        Max relative difference: 0.0500
+        Tolerance (rtol): 0.0100
+        Max normalized residual: 1.5000 (pass if <= 1.0)
         Failing sectors (2): 11, 21
     """
     status = "PASSED" if result.passed else "FAILED"
@@ -89,8 +93,8 @@ def format_diagnostic_result(result: DiagnosticResult) -> str:
     lines = [
         f"Diagnostic: {result.name}",
         f"Status: {status}",
-        f"Tolerance: {result.tolerance:.4f}",
-        f"Max relative difference: {result.max_rel_diff:.4f}",
+        f"Tolerance (rtol): {result.tolerance:.4f}",
+        f"Max normalized residual: {result.max_rel_diff:.4f} (pass if <= 1.0)",
     ]
 
     if result.failing_sectors:
@@ -166,8 +170,8 @@ def run_all_diagnostics(
             if stop_on_failure and not result.passed:
                 raise RuntimeError(
                     f"Diagnostic '{result.name}' failed. "
-                    f"Max relative difference: {result.max_rel_diff:.4f} "
-                    f"(tolerance: {result.tolerance:.4f})"
+                    f"Max normalized residual: {result.max_rel_diff:.4f} "
+                    f"(pass if <= 1.0; rtol: {result.tolerance:.4f})"
                 )
 
         except Exception as e:
@@ -223,16 +227,20 @@ def validate_result(
     value_check - computed value to compare against original
         Float series obtained from calcualtion
     tolerance
-        Relative tolerance for |rel_diff|; default 0.01.
+        Relative tolerance (rtol) in ``|diff| <= tolerance * |value| + atol``;
+        default 0.01.
     atol
         Absolute tolerance added to the allowed residual; default 1e-4.
     include_details
-        If True, attach a details DataFrame (sector, expected, actual, rel_diff).
+        If True, attach a details DataFrame with per-sector normalized
+        residuals in the ``failing values`` column.
 
     Returns
     -------
     DiagnosticResult
-        Standardized result with pass/fail, max_rel_diff, failing_sectors, optional details.
+        ``passed`` is True when all normalized residuals are <= 1.0.
+        ``max_rel_diff`` is the worst normalized residual (see
+        ``DiagnosticResult``).
 
     """
     abs_diff = (value - value_check).abs()
@@ -292,14 +300,15 @@ def compare_commodity_output_to_domestics_use_plus_exports(
     y_d
         Float series from e.g. ``derive_ydom_and_yimp_usa().ydom``
     tolerance
-        Tolerance for |rel_diff|; default 0.05.
+        Relative tolerance (rtol) forwarded to ``validate_result``; default 0.01.
     include_details
-        If True, attach a details DataFrame (sector, expected, actual, rel_diff).
+        If True, attach per-sector normalized residuals via ``validate_result``.
 
     Returns
     -------
     DiagnosticResult
-        Standardized result with pass/fail, max_rel_diff, failing_sectors, optional details.
+        Pass/fail and ``max_rel_diff`` follow ``validate_result`` (normalized
+        residual <= 1.0).
     """
 
     # Make sure all elements have common sectors
@@ -349,14 +358,15 @@ def compare_output_vs_leontief_x_demand(
     use_domestic
         If True, use the domestic Leontief inverse and final demand. Default is False.
     tolerance
-        Tolerance for |rel_diff|; default 0.01.
+        Relative tolerance (rtol) forwarded to ``validate_result``; default 0.01.
     include_details
-        If True, attach a details DataFrame (sector, expected, actual, rel_diff).
+        If True, attach per-sector normalized residuals via ``validate_result``.
 
     Returns
     -------
     DiagnosticResult
-        Standardized result with pass/fail, max_rel_diff, failing_sectors, optional details.
+        Pass/fail and ``max_rel_diff`` follow ``validate_result`` (normalized
+        residual <= 1.0).
     """
 
     # Make sure all elements have common sectors:
@@ -391,7 +401,10 @@ def commodity_industry_output_cpi_consistency(
     tolerance: float,
     include_details: bool = False,
 ) -> DiagnosticResult:
-    """Test that commodity output adjusted by CPI equals market share matrix times CPI-adjusted industry output."""
+    """Test that CPI-adjusted commodity output matches the market-share mix of CPI-adjusted industry output.
+
+    Pass/fail and ``max_rel_diff`` are computed by ``validate_result``.
+    """
 
     # Commodity mix matrix C_m (commodity x industry) (Marketshares transposed)
     # This is equivalent to generateCommodityMixMatrix in useeior which also uses t(V) and x
@@ -418,7 +431,10 @@ def compare_output_from_make_and_use(
     tolerance: float,
     include_details: bool = False,
 ) -> DiagnosticResult:
-    """Check that industry output from Use and Make tables are the same"""
+    """Check that Make-table and Use-table output agree for industry or commodity.
+
+    Pass/fail and ``max_rel_diff`` are computed by ``validate_result``.
+    """
 
     if output == "Industry":
         x_make = V.sum(axis=1)


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

After #458, `test_compare_output_and_L_y[Commodity-True-cornerstone]` failed on CI with sector `S00402` and `max_rel_diff=inf`. The model math was fine; the **comparison metric** was not.

### Why it was failing

The test checks that commodity output matches the Leontief identity `q ≈ L_dom @ y_nab`. It does that by comparing `q` to `L @ y` sector by sector.

`S00402` (“Used and secondhand goods”) is a special commodity with **zero output** (`scaled_q = 0`). After #458, its `y_nab` is a large negative value (~−38B) backcomputed from row balance — that is expected and keeps `q` consistent with `Adom` and `scaled_q`.

On Linux CI, floating-point math in `L @ y` can leave a **tiny nonzero residual** at `S00402` (on the order of 10⁻⁶) while `q` is exactly zero. The old check computed:

```
(q − L@y) / q
```

Dividing by zero produced **`inf`**, which `fillna` did not clear (only `NaN` was handled). The sector was flagged as a failure even though the absolute gap was negligible. The failure was sensitive to platform/BLAS — the same test could pass locally when the residual cancelled to exactly zero.

### What we changed

`validate_result` (used by the Leontief diagnostic and other EEIO checks) now uses the same rule as `numpy.isclose`:

```
|q − L@y| ≤ tolerance × |q| + atol
```

- Sectors with normal output still use **relative** tolerance (1%).
- Sectors with `q ≈ 0` use an **absolute** floor (`atol = 1e-4`) instead of dividing by zero.

`max_rel_diff` is reported as `|diff| / allowed` so values ≤ 1.0 mean pass.

Added unit tests in `TestValidateResult` for the zero-output case, a large-residual failure, and unchanged relative behavior on nonzero sectors.

## Testing

```powershell
uv run pytest bedrock/utils/validation/__tests__/test_eeio_diagnostics.py::TestValidateResult -v
uv run pytest "bedrock/utils/validation/__tests__/test_eeio_diagnostics.py::test_compare_output_and_L_y[Commodity-True-cornerstone]" -m eeio_integration -v
```
