### PR TITLE
fix(ghg): drop FK 5-1-12 flow from UMD 2024 GHGIA path

### DIFF
--- a/bedrock/transform/allocation/derived.py
+++ b/bedrock/transform/allocation/derived.py
@@ -507,6 +507,13 @@ def load_E_from_flowsa() -> pd.DataFrame:
         'CH4_non_fossil'
     )
 
+    # Drop FK 5-1-12 (fluoroketone cover gas, UMD GHGIA Table 4-52 Magnesium
+    # Production). UMD itself excludes it from totals (footnote a), it has no GWP
+    # in GWP100_AR6_CEDA (→ NaN CO2e), and it falls outside CEDA's Kyoto 7-gas
+    # scheme, so the gas-collapse below would leave it as a stray index entry and
+    # break the CornerstoneBMatrix schema. ~6.5e-6 MMT CO2e across 3 sectors.
+    fbs = fbs[fbs['Flowable'] != 'FK 5-1-12']
+
     # Convert values to CO2e
     ghg_mapping: dict[str, float] = {k: v for k, v in GWP100_AR6_CEDA.items()}
     if usa.use_ghg_national_2023_m2:


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

Drop the `FK 5-1-12` flow in `load_E_from_flowsa` (`bedrock/transform/allocation/derived.py`) before the gas-collapse step. `FK 5-1-12` is a fluoroketone cover gas from UMD GHGIA Table 4-52 (Magnesium Production) that UMD itself excludes from totals (footnote a). It has no GWP in `GWP100_AR6_CEDA` and falls outside CEDA's Kyoto 7-gas scheme, so it survived the species→7-gas `reverse` map as a stray index entry and broke the `CornerstoneBMatrix` schema (`isin(['CO2','CH4','N2O','HFCs','PFCs','SF6','NF3'])`) in `derive_cornerstone_B_via_vnorm`.

This blocked every 2024-GHG config (`usa_ghg_data_year=2024`: the `umd_2024_ghgia`, `2024_io_ghg`, and FINAL `v0_3` configs); the 2023 path is unaffected since that FBS never carries this flow. The fix is consumer-side, so the pre-built 2024 FBS on GCS stays valid (no regeneration needed).

## Testing

Loaded E for `2025_usa_cornerstone_full_model_v0_3_umd_2024_ghgia`: gas index is now exactly the 7 CEDA gases, no `FK 5-1-12`, no NaNs. Re-running EF diagnostics for the 3 affected configs from this branch.
