### PR TITLE
chore(snapshots): register v0.3-beta snapshot

### DIFF
--- a/bedrock/utils/config/usa_config.py
+++ b/bedrock/utils/config/usa_config.py
@@ -240,6 +240,7 @@ class USAConfig(BaseModel):
         '9fe22d9afdfdb6806397b2356eb3cf4c4c346744',  # test: snapshot from 2025_usa_cornerstone_fbs_schema
         '7372464249c434c9bebb172c065a4d0e3702176e',  # v0.2
         '4d67c8f0f5721a30ce03f4d3eef85a82e7199032',  # v0.3.0-alpha (current .SNAPSHOT_KEY)
+        '5a90baf0272fe8841e40db8cd513885b34051e86',  # v0.3-beta (config: 2025_usa_cornerstone_v0_3)
     ] = 'v0'
 
     @property

--- a/bedrock/utils/snapshots/releases.py
+++ b/bedrock/utils/snapshots/releases.py
@@ -17,6 +17,7 @@ v0 = "v0"  # config: legacy GCS prefix (pre git-SHA snapshots)
 v0_1 = "1bda811e0169436ae90fd356fbef512ce7518ccb"  # config: 2025_usa_cornerstone_full_model
 v0_2 = "7372464249c434c9bebb172c065a4d0e3702176e"  # config: 2025_usa_cornerstone_full_model
 v0_3_0_alpha = "4d67c8f0f5721a30ce03f4d3eef85a82e7199032"  # config: 2025_usa_cornerstone_full_model; matches .SNAPSHOT_KEY
+v0_3_beta = "5a90baf0272fe8841e40db8cd513885b34051e86"  # config: 2025_usa_cornerstone_v0_3 (not .SNAPSHOT_KEY)
 
 # Intermediate snapshot SHAs (atomic configs, test fixtures — not release labels)
 TEST_config_default = "2ebb51f7190c3a62b5d8b2420bff9b20f57282fc"  # config: 2025_usa_cornerstone_full_model


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

Register the **v0.3-beta** snapshot (cut from `2025_usa_cornerstone_v0_3`, commit `5a90baf`) so it's referenceable as a diagnostics baseline:

- `releases.py`: add `v0_3_beta = "5a90baf0272fe8841e40db8cd513885b34051e86"`
- `usa_config.py`: add that SHA to the `snapshot_version_or_git_sha` Literal

`.SNAPSHOT_KEY` is intentionally **left on v0.3.0-alpha**. The `eeio_integration` tests derive matrices with the default `2025_usa_cornerstone_full_model` config and diff against `.SNAPSHOT_KEY`; promoting a snapshot cut from the divergent `2025_usa_cornerstone_v0_3` config would break them. Beta is registered for diagnostics use only; the `.SNAPSHOT_KEY` bump waits for the blessed release.

The 10 snapshot parquets are already uploaded to `gs://cornerstone-default/snapshots/5a90baf0272fe8841e40db8cd513885b34051e86/`.

## Testing

No behavior change — reference-registry + config Literal additions only. `ruff` clean.
