### PR TITLE
Default cornerstone_industry_avg_margins to True

### DIFF
--- a/bedrock/transform/iot/__tests__/test_phi_helpers.py
+++ b/bedrock/transform/iot/__tests__/test_phi_helpers.py
@@ -16,11 +16,15 @@ from bedrock.utils.config.usa_config import USAConfig
 
 class TestMarginsPhiActive:
     def test_active_when_useeio_margins(self) -> None:
-        cfg = USAConfig(useeio_margins=True)
+        cfg = USAConfig(useeio_margins=True, cornerstone_industry_avg_margins=False)
+        assert margins_phi_active(cfg) is True
+
+    def test_active_when_cornerstone_margins(self) -> None:
+        cfg = USAConfig(cornerstone_industry_avg_margins=True)
         assert margins_phi_active(cfg) is True
 
     def test_inactive_when_no_margins_flag(self) -> None:
-        cfg = USAConfig()
+        cfg = USAConfig(cornerstone_industry_avg_margins=False)
         assert margins_phi_active(cfg) is False
 
 

--- a/bedrock/utils/config/configs/2025_usa_cornerstone_full_model.yaml
+++ b/bedrock/utils/config/configs/2025_usa_cornerstone_full_model.yaml
@@ -12,4 +12,3 @@ load_E_from_flowsa: true
 new_ghg_method: true
 use_E_data_year_for_x_in_B: True
 implement_waste_disaggregation: True
-cornerstone_industry_avg_margins: True

--- a/bedrock/utils/config/configs/2025_usa_cornerstone_full_model_v0_3_2024_io_ghg.yaml
+++ b/bedrock/utils/config/configs/2025_usa_cornerstone_full_model_v0_3_2024_io_ghg.yaml
@@ -23,4 +23,3 @@ load_E_from_flowsa: true
 v0_3_umd_2024_ghgia: true
 use_E_data_year_for_x_in_B: True
 implement_waste_disaggregation: True
-cornerstone_industry_avg_margins: True

--- a/bedrock/utils/config/configs/2025_usa_cornerstone_full_model_v0_3_umd_2023_ghgia.yaml
+++ b/bedrock/utils/config/configs/2025_usa_cornerstone_full_model_v0_3_umd_2023_ghgia.yaml
@@ -13,4 +13,3 @@ load_E_from_flowsa: true
 v0_3_umd_2023_ghgia: true
 use_E_data_year_for_x_in_B: True
 implement_waste_disaggregation: True
-cornerstone_industry_avg_margins: True

--- a/bedrock/utils/config/configs/2025_usa_cornerstone_full_model_v0_3_umd_2024_ghgia.yaml
+++ b/bedrock/utils/config/configs/2025_usa_cornerstone_full_model_v0_3_umd_2024_ghgia.yaml
@@ -18,4 +18,3 @@ load_E_from_flowsa: true
 v0_3_umd_2024_ghgia: true
 use_E_data_year_for_x_in_B: True
 implement_waste_disaggregation: True
-cornerstone_industry_avg_margins: True

--- a/bedrock/utils/config/configs/2025_usa_cornerstone_v0_3.yaml
+++ b/bedrock/utils/config/configs/2025_usa_cornerstone_v0_3.yaml
@@ -40,4 +40,3 @@ update_inflation_factors: True
 # Shared full-model flags.
 use_E_data_year_for_x_in_B: True
 implement_waste_disaggregation: True
-cornerstone_industry_avg_margins: True

--- a/bedrock/utils/config/configs/useeio_phoebe_23.yaml
+++ b/bedrock/utils/config/configs/useeio_phoebe_23.yaml
@@ -34,3 +34,4 @@ skip_scrap_adjustment_in_vnorm: true
 new_ghg_method: false
 
 useeio_margins: True
+cornerstone_industry_avg_margins: False

--- a/bedrock/utils/config/configs/useeio_phoebe_23_cornerstone_margins.yaml
+++ b/bedrock/utils/config/configs/useeio_phoebe_23_cornerstone_margins.yaml
@@ -36,4 +36,3 @@ new_ghg_method: false
 # Margins (single change vs useeio_phoebe_23)
 #####
 useeio_margins: false
-cornerstone_industry_avg_margins: true

--- a/bedrock/utils/config/configs/useeio_phoebe_23_restore_cornerstone_A.yaml
+++ b/bedrock/utils/config/configs/useeio_phoebe_23_restore_cornerstone_A.yaml
@@ -21,3 +21,6 @@ deflate_x_to_detail_io_year_for_B: true
 use_ghg_national_2023_m2: true
 skip_scrap_adjustment_in_vnorm: true
 new_ghg_method: false
+
+useeio_margins: True
+cornerstone_industry_avg_margins: False

--- a/bedrock/utils/config/configs/useeio_phoebe_23_restore_cornerstone_B.yaml
+++ b/bedrock/utils/config/configs/useeio_phoebe_23_restore_cornerstone_B.yaml
@@ -20,3 +20,6 @@ deflate_x_to_detail_io_year_for_B: false # False means use Cornerstone B approac
 use_ghg_national_2023_m2: true
 skip_scrap_adjustment_in_vnorm: true
 new_ghg_method: false
+
+useeio_margins: True
+cornerstone_industry_avg_margins: False

--- a/bedrock/utils/config/configs/useeio_phoebe_23_restore_ghg.yaml
+++ b/bedrock/utils/config/configs/useeio_phoebe_23_restore_ghg.yaml
@@ -19,3 +19,6 @@ deflate_x_to_detail_io_year_for_B: true
 use_ghg_national_2023_m2: false # False means use GHG_Cornerstone_2023
 skip_scrap_adjustment_in_vnorm: true
 new_ghg_method: true # True means use GHG_Cornerstone_2023
+
+useeio_margins: True
+cornerstone_industry_avg_margins: False

--- a/bedrock/utils/config/configs/useeio_phoebe_23_restore_iot_redefinition.yaml
+++ b/bedrock/utils/config/configs/useeio_phoebe_23_restore_iot_redefinition.yaml
@@ -21,3 +21,6 @@ deflate_x_to_detail_io_year_for_B: true
 use_ghg_national_2023_m2: true
 skip_scrap_adjustment_in_vnorm: true
 new_ghg_method: false
+
+useeio_margins: True
+cornerstone_industry_avg_margins: False

--- a/bedrock/utils/config/configs/useeio_phoebe_23_restore_schema_and_ghg.yaml
+++ b/bedrock/utils/config/configs/useeio_phoebe_23_restore_schema_and_ghg.yaml
@@ -20,3 +20,6 @@ deflate_x_to_detail_io_year_for_B: true
 use_ghg_national_2023_m2: false # Restore Cornerstone GHG method
 skip_scrap_adjustment_in_vnorm: true
 new_ghg_method: true
+
+useeio_margins: True
+cornerstone_industry_avg_margins: False

--- a/bedrock/utils/config/configs/useeio_phoebe_23_restore_scrap.yaml
+++ b/bedrock/utils/config/configs/useeio_phoebe_23_restore_scrap.yaml
@@ -19,3 +19,6 @@ deflate_x_to_detail_io_year_for_B: true
 use_ghg_national_2023_m2: true
 skip_scrap_adjustment_in_vnorm: false # False means perform scrap adjustment
 new_ghg_method: false
+
+useeio_margins: True
+cornerstone_industry_avg_margins: False

--- a/bedrock/utils/config/configs/v8_ceda_2025_usa.yaml
+++ b/bedrock/utils/config/configs/v8_ceda_2025_usa.yaml
@@ -18,6 +18,7 @@ ipcc_ar_version: "AR6"
 # PUR price conversion
 #####
 ceda_margins: True
+cornerstone_industry_avg_margins: False
 
 #####
 # Bugfix

--- a/bedrock/utils/config/usa_config.py
+++ b/bedrock/utils/config/usa_config.py
@@ -87,7 +87,7 @@ class USAConfig(BaseModel):
     adjust_summary_A_and_q_dollar_year: bool = False  # DRI: mo.li
     ceda_margins: bool = False  # DRI: WesIngwersen
     useeio_margins: bool = False  # DRI: WesIngwersen
-    cornerstone_industry_avg_margins: bool = False  # DRI: WesIngwersen
+    cornerstone_industry_avg_margins: bool = True  # DRI: WesIngwersen
     ### GHG Methodology selection
     load_E_from_flowsa: bool = False  # if True, use load_E_from_flowsa()
     usa_ghg_methodology: ta.Literal['national', 'state'] = 'national'


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

Flip the `cornerstone_industry_avg_margins` default in `USAConfig` (`bedrock/utils/config/usa_config.py`) from `False` to `True`, so the cornerstone margin method applies unless a config opts out. The margins flags remain mutually exclusive (`useeio_margins` / `ceda_margins` / `cornerstone_industry_avg_margins`).

Pin the alternate margin method on configs that select one, since they would otherwise collide with the new default:

- USEEIO-parity configs (`useeio_phoebe_23` + `restore_*` sensitivities): set `useeio_margins: True` and `cornerstone_industry_avg_margins: False`.
- `v8_ceda_2025_usa.yaml`: keep `ceda_margins: True` and add `cornerstone_industry_avg_margins: False`.

Remove the now-redundant explicit `cornerstone_industry_avg_margins: True` lines from the cornerstone configs (`2025_usa_cornerstone_*`) and `useeio_phoebe_23_cornerstone_margins.yaml`, which now inherit the default.

Update `test_phi_helpers.py` for the new default: the `useeio_margins` case now also sets `cornerstone_industry_avg_margins=False`, the inactive case disables it explicitly, and a new case covers `margins_phi_active` under the cornerstone default.

## Testing

Loaded all 47 configs through `USAConfig` validation — all pass, effective margin selection unchanged. `pytest test_phi_helpers.py test_usa_config.py` → 25 passed.