### PR TITLE
feat(config): point canonical pipeline at 2025_usa_cornerstone_v0_3

### DIFF
--- a/.github/workflows/generate_diagnostics.yml
+++ b/.github/workflows/generate_diagnostics.yml
@@ -7,7 +7,7 @@ on:
         description: "USA config name (without .yaml extension)"
         required: true
         type: string
-        default: "2025_usa_cornerstone_full_model"
+        default: "2025_usa_cornerstone_v0_3"
       sheet_id:
         description: "Google Sheets ID for EF diagnostics"
         required: true

--- a/.github/workflows/generate_snapshots.yml
+++ b/.github/workflows/generate_snapshots.yml
@@ -7,7 +7,7 @@ on:
         description: "USA config name (without .yaml extension)"
         required: true
         type: string
-        default: "2025_usa_cornerstone_full_model"
+        default: "2025_usa_cornerstone_v0_3"
       snapshot_prefix_override:
         description: "Override snapshot prefix (optional)"
         required: false
@@ -42,7 +42,7 @@ jobs:
       - name: Generate snapshots
         id: generate
         run: |
-          CONFIG_NAME="${{ github.event.inputs.config_name || '2025_usa_cornerstone_full_model' }}"
+          CONFIG_NAME="${{ github.event.inputs.config_name || '2025_usa_cornerstone_v0_3' }}"
           PREFIX="${{ github.event.inputs.snapshot_prefix_override }}"
           uv run python bedrock/utils/snapshots/generate_snapshots.py \
             --config_name "$CONFIG_NAME" \

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ See [`USAConfig`](bedrock/utils/config/usa_config.py) for the full list.
 ### Configuration files
 
 All configuration files are in [`bedrock/utils/config/configs/`](bedrock/utils/config/configs/), where:
-- A single *full-model* config represents a full set of methodology choices made for a data release. For example, [`2025_usa_cornerstone_full_model.yaml`](bedrock/utils/config/configs/2025_usa_cornerstone_full_model.yaml) is now the default config in `get_usa_config()`.
+- A single *full-model* config represents a full set of methodology choices made for a data release. [`2025_usa_cornerstone_v0_3.yaml`](bedrock/utils/config/configs/2025_usa_cornerstone_v0_3.yaml) is the default config in `get_usa_config()`. [`2025_usa_cornerstone_full_model.yaml`](bedrock/utils/config/configs/2025_usa_cornerstone_full_model.yaml) retains the v0.2 methodology stack for historical comparison.
 - Several *atomic configs* each isolate a single methodological change from the baseline so the impact of each choice can be measured independently. For example, [`2025_usa_cornerstone_taxonomy.yaml`](bedrock/utils/config/configs/2025_usa_cornerstone_taxonomy.yaml) is the config for a specific choice to use Cornerstone taxonomy.
 
 A separate `snapshot_version_or_git_sha` field specifies the baseline SHA, so diagnostic runs can compare current output against any released baseline.

--- a/bedrock/publish/README.md
+++ b/bedrock/publish/README.md
@@ -113,14 +113,14 @@ computes `Ydom_matrix = Ytot_matrix - Yimp_matrix`. Then re-extend
    `write_model_to_xlsx` to a tmp directory and compares against the
    parquet snapshot.
 
-   **The test is hard-coded to `2025_usa_cornerstone_full_model`.** If
+   **The test uses `CANONICAL_USA_CONFIG` (`2025_usa_cornerstone_v0_3`).** If
    `<cfg>` differs, this step does NOT validate the artifact you are
    about to publish. (TODO: parameterize the test to validate arbitrary
    configs; tracked in
    [bedrock/publish/__tests__/test_excel_vs_snapshot.py](__tests__/test_excel_vs_snapshot.py).)
 
    **Skippable when** all three hold:
-   - `<cfg>` is `2025_usa_cornerstone_full_model`, AND
+   - `<cfg>` is `2025_usa_cornerstone_v0_3`, AND
    - you are publishing from a `main` SHA covered by the most recent
      green
      [`test_integration.yml`](../../.github/workflows/test_integration.yml)

--- a/bedrock/publish/__tests__/test_excel_vs_snapshot.py
+++ b/bedrock/publish/__tests__/test_excel_vs_snapshot.py
@@ -6,7 +6,7 @@ written at HEAD reproduces the values of the pinned
 implies either (a) bedrock derivation drift, or (b) the snapshot is stale
 and needs regenerating via `bedrock.utils.snapshots.generate_snapshots`.
 
-TODO: `_DEFAULT_CONFIG` is hard-coded to `2025_usa_cornerstone_full_model`,
+TODO: `_DEFAULT_CONFIG` is hard-coded to ``CANONICAL_USA_CONFIG``
 so this guard only covers that config. Parameterize via env var or pytest
 parameter so arbitrary configs published via `bedrock.publish.excel.cli` can be
 validated against their corresponding snapshots before upload.
@@ -24,9 +24,10 @@ import pytest
 from bedrock.publish.__tests__._helpers import setup_config, teardown
 from bedrock.publish.excel.writer import write_model_to_xlsx
 from bedrock.publish.model_objects import PUBLISH_LOCATION
+from bedrock.utils.config.usa_config import CANONICAL_USA_CONFIG
 from bedrock.utils.snapshots.loader import load_current_snapshot
 
-_DEFAULT_CONFIG = '2025_usa_cornerstone_full_model'
+_DEFAULT_CONFIG = CANONICAL_USA_CONFIG
 
 
 def _strip_loc_suffix(values: pd.Index) -> pd.Index:

--- a/bedrock/utils/config/config_controllers.py
+++ b/bedrock/utils/config/config_controllers.py
@@ -5,7 +5,7 @@ that run the same pipeline under multiple configurations sequentially.
 helpers bypass that guard by writing directly to the module globals, enabling
 patterns like::
 
-    for config_name in ("useeio_phoebe_23", "2025_usa_cornerstone_full_model"):
+    for config_name in ("useeio_phoebe_23", "2025_usa_cornerstone_v0_3"):
         reset_usa_config()
         set_usa_config(config_name)
         results[config_name] = run_pipeline()

--- a/bedrock/utils/config/usa_config.py
+++ b/bedrock/utils/config/usa_config.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field, model_validator
 
 CONFIG_DIR = os.path.join(os.path.dirname(__file__), 'configs')
 USA_CONFIG_ENV_VAR = 'USA_CONFIG_FILE'
+CANONICAL_USA_CONFIG = '2025_usa_cornerstone_v0_3'
 
 DIAGNOSTICS_CLI_OVERRIDE_KEYS: frozenset[str] = frozenset(
     {
@@ -345,7 +346,7 @@ def get_usa_config() -> USAConfig:
         if env_usa_config_file:
             _usa_config = _load_usa_config_from_file_name(env_usa_config_file)
         else:
-            set_global_usa_config('2025_usa_cornerstone_full_model.yaml')
+            set_global_usa_config(f'{CANONICAL_USA_CONFIG}.yaml')
     assert _usa_config is not None
     return _usa_config
 

--- a/bedrock/utils/snapshots/README.md
+++ b/bedrock/utils/snapshots/README.md
@@ -27,7 +27,7 @@ These are **independent** concepts and frequently point at different commits:
 | Release tag | annotated git tag `v0.X.Y` | Marks a snapshot/release boundary so methodology evolution is easy to read in history. |
 | Named release | [`releases.py`](releases.py) | Reference-only map of release labels → snapshot SHAs. Not imported by runtime code; update in Phase A alongside `.SNAPSHOT_KEY`. |
 | Diagnostic baseline pin | `USAConfig.snapshot_version_or_git_sha` | `Literal[...]` of SHAs that any config may point at as its diagnostic baseline. Every released snapshot SHA must be added here. |
-| Canonical config | [`2025_usa_cornerstone_full_model.yaml`](../config/configs/2025_usa_cornerstone_full_model.yaml) | The single config used to generate the snapshots that back `.SNAPSHOT_KEY`. Atomic configs are not snapshotted here; see "Adhoc snapshots" below. |
+| Canonical config | [`2025_usa_cornerstone_v0_3.yaml`](../config/configs/2025_usa_cornerstone_v0_3.yaml) | The single config used to generate the snapshots that back `.SNAPSHOT_KEY`. Atomic configs are not snapshotted here; see "Adhoc snapshots" below. |
 
 ### Where snapshot SHAs live
 
@@ -112,7 +112,7 @@ Trigger the `generate_snapshots` workflow manually:
 
 - GitHub → Actions → **generate_snapshots** → Run workflow
 - Branch: `main` (or the specific SHA from step A1 if newer commits have landed)
-- `config_name`: leave as the default `2025_usa_cornerstone_full_model` (the canonical config)
+- `config_name`: leave as the default `2025_usa_cornerstone_v0_3` (the canonical config)
 - Leave `snapshot_prefix_override` blank so the prefix is the commit SHA
 
 Wait for the success notification in `#alerts-bedrock`. Artifacts will be at `gs://cornerstone-default/snapshots/<sha>/`.
@@ -165,7 +165,7 @@ git tag -a v0.X.Y -m "Bedrock release v0.X.Y
 
 Snapshot SHA:  $SNAP
 GCS prefix:    gs://cornerstone-default/snapshots/$SNAP/
-Canonical config: 2025_usa_cornerstone_full_model
+Canonical config: 2025_usa_cornerstone_v0_3
 
 Highlights since previous tag:
 - <bullet>
@@ -188,7 +188,7 @@ Post in `#alerts-bedrock` (and any other relevant channel):
 > :package: **Bedrock release `v0.X.Y`**
 > Tag SHA: `<short_tag_sha>` ([compare](https://github.com/cornerstone-data/bedrock/compare/v0.X.<prev>...v0.X.Y))
 > Snapshot SHA: `<short_snapshot_sha>` (unchanged from previous release / new since `v0.X.<prev>`)
-> Canonical config: `2025_usa_cornerstone_full_model`
+> Canonical config: `2025_usa_cornerstone_v0_3`
 > Highlights: <one or two lines>
 > Downstream impact: <e.g. diagnostics baselines should bump to this SHA when ready>
 
@@ -208,7 +208,7 @@ A clean bump PR diff looks roughly like this (anticipating release `v0.3.0`):
 --- a/bedrock/utils/snapshots/releases.py
 +++ b/bedrock/utils/snapshots/releases.py
  v0_2 = "7372464249c434c9bebb172c065a4d0e3702176e"  # config: 2025_usa_cornerstone_full_model
-+v0_3_0 = "<new_sha>"  # config: 2025_usa_cornerstone_full_model
++v0_3_0 = "<new_sha>"  # config: 2025_usa_cornerstone_v0_3
 
 --- a/bedrock/utils/config/usa_config.py
 +++ b/bedrock/utils/config/usa_config.py
@@ -238,7 +238,7 @@ If a bad snapshot accidentally got uploaded under a SHA you want to keep, you ca
 
 The `generate_snapshots.py` script supports `--adhoc`, which uploads to `gs://cornerstone-default/snapshots/<sha>/adhoc/` instead of the top-level SHA folder. Use this for:
 
-- Snapshotting an atomic config (anything other than `2025_usa_cornerstone_full_model`)
+- Snapshotting an atomic config (anything other than `2025_usa_cornerstone_v0_3`)
 - Local experimentation where you don't want to pollute the canonical snapshot prefix
 
 Adhoc snapshots are never wired into `.SNAPSHOT_KEY` or `releases.py`. They exist for ad-hoc diagnostic comparisons only.

--- a/bedrock/utils/snapshots/generate_snapshots.py
+++ b/bedrock/utils/snapshots/generate_snapshots.py
@@ -14,7 +14,7 @@ import pyarrow.parquet as pq
 
 import bedrock.utils.config.common as common
 from bedrock.utils.config.settings import GIT_HASH_LONG, PATHS
-from bedrock.utils.config.usa_config import set_global_usa_config
+from bedrock.utils.config.usa_config import CANONICAL_USA_CONFIG, set_global_usa_config
 from bedrock.utils.io.gcp import upload_file_to_gcs
 from bedrock.utils.io.gcp_paths import GCS_SNAPSHOT_DIR
 from bedrock.utils.snapshots.names import SnapshotName
@@ -126,9 +126,7 @@ def upload_snapshots(
 
 
 @click.command(help='Generate snapshots for bedrock EEIO model')
-@click.option(
-    '--config_name', required=True, type=str, default='2025_usa_cornerstone_full_model'
-)
+@click.option('--config_name', required=True, type=str, default=CANONICAL_USA_CONFIG)
 @click.option('--adhoc', is_flag=True, help='Upload to adhoc directory')
 @click.option(
     '--snapshot_prefix_override',

--- a/bedrock/utils/validation/generate_diagnostics.py
+++ b/bedrock/utils/validation/generate_diagnostics.py
@@ -13,7 +13,11 @@ from bedrock.utils.config.settings import (
     GIT_HASH_LONG,
     GIT_PR_URL,
 )
-from bedrock.utils.config.usa_config import get_usa_config, set_global_usa_config
+from bedrock.utils.config.usa_config import (
+    CANONICAL_USA_CONFIG,
+    get_usa_config,
+    set_global_usa_config,
+)
 from bedrock.utils.io.gcp import delete_default_sheet1, update_sheet_tab
 from bedrock.utils.snapshots.loader import resolve_snapshot_key
 
@@ -28,7 +32,7 @@ logger = logging.getLogger(__name__)
     '--config_name',
     required=True,
     type=str,
-    default='2025_usa_cornerstone_full_model',
+    default=CANONICAL_USA_CONFIG,
 )
 @click.option('--git_branch', default=None, type=str, help='Override git branch name')
 @click.option('--pr_url', default=None, type=str, help='Override PR URL')


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

The bedrock pipeline default config becomes `2025_usa_cornerstone_v0_3` instead of `2025_usa_cornerstone_full_model`.

- `CANONICAL_USA_CONFIG` in `usa_config.py` is the single source of truth for the config stem.
- `get_usa_config()`, `generate_snapshots`, `generate_diagnostics`, and the `generate_snapshots` / `generate_diagnostics` GitHub workflows use that constant.
- `test_excel_vs_snapshot` and README / snapshots / publish docs reference the v0.3 config as canonical.
- `2025_usa_cornerstone_full_model.yaml` remains available for the v0.2 methodology stack.

## Testing

```powershell
uv run black --check .
uv run ruff check .
uv run pytest
```

### IMPORTANT
Integration tests will fail upon pulling this in until the snapshot is regenerated on main and `.SNAPSHOT_KEY` is updated

