### PR TITLE
Add EF diagnostics dispatch + plot skills

### DIFF
--- a/.claude/skills/dispatch-ef-diagnostics/SKILL.md
+++ b/.claude/skills/dispatch-ef-diagnostics/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: dispatch-ef-diagnostics
+description: Use this skill to dispatch EF (emission-factor) diagnostics runs for the a_matrix_time_series epic — create and name empty diagnostics Google Sheets in the Drive folder, trigger the generate_diagnostics GitHub Actions workflow per (scenario, approach, year) cell, and record the run index. Trigger when the user says "dispatch the EF diagnostics", "kick off the diagnostics runs", "create the diagnostics sheets and run them", "trigger generate_diagnostics", "re-dispatch the failed cells", or asks to run the model under several A-matrix configs and produce per-run diagnostics sheets.
+disable-model-invocation: false
+argument-hint: [scenarios] [years] [approaches] (e.g. "bundle_v0_3 2019-2023" or "isolate_a_matrix useeio_nowcast 2023")
+---
+
+# Dispatch EF diagnostics runs
+
+Fan out the `generate_diagnostics` GitHub Actions workflow to produce **one diagnostics Google Sheet per `(scenario, approach, year)` cell**. Each sheet gets the `N_and_diffs` / `D_and_diffs` / `D_and_N_significant_sectors` / `config_summary` tabs that the `plot-ef-diagnostics` skill consumes. Default baseline is **CEDA-US (v0)**.
+
+The driver is `bedrock/analysis/a_matrix_time_series/dispatch_ef_time_series.py`. Per cell it: (1) **creates** a Sheet in the Drive folder with a deterministic title, (2) **triggers** `gh workflow run generate_diagnostics.yml`, (3) **records** a row in `output/results/ef_run_index.csv`. It is **idempotent** — cells already in the index are skipped, so re-running only fills gaps.
+
+## Prerequisites — verify, don't assume
+
+| Check | How |
+|---|---|
+| `gh` auth + `workflow` scope | `gh auth status` |
+| Workflow registered | `gh workflow list \| grep -i diagnostic` → expect `generate_diagnostics active` |
+| Configs exist **on the ref** | `git fetch origin <ref>` then `git cat-file -e origin/<ref>:bedrock/utils/config/configs/<cfg>.yaml`. Don't trust a spec sheet's "on main?" column — confirm. |
+| Google ADC + Drive | `gcloud auth application-default login` (Drive scope). Confirm read access + see what's already in the folder via `_drive_client().files().list(...)`. |
+| USEEIO baseline pin | `bedrock/utils/snapshots/useeio_baseline_pin.json` (currently `USEEIOv2.6.0-phoebe-23`, a GCS Excel). With `use_useeio_baseline=true` the workflow benchmarks against this pin **in addition to** the always-on CEDA-v0 comparison. |
+
+Workflow inputs (`generate_diagnostics.yml`): `config_name, sheet_id, use_useeio_baseline (bool), model_base_year, usa_ghg_data_year, pr_url`. The **git-ref is `gh workflow run --ref`, not an input** — it selects the model code the run executes against.
+
+## Clarify first — ask before acting
+
+Do **not** create any sheet or dispatch until these are confirmed. Ask via `AskUserQuestion`, offering the default as the recommended option. Treat anything still ambiguous as a blocker.
+
+| Detail | Default |
+|---|---|
+| Drive folder | `1M2-Vopqfrx1vGcwoNi6wq55FmoELNV1s` (`EF_TIME_SERIES_DRIVE_FOLDER_ID`) |
+| Scenarios | `bundle_v0_3` (or `isolate_a_matrix`, or both) |
+| Approaches | all in the scenario (e.g. restrict to `useeio_nowcast`) |
+| Years | `2019,2020,2021,2022,2023` — sets `model_base_year` + `usa_ghg_data_year` |
+| Baseline | CEDA-only (ask whether to also tick USEEIO via `--use-useeio-baseline`) |
+| git-ref | `main` |
+| Throttle | `poll` (or `sleep:N` / `none`) |
+| Sheet title | `[{date}, {year}, {baseline} based, {approach label}, {scenario}] EFs diagnostics` |
+| Dry-run first? | yes |
+
+Echo the resolved plan back (folder, cell count, baseline, git-ref) and get a go-ahead before the non-dry-run dispatch — it creates sheets and consumes CI minutes. **Always show the full list of sheet titles for review before creating any.**
+
+## Bespoke config lists (the common real case)
+
+Most real requests come as a **config-spec Google Sheet**, not the two canned scenarios. `SCENARIO_YAMLS` only knows `isolate_a_matrix` / `bundle_v0_3` (4 A-matrix YAMLs each) — an arbitrary release-progression list (`useeio_phoebe_23*`, `2025_usa_cornerstone_*`, `…_v0_3_*`) **can't be expressed via `--scenarios/--approaches`**. Don't force-fit it.
+
+Instead drive the dispatcher's **helper functions** with the custom list (reuse, don't reinvent):
+
+```python
+from bedrock.analysis.a_matrix_time_series.dispatch_ef_time_series import (
+    _create_sheet, _trigger_workflow, _wait_for_capacity, EF_TIME_SERIES_DRIVE_FOLDER_ID,
+)
+# per config: _wait_for_capacity(...) → _create_sheet(folder, title) → _trigger_workflow(...) → persist a row
+```
+
+A spec sheet's observed layout has two baseline-grouped tables:
+- **"compare to USEEIO Phoebe"** → run with `use_useeio_baseline=true`.
+- **"compare to v0 ceda"** → CEDA-only (default).
+- A config in **both** is the user's call: one run with the box on already includes CEDA-v0 columns (so a separate CEDA-only sheet is partly redundant) vs. two distinct sheets. Surface it; let them choose.
+- These are **release snapshots → one run per config**, not the multi-year sweep. **Match each config's year to its YAML**: configs that set `v0_3_umd_2024_ghgia: true` or hard-code `model_base_year: 2024` (e.g. `…_2024_io_ghg`, `…_umd_2024_ghgia`, **and FINAL `…_v0_3`**) must run at 2024. When a config hard-codes its years, pass **no** `model_base_year`/`usa_ghg_data_year` override so the YAML wins.
+
+Persist this batch to a **separate index CSV** (e.g. `output/results/ef_run_index_release_<label>.csv`), not the canonical `ef_run_index.csv`, so `compile_ef_diagnostics` isn't polluted. Write `sheet_id` on create and `triggered_at` on trigger so the run is **resumable** — re-running skips rows that already have `triggered_at`.
+
+## Runtime & serialization
+
+`generate_diagnostics.yml` sets `concurrency: { group: generate_diagnostics, cancel-in-progress: false }`, so GitHub runs these **one at a time**; firing many in quick succession **drops** the pending ones. So:
+- The `poll` throttle is **mandatory**; the batch is effectively serial.
+- Runs are **typically ~2–5 min each** (`timeout-minutes: 60` is a ceiling, not the norm) ⇒ a batch ≈ N × a few min; **24 runs ≈ 1–1.5 h**.
+- Run the dispatcher **in the background** for anything beyond a handful of cells; report progress from its log + index.
+- `_wait_for_capacity`'s default `timeout=1800` is usually fine; pass `timeout≈5400` as a safety margin in case a run nears the 60-min ceiling.
+- Don't parallelize by firing fast — you'll lose runs to the concurrency group.
+
+## Known failure modes (model-side, not dispatch)
+
+These surface as a **failed GH run after a successful dispatch** — the sheet is created but stays empty. Pre-flight by grepping each config for year flags and snapshot pins.
+
+- **Year / flag mismatch.** Overriding `usa_ghg_data_year`/`model_base_year` to a value a config forbids → e.g. `ValueError: usa_ghg_data_year=2023 is incompatible with v0_3_umd_2024_ghgia`. Catch up front: `grep -lE 'v0_3_umd_2024_ghgia:\s*[Tt]rue' …/configs/*.yaml` → those run at 2024. Fix: re-run at the required year **and rename the sheet's year** to match.
+- **Interim configs pinned to an old snapshot.** A config that pins `snapshot_version_or_git_sha` and flips an interim flag (e.g. `2025_usa_cornerstone_ghg_mecs` + `update_mecs_method`) may fail to resolve its GHG FlowBySector method on `main` HEAD → `AttributeError: 'NoneType' object has no attribute 'pop'` in flowsa `generateFlowBySector`. Run these against their **pinned snapshot/branch**, not `main`. Often the effect is already folded into a later bundled config (MECS ⊂ `…_umd_2024_ghgia`), so the standalone cell can be skipped.
+
+## Standard procedure
+
+1. **Dry-run first** — prints the plan (titles + configs), creates/triggers nothing:
+   ```bash
+   python -m bedrock.analysis.a_matrix_time_series.dispatch_ef_time_series \
+       --git-ref main --scenarios bundle_v0_3 --years 2019,2020,2021,2022,2023 --dry-run
+   ```
+2. **Dispatch for real** (drop `--dry-run`):
+   ```bash
+   python -m bedrock.analysis.a_matrix_time_series.dispatch_ef_time_series \
+       --git-ref main \
+       --scenarios isolate_a_matrix,bundle_v0_3 \
+       --years 2019,2020,2021,2022,2023 \
+       [--approaches useeio_nowcast] [--use-useeio-baseline] [--throttle poll|sleep:N|none]
+   ```
+3. **Wait** for GH Actions (~2–5 min per run, serial). Watch with `gh run list --workflow generate_diagnostics.yml`.
+4. **Compile + plot** (reviewer path — see the `plot-ef-diagnostics` skill):
+   ```bash
+   python -m bedrock.analysis.a_matrix_time_series.compile_ef_diagnostics
+   python -m bedrock.analysis.a_matrix_time_series.plot_ef_diagnostics
+   ```
+
+## Flags
+
+| Flag | Meaning |
+|---|---|
+| `--git-ref` | **Required.** Branch/tag the workflow runs against (usually `main`). |
+| `--scenarios` | Comma list: `isolate_a_matrix`, `bundle_v0_3` (default `bundle_v0_3`). |
+| `--years` | Comma list (default `2019,2020,2021,2022,2023`). Sets `model_base_year` and `usa_ghg_data_year`. |
+| `--approaches` | Optional filter, e.g. `useeio_nowcast`. Default = all approaches in the scenario. |
+| `--use-useeio-baseline` | Add USEEIO baseline columns. Default = CEDA-only. |
+| `--throttle` | `poll` (default; blocks until prior runs clear), `sleep:N`, or `none`. |
+| `--dry-run` | Print the plan only. |
+| `--re-dispatch-from-csv` | Re-trigger cells already in `ef_run_index.csv` (recovery; **reuses** existing sheets). |
+
+## Conventions (don't reinvent)
+
+- **Drive folder:** `EF_TIME_SERIES_DRIVE_FOLDER_ID = 1M2-Vopqfrx1vGcwoNi6wq55FmoELNV1s`.
+- **Sheet title:** `[{YYYY-MM-DD}, {year}, {baseline} based, {approach label}, {scenario}] EFs diagnostics`.
+- **Run index:** `output/results/ef_run_index.csv` — columns `scenario, approach, year, baseline, config_name, sheet_id, sheet_title, useeio_box_ticked, git_ref, triggered_at`.
+- **Scenario → YAML** (in `dispatch_ef_time_series.py`), keyed by approach:
+  - `isolate_a_matrix` (A-matrix method only, else v0 defaults): `2025_usa_cornerstone_A_{useeio,summary_tables,commodity_price_index,useeio_nowcast}`.
+  - `bundle_v0_3` (full v0.3 stack + one A-matrix alternative): `2025_usa_cornerstone_full_model_A_{…}`.
+- **Approach labels** (title text): `useeio → "A matrix with 2017 benchmark A"`, `summary_tables → "A matrix with summary tables"`, `commodity_price_index → "A matrix with commodity price index"`, `useeio_nowcast → "A matrix from USEEIO nowcast"`.
+
+## Recovery / utilities
+
+- **Lost the local index?** Rebuild from Drive: `python -m bedrock.analysis.a_matrix_time_series.recover_ef_run_index --folder-id 1M2-Vopqfrx1vGcwoNi6wq55FmoELNV1s`.
+- **Batch hit rate limits?** `--re-dispatch-from-csv` re-triggers without minting new sheets.
+
+## Manual fallback (no driver)
+
+For a one-off cell by hand: create a sheet in the Drive folder named per the template (`_create_sheet` or Drive UI), trigger the workflow, then append the index row yourself:
+```bash
+gh workflow run generate_diagnostics.yml --ref main \
+  -f config_name=<config> -f sheet_id=<id> \
+  -f model_base_year=<year> -f usa_ghg_data_year=<year> -f use_useeio_baseline=false
+```
+
+## Reference
+
+- Driver: `bedrock/analysis/a_matrix_time_series/dispatch_ef_time_series.py`
+- Workflow: `.github/workflows/generate_diagnostics.yml` → `bedrock/utils/validation/generate_diagnostics.py` (single-run entry) → `calculate_ef_diagnostics.py` (writes the tabs).
+- Package overview + DAG: `bedrock/analysis/a_matrix_time_series/README.md`.
+- Operator checklist: `bedrock/analysis/a_matrix_time_series/useeio_nowcast_ef_runbook.md`.

--- a/.claude/skills/plot-ef-diagnostics/SKILL.md
+++ b/.claude/skills/plot-ef-diagnostics/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: plot-ef-diagnostics
+description: Use this skill to generate plots from one or more EF (emission-factor) diagnostics Google Sheets — the per-sector N (total EF) / D (direct EF) percent-diff distributions vs the CEDA-US (v0) baseline, cross-scenario comparisons (e.g. current scenario vs a v0.2 snapshot sheet), and deck-style histogram panels. Trigger when the user says "plot N against CEDA v0", "compare N to the v0.2 sheet", "make the EF diagnostics plots", "match the deck histogram style", "plot the diagnostics for this sheet", or hands over a diagnostics sheet URL/ID and asks for N/EF comparison plots.
+disable-model-invocation: false
+argument-hint: <diagnostics-sheet-id-or-url> [vs <baseline-sheet-id> | --deck-style] [color]
+---
+
+# Plot EF diagnostics
+
+Produce N/EF comparison plots from diagnostics sheets. **Reuse the repo's existing plotting machinery — every panel style the user asks for already exists.** Import the fetch + plot primitives below before writing anything new.
+
+## Step 0 — orient (always)
+
+- A diagnostics sheet has tabs `N_and_diffs`, `D_and_diffs`, `D_and_N_significant_sectors`, `config_summary`. Columns: `sector, sector_name, N_new, N_old_inflated, N_old, N_perc_diff, comparison_type` (D mirrors N).
+- **`N_perc_diff` is already "N vs CEDA v0"** — `(N_new − N_old_inflated) / |N_old_inflated|`, where `N_old_inflated` is the CEDA baseline inflated to the run's dollar year. So most "vs CEDA" asks need no recomputation.
+- Reading a sheet via the Drive MCP returns markdown that **escapes underscores** (`N\_new`). Don't grep the raw export for `N_new` — use `load_tab` (below).
+- Check `config_summary` for run identity + dollar year (`config_name`, `model_base_year`, `usa_io_data_year`, `usa_ghg_data_year`).
+
+## Clarify first — ask before plotting
+
+Once you know the sheet(s), confirm via `AskUserQuestion` (defaults as recommended). Skip a question only when the user already answered it.
+
+| Detail | Default |
+|---|---|
+| Diagnostics sheet ID(s) | from the user — accept URL or bare ID; extract the ID |
+| Comparison mode | vs CEDA v0 (Recipe A). B = vs another sheet; C = deck histogram style |
+| Baseline / comparison sheet | required for Recipe B (e.g. the v0.2 sheet whose `N_new` is the baseline) |
+| EF kind | N (total), D (direct), or both |
+| Panel color / label | by approach (`APPROACH_COLORS`); orange `#ff7f0e` if asked |
+| Output tag / folder | sheet- or config-derived; lands under `bedrock/utils/validation/analysis/output/<tag>/` |
+
+For Recipe B, surface the **dollar-year guard** (below) and ask whether to proceed on raw `N_new` or switch to inflation-adjusted columns.
+
+## Building blocks (import, don't re-implement)
+
+- **Fetch (parquet-cached):** `from bedrock.utils.validation.analysis.fetch import load_tab` → `load_tab(sheet_id, "N_and_diffs")` (pass `refresh=True` to re-pull).
+- **Plot primitives:** `from bedrock.utils.validation.analysis.plotting import setup_mpl, percent_histogram, apply_axis_fonts, save_and_close, DEFAULT_XLIM, TITLE_FONTSIZE`.
+- **Deck-panel extractor + constants:** `from bedrock.analysis.a_matrix_time_series.plot_v0_3_n_pct_hist import _pct_values` and `from bedrock.analysis.a_matrix_time_series.plot_ef_diagnostics import HIST_BINS, HIST_PCT_CLIP, HIST_FONT_SCALE, HIST_STATS_EXTRA_SCALE, STATS_FONTSIZE, TITLE_FONTSIZE, AXIS_LABEL_FONTSIZE, TICK_LABEL_FONTSIZE`.
+- **Approach palette** (`from bedrock.analysis.a_matrix_time_series.constants import APPROACH_COLORS`): `useeio #7f7f7f`, `ceda_default #bcbd22`, `summary_tables #1f77b4`, `industry_price_index #9467bd`, `commodity_price_index #2ca02c`, `useeio_nowcast #ff7f0e`.
+
+## Recipe A — single sheet, N/D vs CEDA v0 (full suite)
+
+The maintained CLI; produces the N % diff histogram (the core ask) + N/D 2×2 + EF scatters from the sheet's own diffs:
+```bash
+uv run python -m bedrock.utils.validation.analysis.diagnostics_plots \
+    --sheet-id <SHEET_ID> --tag <label>
+```
+Outputs: `ef_n_perc_diff_histogram.png`, `ef_perc_diff_histogram.png`, `ef_pct_change_vs_abs_change.png`, `ef_pct_change_vs_ef_size.png`, `ef_abs_change_histogram.png` (+ `bly_*` if a `BLy` tab exists).
+
+## Recipe B — cross-scenario: this sheet's N vs another sheet's N (e.g. v0.2)
+
+For "current scenario vs the v0.2 sheet" (v0.2's N lives in *its* `N_new`), **no rerun needed** — inner-join the two sheets' `N_new` on `sector` (row order differs; drop zero/old-only rows).
+
+**Guard first:** compare `N_new` directly **only if dollar years match** (`model_base_year`, `usa_io_data_year`, `usa_ghg_data_year` equal in both `config_summary` tabs). If they differ, the comparison conflates method change with inflation — use the inflation-adjusted columns instead.
+
+Reuse `load_tab` + `percent_histogram`: produce a log-log scatter (`x = baseline N`, `y = current N`, y=x line, R², median/p95 of % diff) and a `percent_histogram` of `(current − baseline)/|baseline|`. (Prior inline script saved under `output/current_vs_v0_2/`.)
+
+## Recipe C — deck histogram style (match the slides)
+
+Deck panels (e.g. "[CEDA as baseline] Bundled effect in N", titled by approach) come from `plot_ef_diagnostics._hist_panel` / `plot_v0_3_n_pct_hist._render`: each panel is one sheet's `N_perc_diff`, clipped to ±`HIST_PCT_CLIP` (100%), `HIST_BINS` (60) bins, zero line, `PercentFormatter` x-axis "Percentage Diff (%)", y "sector count", an `n / median / p95(|·|)` white box top-left, title + bar color from the approach.
+
+- Single sheet, exact deck style: `python -m bedrock.analysis.a_matrix_time_series.plot_v0_3_n_pct_hist <SHEET_ID>`.
+- **Color override** (the script colors by approach, grey for unrecognized configs): replicate the `_render` body in a small figure, pulling pct via `_pct_values(load_tab(sid, "N_and_diffs"), "N")`, and pass an explicit color. **Orange = `#ff7f0e`** (the `useeio_nowcast` entry).
+- **Side-by-side** (e.g. "v0.2 vs new"): lay panels out 1×N reusing the same constants so output matches the deck. Keep v0.2 blue (`#1f77b4`); color the new scenario as requested.
+
+## Standing rules
+
+- **Search before creating.** Prefer Recipe A/C's entry points; drop to an inline script only for cross-sheet joins (B) or a color/layout the scripts don't expose.
+- **Never aggregate A-matrix Δ across columns** — different denominators per column, not commensurable. (N/EF per-sector diffs are fine to pool.)
+- **Name artifacts by content, not step number** — no `step*` prefixes in PNG/CSV/tab names.
+- Verify each PNG by reading it back before reporting done; report key stats (n, median, p95, top movers).
+
+## Reference
+
+- `bedrock/utils/validation/analysis/`: `diagnostics_plots.py` (CLI), `plotting.py` (primitives), `fetch.py` (cached loader).
+- `bedrock/analysis/a_matrix_time_series/`: `plot_ef_diagnostics.py` (`_hist_panel`, `_scatter_panel`, constants), `plot_v0_3_n_pct_hist.py` (`_render`, `_pct_values`), `constants.py` (`APPROACH_COLORS`).
+- Sheets come from the `dispatch-ef-diagnostics` skill / `generate_diagnostics` workflow.


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

Add two operator skills under `.claude/skills/` for the `a_matrix_time_series` EF-diagnostics flow:

- `dispatch-ef-diagnostics` — create/name the per-`(scenario, approach, year)` diagnostics Google Sheets, trigger the `generate_diagnostics` workflow, and record `ef_run_index.csv`.
- `plot-ef-diagnostics` — generate the N/D percent-diff histograms, cross-scenario comparisons, and deck-style panels from those sheets.

Both are single `SKILL.md` files. Every code path, constant, CLI flag, and import they reference was verified against the current tree (`dispatch_ef_time_series.py`, `diagnostics_plots.py`, `plot_ef_diagnostics.py`, `plot_v0_3_n_pct_hist.py`, `APPROACH_COLORS`).

## Testing

Docs-only; no runtime code changed. Facts cross-checked against the referenced modules.