### PR TITLE
feat(diagnostics): add overlay + multi-panel EF histogram plotters

### DIFF
--- a/bedrock/utils/validation/analysis/overlay_ef_hist.py
+++ b/bedrock/utils/validation/analysis/overlay_ef_hist.py
@@ -1,0 +1,115 @@
+"""Overlay per-sector N/D % diff distributions from multiple diagnostics Sheets.
+
+Each input Sheet contributes one semi-transparent histogram series per EF kind,
+so two (or more) model versions can be compared on a single axis — e.g. v0.2 vs
+v0.3, each measured as ``% diff vs the CEDA v0 baseline``. Percent-diff columns
+are normalized across the two storage conventions seen in diagnostics Sheets
+(percent-strings like ``"-6.86%"`` vs bare fractions like ``"0.0155"``), so runs
+written at different times overlay correctly.
+
+This lives in the validation analysis package (not under a-matrix analysis) so it
+is reusable for general validation/visualization. It reads the same
+``N_and_diffs`` / ``D_and_diffs`` tabs that ``generate_diagnostics`` writes.
+
+Usage:
+    python -m bedrock.utils.validation.analysis.overlay_ef_hist \\
+        --series "v0.2=1pCSgLD14lmrQg3OtfHvnK4lQrFtqiavrjCt-C3R_bSw" \\
+        --series "v0.3=1_DMZHI-vhHFrk7Bvd6Bx8Wmc5-3K3IQa3ylLN4tEHb0" \\
+        --out-dir bedrock/utils/validation/v0.3/output
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import click
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from bedrock.utils.io.gcp import read_sheet_tab
+
+from .plotting import (
+    normalize_pct_diff_to_percent,
+    overlay_pct_diff_histogram,
+    save_and_close,
+    setup_mpl,
+)
+
+logger = logging.getLogger(__name__)
+
+EF_KIND_LABEL = {'N': 'total EF (N)', 'D': 'direct EF (D)'}
+
+
+def _series_for_kind(sheet_id: str, ef_kind: str) -> 'pd.Series[float]':
+    """Return the per-sector pct-diff series (in percent) for one Sheet/kind."""
+    tab = f'{ef_kind}_and_diffs'
+    col = f'{ef_kind}_perc_diff'
+    df = read_sheet_tab(sheet_id, tab)
+    if col not in df.columns:
+        raise KeyError(f'{tab!r} in {sheet_id} has no {col!r}; got {list(df.columns)}')
+    return normalize_pct_diff_to_percent(df[col]).dropna()
+
+
+def _parse_series(series: tuple[str, ...]) -> dict[str, str]:
+    """Parse ``label=sheet_id`` pairs into an ordered mapping."""
+    out: dict[str, str] = {}
+    for item in series:
+        if '=' not in item:
+            raise click.BadParameter(f"--series must be 'label=sheet_id', got {item!r}")
+        label, sheet_id = item.split('=', 1)
+        out[label.strip()] = sheet_id.strip()
+    return out
+
+
+@click.command()
+@click.option(
+    '--series',
+    multiple=True,
+    required=True,
+    help="Repeatable 'label=sheet_id' pair, one per model version to overlay.",
+)
+@click.option(
+    '--out-dir',
+    type=click.Path(file_okay=False, path_type=Path),
+    required=True,
+    help='Directory to write ef_overlay_hist_{N,D}.png into.',
+)
+@click.option('--title', default=None, help='Optional title prefix.')
+def main(series: tuple[str, ...], out_dir: Path, title: str | None) -> None:
+    setup_mpl(font_size=14)
+    label_to_sheet = _parse_series(series)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    for ef_kind in ('N', 'D'):
+        series_by_label = {}
+        for label, sheet_id in label_to_sheet.items():
+            try:
+                series_by_label[label] = _series_for_kind(sheet_id, ef_kind)
+            except Exception as e:  # noqa: BLE001
+                logger.warning('Skipping %s for %s: %s', label, ef_kind, e)
+        if not series_by_label:
+            logger.warning('No data for %s; skipping.', ef_kind)
+            continue
+        fig, ax = plt.subplots(figsize=(11, 6.5))
+        kind_label = EF_KIND_LABEL[ef_kind]
+        versions = ' vs '.join(series_by_label)
+        suptitle = (
+            f'{title + " — " if title else ""}{kind_label} per-sector % diff '
+            f'vs CEDA v0 — {versions}'
+        )
+        overlay_pct_diff_histogram(
+            ax,
+            series_by_label,
+            xlabel='EF change vs CEDA v0 baseline (%)',
+            title=suptitle,
+        )
+        fig.tight_layout()
+        out = out_dir / f'ef_overlay_hist_{ef_kind}.png'
+        save_and_close(fig, out)
+        print(f'Wrote: {out}')
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO, format='%(message)s')
+    main()

--- a/bedrock/utils/validation/analysis/panel_ef_hist.py
+++ b/bedrock/utils/validation/analysis/panel_ef_hist.py
@@ -1,0 +1,198 @@
+"""Multi-panel per-config N/D % diff histograms (one panel per diagnostics Sheet).
+
+Each panel is the standalone-histogram style from ``diagnostics_plots`` — a
+percent-diff histogram with median / 0 / ±10 / ±20 reference lines and a
+``Beyond ±20%`` top-30 sector text box. Lay several runs side by side (e.g. a
+v0.2 baseline panel plus each underlying v0.3 config) to compare where the EF
+distribution moves config-by-config. Renders one figure per EF kind (N, D).
+
+Percent-diff columns are read via ``fetch.load_tab`` (which coerces bare-fraction
+strings to floats) and ``_normalize_perc_diff`` / ``_parse_pct`` (which also
+handle ``"X%"`` strings), so older percent-string runs and newer fraction runs
+panel together correctly.
+
+Usage:
+    python -m bedrock.utils.validation.analysis.panel_ef_hist \\
+        --series "v0.2 (baseline)=1pCSgLD..." \\
+        --series "v0.3 step: update inflation factors=1-uMBFx2..." \\
+        --out-dir bedrock/utils/validation/v0.3/output [--ncols 3]
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import re
+from pathlib import Path
+
+import click
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from .diagnostics_plots import (
+    _beyond_20_text,
+    _drop_old_only,
+    _normalize_perc_diff,
+    _normalize_schema,
+)
+from .fetch import load_tab
+from .plotting import (
+    DEFAULT_XLIM,
+    apply_axis_fonts,
+    percent_histogram,
+    save_and_close,
+    setup_mpl,
+)
+
+logger = logging.getLogger(__name__)
+
+EF_KIND_LABEL = {'N': 'total EF (N)', 'D': 'direct EF (D)'}
+KIND_TAB = {'N': 'N_and_diffs', 'D': 'D_and_diffs'}
+
+
+def _parse_series(series: tuple[str, ...]) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for item in series:
+        if '=' not in item:
+            raise click.BadParameter(f"--series must be 'label=sheet_id', got {item!r}")
+        label, sheet_id = item.split('=', 1)
+        out[label.strip()] = sheet_id.strip()
+    return out
+
+
+def _own_baseline_frame(sheet_id: str, ef_kind: str) -> pd.DataFrame:
+    """Per-sector ``{kind}_perc_diff`` vs the sheet's own baseline (CEDA v0)."""
+    df = _drop_old_only(_normalize_schema(load_tab(sheet_id, KIND_TAB[ef_kind])))
+    return _normalize_perc_diff(df, ef_kind)
+
+
+def _new_ef(sheet_id: str, ef_kind: str) -> pd.DataFrame:
+    """Sector-indexed absolute ``{kind}_new`` (float) + ``sector_name``."""
+    col = f'{ef_kind}_new'
+    df = _drop_old_only(_normalize_schema(load_tab(sheet_id, KIND_TAB[ef_kind])))
+    out = df[['sector', 'sector_name', col]].copy()
+    out[col] = pd.to_numeric(out[col], errors='coerce')
+    return out
+
+
+def _vs_baseline_frame(cfg_sheet: str, base_sheet: str, ef_kind: str) -> pd.DataFrame:
+    """Per-sector ``{kind}_perc_diff`` of one config vs a chosen baseline sheet.
+
+    Recomputed from absolute EFs as ``(cfg_new - base_new) / |base_new|`` so the
+    denominator is the baseline run (e.g. v0.2), not each sheet's stored
+    CEDA-v0 comparison. Returns the schema ``_beyond_20_text`` /
+    ``percent_histogram`` expect (``sector``, ``sector_name``,
+    ``{kind}_perc_diff`` as a fraction).
+    """
+    col = f'{ef_kind}_new'
+    cfg = _new_ef(cfg_sheet, ef_kind)
+    base = _new_ef(base_sheet, ef_kind)[['sector', col]].rename(columns={col: '_base'})
+    m = cfg.merge(base, on='sector', how='inner')
+    pdiff = (m[col] - m['_base']) / m['_base'].abs()
+    return pd.DataFrame(
+        {
+            'sector': m['sector'],
+            'sector_name': m['sector_name'],
+            f'{ef_kind}_perc_diff': pdiff,
+        }
+    )
+
+
+@click.command()
+@click.option(
+    '--series',
+    multiple=True,
+    required=True,
+    help="Repeatable 'label=sheet_id' pair, one per panel (first = baseline).",
+)
+@click.option(
+    '--out-dir',
+    type=click.Path(file_okay=False, path_type=Path),
+    required=True,
+)
+@click.option('--ncols', default=3, show_default=True, help='Panels per row.')
+@click.option(
+    '--baseline',
+    default=None,
+    help=(
+        "Optional 'label=sheet_id'. When set, each --series config is "
+        "recomputed vs this sheet's absolute EFs (e.g. v0.2 as baseline) "
+        "instead of each sheet's own CEDA-v0 comparison."
+    ),
+)
+def main(
+    series: tuple[str, ...], out_dir: Path, ncols: int, baseline: str | None
+) -> None:
+    setup_mpl(font_size=13)
+    label_to_sheet = _parse_series(series)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    base_label = base_sheet = None
+    if baseline is not None:
+        ((base_label, base_sheet),) = _parse_series((baseline,)).items()
+
+    for ef_kind in ('N', 'D'):
+        col = f'{ef_kind}_perc_diff'
+        frames: list[tuple[str, pd.DataFrame]] = []
+        for label, sheet_id in label_to_sheet.items():
+            try:
+                if base_sheet is not None:
+                    frames.append(
+                        (label, _vs_baseline_frame(sheet_id, base_sheet, ef_kind))
+                    )
+                else:
+                    frames.append((label, _own_baseline_frame(sheet_id, ef_kind)))
+            except Exception as e:  # noqa: BLE001
+                logger.warning('Skipping %s for %s: %s', label, ef_kind, e)
+        if not frames:
+            logger.warning('No data for %s; skipping.', ef_kind)
+            continue
+
+        n = len(frames)
+        cols = min(ncols, n)
+        rows = math.ceil(n / cols)
+        fig, axes = plt.subplots(
+            rows, cols, figsize=(10.0 * cols, 8.5 * rows), squeeze=False
+        )
+        flat = list(axes.flat)
+        for i, (label, df) in enumerate(frames):
+            ax = flat[i]
+            percent_histogram(
+                ax,
+                df[col].dropna() * 100,
+                xlim=DEFAULT_XLIM,
+                xlabel='Percentage Diff (%)',
+                ylabel='Count',
+                title=label,
+                text_box=_beyond_20_text(df, col),
+                text_box_fontsize=8,
+                legend_fontsize=10,
+            )
+            apply_axis_fonts(ax)
+        for ax in flat[n:]:
+            ax.axis('off')
+        # Shared y-limit so panel heights are comparable across configs.
+        ymax = max(flat[i].get_ylim()[1] for i in range(n))
+        for i in range(n):
+            flat[i].set_ylim(0, ymax)
+
+        baseline_name = base_label if base_label is not None else 'CEDA v0'
+        fig.suptitle(
+            f'{EF_KIND_LABEL[ef_kind]} per-sector % diff vs {baseline_name} — '
+            'v0.3 configs',
+            fontsize=18,
+        )
+        fig.tight_layout()
+        slug = (
+            '_vs_' + re.sub(r'[^0-9a-zA-Z]+', '_', base_label).strip('_')
+            if base_label is not None
+            else ''
+        )
+        out = out_dir / f'ef_panels{slug}_{ef_kind}.png'
+        save_and_close(fig, out)
+        print(f'Wrote: {out}')
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO, format='%(message)s')
+    main()

--- a/bedrock/utils/validation/analysis/plotting.py
+++ b/bedrock/utils/validation/analysis/plotting.py
@@ -178,6 +178,78 @@ def percent_histogram(
         )
 
 
+def normalize_pct_diff_to_percent(raw: "pd.Series[Any]") -> "pd.Series[float]":
+    """Normalize a diagnostics ``*_perc_diff`` column to percent units.
+
+    Diagnostics Sheets store percent diffs in two conventions:
+    - percent-formatted strings, e.g. ``"-6.86%"`` (already in percent)
+    - bare fractions, e.g. ``"0.0155"`` (= 1.55%, needs ×100)
+
+    Cells containing ``%`` are parsed as percent; bare numerics are treated as
+    fractions and scaled to percent. Non-parseable cells become NaN. This lets
+    one overlay mix older (``%``-string) and newer (fraction) runs safely.
+    """
+    s = raw.astype(str).str.strip()
+    has_pct = s.str.contains("%", na=False)
+    num = pd.to_numeric(s.str.replace("%", "", regex=False), errors="coerce")
+    return num.where(has_pct, num * 100.0)
+
+
+def overlay_pct_diff_histogram(
+    ax: Axes,
+    series_by_label: dict[str, "pd.Series[float]"],
+    *,
+    colors: dict[str, str] | None = None,
+    xlim: tuple[float, float] = (-100.0, 100.0),
+    bin_width: float = 5.0,
+    beyond_threshold: float = 20.0,
+    xlabel: str = "EF change vs baseline (%)",
+    ylabel: str = "sector count",
+    title: str | None = None,
+    legend_loc: str = "upper right",
+    legend_fontsize: int = LEGEND_FONTSIZE,
+) -> None:
+    """Overlay multiple percent-diff distributions on one axis.
+
+    Each series renders as a semi-transparent histogram with a dashed median
+    line; the legend reports per-series ``median``, ``% up`` (share > 0), and
+    ``% beyond ±threshold``. Inputs are in percent units (run values through
+    :func:`normalize_pct_diff_to_percent` first). Bars are clipped to ``xlim``;
+    stats are computed on the unclipped values so tails are not hidden.
+    """
+    palette = ("#1f77b4", "#ff7f0e", "#2ca02c", "#d62728", "#9467bd", "#8c564b")
+    bin_edges = np.arange(xlim[0], xlim[1] + bin_width, bin_width).tolist()
+    for i, (label, raw) in enumerate(series_by_label.items()):
+        vals = pd.to_numeric(raw, errors="coerce").dropna()
+        if vals.empty:
+            continue
+        color = (colors or {}).get(label) or palette[i % len(palette)]
+        median = float(vals.median())
+        pct_up = float((vals > 0).mean() * 100.0)
+        beyond = float((vals.abs() > beyond_threshold).mean() * 100.0)
+        legend = (
+            f"{label} (n={len(vals)})\nmedian {median:+.0f}% | {pct_up:.0f}% up | "
+            f"{beyond:.0f}% beyond ±{beyond_threshold:g}%"
+        )
+        ax.hist(
+            vals.clip(xlim[0], xlim[1]),
+            bins=bin_edges,
+            color=color,
+            alpha=0.5,
+            label=legend,
+        )
+        ax.axvline(median, color=color, linestyle="--", linewidth=1.3)
+    ax.axvline(0, color=ZERO_COLOR, linewidth=1.0)
+    ax.set_xlim(xlim)
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel(ylabel)
+    if title is not None:
+        ax.set_title(title)
+    format_percent_axis(ax, PERCENT_TICKS)
+    ax.grid(True, ls=":", alpha=0.3)
+    ax.legend(fontsize=legend_fontsize, loc=legend_loc, framealpha=0.5)
+
+
 def abs_change_histogram(
     ax: Axes,
     values: "pd.Series[float]",


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

Add reusable EF percent-diff histogram plotters to the validation analysis package (usable for general validation/visualization, not tied to a-matrix analysis):

- `plotting.py`: `normalize_pct_diff_to_percent` (handles both diagnostics storage conventions — `"-6.86%"` strings and bare `0.0155` fractions) and `overlay_pct_diff_histogram` (N-series semi-transparent overlay with per-series median line + `median | % up | % beyond ±20%` legend).
- `overlay_ef_hist.py`: driver that overlays N/D distributions from multiple diagnostics Sheets on one axis (e.g. v0.2 vs v0.3, both vs CEDA v0).
- `panel_ef_hist.py`: multi-panel grid, one `percent_histogram` panel per Sheet (median/0/±10/±20 + top-30 "Beyond ±20%" box). Supports `--baseline "label=sheet_id"` to rebaseline each config against another run's absolute EFs (e.g. each v0.3 config vs v0.2) instead of its stored CEDA-v0 comparison.

Reuses existing `diagnostics_plots` helpers and `fetch.load_tab` so percent-string and fraction runs render together correctly.

See sample plots in [this deck](https://docs.google.com/presentation/d/1wqNYv3SU9WfAwWzmAN0ECuDtKh1lUqDQBlg6eJOXnvA/edit?slide=id.g3f15496c06c_0_35#slide=id.g3f15496c06c_0_35)

## Testing

Ran all three against the v0.2 + v0.3 diagnostics Sheets (overlay, per-config panels vs CEDA v0, and per-config panels vs v0.2). `ruff check`, `ruff format --check`, and `mypy bedrock/utils/validation/analysis/{plotting,overlay_ef_hist,panel_ef_hist}.py` all pass.
