### PR TITLE
test(transform): pin GHG_national_Cornerstone_2024 FBS regen

### DIFF
--- a/bedrock/extract/__tests__/conftest.py
+++ b/bedrock/extract/__tests__/conftest.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import typing as ta
+
+import pytest
+
+import bedrock.extract.allocation.epa as epa
+import bedrock.utils.config.common as common
+from bedrock.utils.config.usa_config import reset_usa_config, set_global_usa_config
+
+# EPA_GHGI FBA generation loads staged tables via allocation/epa.py, which
+# reads usa_ghg_data_year from the global config. Pin 2023 so regen tests do
+# not inherit v0.3 (2024 / pre-built FBS from GCS).
+_USA_CONFIG_FOR_EPA_FBA_INTEGRATION = 'test_usa_config'
+
+
+def _clear_epa_extract_caches() -> None:
+    for obj in epa.__dict__.values():
+        cache_clear = getattr(obj, 'cache_clear', None)
+        if cache_clear is not None:
+            cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def usa_config_2023_for_epa_fba_integration(
+    request: pytest.FixtureRequest,
+) -> ta.Iterator[None]:
+    if request.node.get_closest_marker('eeio_integration') is None:
+        yield
+        return
+
+    _clear_epa_extract_caches()
+    reset_usa_config(should_reset_env_var=True)
+    set_global_usa_config(_USA_CONFIG_FOR_EPA_FBA_INTEGRATION)
+    common.download_fba_on_api_error = True
+    try:
+        yield
+    finally:
+        _clear_epa_extract_caches()
+        reset_usa_config(should_reset_env_var=True)
+        common.download_fba_on_api_error = False

--- a/bedrock/extract/eia/EIA_MECS_Energy_Allocation_CEDA.yaml
+++ b/bedrock/extract/eia/EIA_MECS_Energy_Allocation_CEDA.yaml
@@ -13,3 +13,4 @@ url: None
 parse_response_fxn: !script_function:EIA_MECS eia_mecs_energy_ceda_parse
 years:
   - 2018
+  - 2022

--- a/bedrock/transform/__tests__/test_fbs.py
+++ b/bedrock/transform/__tests__/test_fbs.py
@@ -24,7 +24,7 @@ def _prepare_fbs_for_pin_compare(df: pd.DataFrame) -> pd.DataFrame:
     out = df.drop(columns=_SKIP_FBS_COMPARE_COLUMNS, errors='ignore').copy()
     for col in _NUMERIC_FBS_COMPARE_COLUMNS:
         if col in out.columns:
-            out[col] = pd.to_numeric(out[col], errors='coerce')
+            out[col] = pd.to_numeric(out[col], errors='coerce').fillna(0.0)
     return out
 
 

--- a/bedrock/transform/__tests__/test_fbs.py
+++ b/bedrock/transform/__tests__/test_fbs.py
@@ -16,6 +16,16 @@ from bedrock.utils.snapshots.fbs_pin import (
 from bedrock.utils.validation.validation import compare_FBS
 
 _SKIP_FBS_COMPARE_COLUMNS = ['ProducedBySectorType', 'ConsumedBySectorType']
+# Pinned parquet may store these as object/None; regen uses float64/NaN per schema.
+_NUMERIC_FBS_COMPARE_COLUMNS = ('Spread', 'Min', 'Max')
+
+
+def _prepare_fbs_for_pin_compare(df: pd.DataFrame) -> pd.DataFrame:
+    out = df.drop(columns=_SKIP_FBS_COMPARE_COLUMNS, errors='ignore').copy()
+    for col in _NUMERIC_FBS_COMPARE_COLUMNS:
+        if col in out.columns:
+            out[col] = pd.to_numeric(out[col], errors='coerce')
+    return out
 
 
 @pytest.fixture
@@ -49,8 +59,8 @@ def test_generate_cornerstone_ghg_fbs_2024_matches_pinned_reference(
     df_m = compare_FBS(fbs_reference, fbs_regenerated, ignore_metasources=False)
 
     assert_frame_equal(
-        fbs_reference.drop(columns=_SKIP_FBS_COMPARE_COLUMNS, errors='ignore'),
-        fbs_regenerated.drop(columns=_SKIP_FBS_COMPARE_COLUMNS, errors='ignore'),
+        _prepare_fbs_for_pin_compare(fbs_reference),
+        _prepare_fbs_for_pin_compare(fbs_regenerated),
         check_like=True,
     )
     assert len(df_m) == 0

--- a/bedrock/transform/__tests__/test_fbs.py
+++ b/bedrock/transform/__tests__/test_fbs.py
@@ -19,25 +19,24 @@ _SKIP_FBS_COMPARE_COLUMNS = ['ProducedBySectorType', 'ConsumedBySectorType']
 
 
 @pytest.fixture
-def isolated_flow_dirs(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> Iterator[Path]:
-    """Empty FBA/FBS output dirs so regen cannot reuse developer-local caches."""
-    fba_dir = tmp_path / 'fba'
+def isolated_fbs_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """Empty FBS output dir so regen cannot reuse a developer-local FBS cache.
+
+    FBA_DIR stays at the default extract/output_data path so upstream FBAs
+    load from GCS when available instead of being regenerated in an empty tmp dir.
+    """
     fbs_dir = tmp_path / 'fbs'
-    fba_dir.mkdir()
     fbs_dir.mkdir()
-    monkeypatch.setattr(settings, 'FBA_DIR', fba_dir)
     monkeypatch.setattr(settings, 'FBS_DIR', fbs_dir)
     yield fbs_dir
 
 
 @pytest.mark.eeio_integration
 def test_generate_cornerstone_ghg_fbs_2024_matches_pinned_reference(
-    isolated_flow_dirs: Path,
+    isolated_fbs_dir: Path,
 ) -> None:
     """Regenerated GHG_national_Cornerstone_2024 matches the pinned GCS parquet."""
-    fbs_dir = isolated_flow_dirs
+    fbs_dir = isolated_fbs_dir
     pin = load_cornerstone_ghg_fbs_pin()
     method = pin['method']
 

--- a/bedrock/transform/__tests__/test_fbs.py
+++ b/bedrock/transform/__tests__/test_fbs.py
@@ -13,7 +13,6 @@ from bedrock.utils.snapshots.fbs_pin import (
     download_pinned_cornerstone_ghg_fbs,
     load_cornerstone_ghg_fbs_pin,
 )
-from bedrock.utils.validation.validation import compare_FBS
 
 _SKIP_FBS_COMPARE_COLUMNS = ['ProducedBySectorType', 'ConsumedBySectorType']
 # Pinned parquet may store these as object/None; regen uses float64/NaN per schema.
@@ -56,11 +55,8 @@ def test_generate_cornerstone_ghg_fbs_2024_matches_pinned_reference(
     FlowBySector.generateFlowBySector(method, download_sources_ok=True)
     fbs_regenerated = getFlowBySector(method)
 
-    df_m = compare_FBS(fbs_reference, fbs_regenerated, ignore_metasources=False)
-
     assert_frame_equal(
         _prepare_fbs_for_pin_compare(fbs_reference),
         _prepare_fbs_for_pin_compare(fbs_regenerated),
         check_like=True,
     )
-    assert len(df_m) == 0

--- a/bedrock/transform/__tests__/test_fbs.py
+++ b/bedrock/transform/__tests__/test_fbs.py
@@ -1,50 +1,57 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
 
 from bedrock.transform.flowbysector import FlowBySector, getFlowBySector
+from bedrock.utils.config import settings
+from bedrock.utils.snapshots.fbs_pin import (
+    download_pinned_cornerstone_ghg_fbs,
+    load_cornerstone_ghg_fbs_pin,
+)
 from bedrock.utils.validation.validation import compare_FBS
 
-
-@pytest.mark.skip  # replaced by compare to remote test
-def test_generate_fbs() -> None:
-    y = 2022
-    method = f'GHG_national_{y}_m1'
-    FlowBySector.generateFlowBySector(method, download_sources_ok=False)
-    fbs = getFlowBySector(method)
-
-    assert len(fbs) > 0
+_SKIP_FBS_COMPARE_COLUMNS = ['ProducedBySectorType', 'ConsumedBySectorType']
 
 
-METHODS = [
-    pytest.param('GHG_national_Cornerstone_2023', id='GHG_national_Cornerstone_2023'),
-]
+@pytest.fixture
+def isolated_flow_dirs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[Path]:
+    """Empty FBA/FBS output dirs so regen cannot reuse developer-local caches."""
+    fba_dir = tmp_path / 'fba'
+    fbs_dir = tmp_path / 'fbs'
+    fba_dir.mkdir()
+    fbs_dir.mkdir()
+    monkeypatch.setattr(settings, 'FBA_DIR', fba_dir)
+    monkeypatch.setattr(settings, 'FBS_DIR', fbs_dir)
+    yield fbs_dir
 
 
 @pytest.mark.eeio_integration
-@pytest.mark.parametrize('method', METHODS)
-def test_generate_fbs_compare_to_remote(method: str) -> None:
-    # Download and load from GCS (local directory needs to be empty of this
-    # method to force download)
-    fbs_remote = getFlowBySector(method, download_FBS_if_missing=True)
+def test_generate_cornerstone_ghg_fbs_2024_matches_pinned_reference(
+    isolated_flow_dirs: Path,
+) -> None:
+    """Regenerated GHG_national_Cornerstone_2024 matches the pinned GCS parquet."""
+    fbs_dir = isolated_flow_dirs
+    pin = load_cornerstone_ghg_fbs_pin()
+    method = pin['method']
 
-    # Compare to newly generated version
-    FlowBySector.generateFlowBySector(method, download_sources_ok=False)
-    fbs = getFlowBySector(method)
+    pinned_path = download_pinned_cornerstone_ghg_fbs(pin, fbs_dir)
+    fbs_reference = pd.read_parquet(pinned_path)
 
-    df_m = compare_FBS(fbs_remote, fbs, ignore_metasources=False)
+    FlowBySector.generateFlowBySector(method, download_sources_ok=True)
+    fbs_regenerated = getFlowBySector(method)
 
-    # Drop some columns that may have different dtypes and are not used
-    skip_columns = ['ProducedBySectorType', 'ConsumedBySectorType']
+    df_m = compare_FBS(fbs_reference, fbs_regenerated, ignore_metasources=False)
 
     assert_frame_equal(
-        fbs_remote.drop(columns=skip_columns),
-        fbs.drop(columns=skip_columns),
+        fbs_reference.drop(columns=_SKIP_FBS_COMPARE_COLUMNS, errors='ignore'),
+        fbs_regenerated.drop(columns=_SKIP_FBS_COMPARE_COLUMNS, errors='ignore'),
         check_like=True,
     )
-
     assert len(df_m) == 0
-
-
-if __name__ == '__main__':
-    # test_generate_fbs()
-    test_generate_fbs_compare_to_remote(method='GHG_national_Cornerstone_2023')

--- a/bedrock/transform/allocation/conftest.py
+++ b/bedrock/transform/allocation/conftest.py
@@ -1,11 +1,63 @@
 from __future__ import annotations
 
+import typing as ta
+
 import pandas as pd
 import pytest
 
+import bedrock.extract.allocation.epa as epa
+import bedrock.utils.config.common as common
+from bedrock.utils.config.usa_config import reset_usa_config, set_global_usa_config
 from bedrock.utils.snapshots.loader import load_current_snapshot
 
+# CH4/N2O/CO2/other_gases integration tests exercise per-source EPA allocation at
+# usa_ghg_data_year 2023. EPA table extract supports 2022/2023 only; there is
+# no EPA 2024 inventory path and these allocators are slated for retirement.
+# Runtime v0.3 loads pre-built 2024 FBS from GCS and does not use this path.
+_ALLOCATION_2023_SUBPACKAGES = frozenset({'ch4', 'n2o', 'co2', 'other_gases'})
+_USA_CONFIG_FOR_ALLOCATION_INTEGRATION = 'test_usa_config'
 
-@pytest.fixture(scope="session")
+
+def _clear_epa_extract_caches() -> None:
+    for obj in epa.__dict__.values():
+        cache_clear = getattr(obj, 'cache_clear', None)
+        if cache_clear is not None:
+            cache_clear()
+
+
+def _is_epa_allocation_integration_test(request: pytest.FixtureRequest) -> bool:
+    if request.node.get_closest_marker('eeio_integration') is None:
+        return False
+    parts = request.node.path.parts
+    try:
+        allocation_idx = parts.index('allocation')
+    except ValueError:
+        return False
+    if allocation_idx + 1 >= len(parts):
+        return False
+    return parts[allocation_idx + 1] in _ALLOCATION_2023_SUBPACKAGES
+
+
+@pytest.fixture(autouse=True)
+def usa_config_2023_for_epa_allocation_integration(
+    request: pytest.FixtureRequest,
+) -> ta.Iterator[None]:
+    if not _is_epa_allocation_integration_test(request):
+        yield
+        return
+
+    _clear_epa_extract_caches()
+    reset_usa_config(should_reset_env_var=True)
+    set_global_usa_config(_USA_CONFIG_FOR_ALLOCATION_INTEGRATION)
+    common.download_fba_on_api_error = True
+    try:
+        yield
+    finally:
+        _clear_epa_extract_caches()
+        reset_usa_config(should_reset_env_var=True)
+        common.download_fba_on_api_error = False
+
+
+@pytest.fixture(scope='session')
 def E_usa_es_snapshot() -> pd.DataFrame:
-    return load_current_snapshot("E_USA_ES")
+    return load_current_snapshot('E_USA_ES')

--- a/bedrock/transform/flowby.py
+++ b/bedrock/transform/flowby.py
@@ -1107,6 +1107,10 @@ class _FlowBy(pd.DataFrame):
                 download_sources_ok=download_sources_ok
             )
 
+        geoscale = config.get('geoscale') or self.config.get('geoscale')
+        if geoscale is not None:
+            attribution_fbs.config['geoscale'] = geoscale
+
         return attribution_fbs
 
     def harmonize_geoscale(

--- a/bedrock/transform/ghg/GHG_national_Cornerstone_2024.yaml
+++ b/bedrock/transform/ghg/GHG_national_Cornerstone_2024.yaml
@@ -24,6 +24,7 @@ _attribution_sources:
   EIA_MECS_Energy_Allocation_CEDA: &mecs_energy_alloc
     activity_to_sector_mapping: CEDA_2025
     year: *mecs_year
+    geoscale: national
 
   BEA: &bea # 2017 Make and Use tables
     year: 2017

--- a/bedrock/transform/iot/derive_PRO_to_PUR_ratio.py
+++ b/bedrock/transform/iot/derive_PRO_to_PUR_ratio.py
@@ -20,6 +20,9 @@ import pandas as pd
 
 from bedrock.extract.iot.io_2017 import load_2017_margins_usa
 from bedrock.transform.eeio.derived_2017_helpers import EXPANDED_SECTORS_2012_TO_2017
+from bedrock.transform.iot.derived_gross_industry_output import (
+    available_gross_output_years,
+)
 from bedrock.utils.config.usa_config import USAConfig, get_usa_config
 from bedrock.utils.economic.inflation_helpers_cornerstone import (
     default_price_index_panel_years,
@@ -334,8 +337,22 @@ def derive_phi_cornerstone_usa() -> pd.Series[float]:
 
 
 def default_phi_panel_years() -> tuple[int, ...]:
-    """Years with price-index coverage for Phi panel export (from IO base year onward)."""
-    return default_price_index_panel_years()
+    """Years exportable on the Excel Phi panel (from IO base year onward).
+
+    Margin inflation for Phi uses ITA commodity price indices, which require
+    detail gross output at each target year. Price-index levels can run one year
+    ahead of detail GO when quarterly summary PI is stitched in before the
+    annual detail release.
+    """
+    pi_years = default_price_index_panel_years()
+    go_years = set(available_gross_output_years())
+    years = tuple(y for y in pi_years if y in go_years)
+    if not years:
+        raise ValueError(
+            'No Phi panel years remain after intersecting price-index coverage '
+            f'{pi_years} with gross-output availability {go_years}.'
+        )
+    return years
 
 
 @functools.cache

--- a/bedrock/transform/iot/derived_gross_industry_output.py
+++ b/bedrock/transform/iot/derived_gross_industry_output.py
@@ -26,11 +26,7 @@ def available_gross_output_years() -> tuple[int, ...]:
 
     go_detail = map_detail_table(load_go_detail())
     return tuple(
-        sorted(
-            int(col)
-            for col in go_detail.columns
-            if col not in _GO_METADATA_COLS
-        )
+        sorted(int(col) for col in go_detail.columns if col not in _GO_METADATA_COLS)
     )
 
 

--- a/bedrock/transform/iot/derived_gross_industry_output.py
+++ b/bedrock/transform/iot/derived_gross_industry_output.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import logging
 import typing as ta
 
@@ -10,10 +11,27 @@ from bedrock.utils.economic.units import MILLION_CURRENCY_TO_CURRENCY
 from bedrock.utils.taxonomy.bea.matrix_mappings import USA_GROSS_INDUSTRY_OUTPUT_YEARS
 
 SECTOR_CODE_COL = 'sector_code'
+_GO_METADATA_COLS = frozenset({'sector_name', SECTOR_CODE_COL})
 
 logger = logging.getLogger(__name__)
 
 RedefinitionMode = ta.Literal['before', 'after']
+
+
+@functools.cache
+def available_gross_output_years() -> tuple[int, ...]:
+    """Calendar years present in the BEA detail gross-output workbook (UGO305-A)."""
+    from bedrock.extract.iot.gdp import load_go_detail
+    from bedrock.transform.iot.helpers import map_detail_table
+
+    go_detail = map_detail_table(load_go_detail())
+    return tuple(
+        sorted(
+            int(col)
+            for col in go_detail.columns
+            if col not in _GO_METADATA_COLS
+        )
+    )
 
 
 def derive_gross_output(

--- a/bedrock/utils/snapshots/README.md
+++ b/bedrock/utils/snapshots/README.md
@@ -28,8 +28,17 @@ These are **independent** concepts and frequently point at different commits:
 | Named release | [`releases.py`](releases.py) | Reference-only map of release labels → snapshot SHAs. Not imported by runtime code; update in Phase A alongside `.SNAPSHOT_KEY`. |
 | Diagnostic baseline pin | `USAConfig.snapshot_version_or_git_sha` | `Literal[...]` of SHAs that any config may point at as its diagnostic baseline. Every released snapshot SHA must be added here. |
 | Canonical config | [`2025_usa_cornerstone_v0_3.yaml`](../config/configs/2025_usa_cornerstone_v0_3.yaml) | The single config used to generate the snapshots that back `.SNAPSHOT_KEY`. Atomic configs are not snapshotted here; see "Adhoc snapshots" below. |
+| Cornerstone GHG FBS pin | [`cornerstone_ghg_fbs_2024_pin.json`](cornerstone_ghg_fbs_2024_pin.json) | Pins one `GHG_national_Cornerstone_2024` parquet in `transform/output_data` (filename + SHA256). Guards FBS regeneration in [`test_fbs.py`](../../transform/__tests__/test_fbs.py). See "Cornerstone GHG FBS pin" below. |
 
-### Where snapshot SHAs live
+### Pins vs runtime loaders
+
+| Artifact | Pins | Consumed by |
+|---|---|---|
+| [`.SNAPSHOT_KEY`](.SNAPSHOT_KEY) | Full pipeline outputs at a git SHA | `test_usa.py` (`eeio_integration`) |
+| [`cornerstone_ghg_fbs_2024_pin.json`](cornerstone_ghg_fbs_2024_pin.json) | One `GHG_national_Cornerstone_2024` parquet | `test_fbs.py` (`eeio_integration`) |
+| `_load_cornerstone_ghg_fbs_from_gcs` in [`derived.py`](../../transform/allocation/derived.py) | Nothing — selects the newest upload matching `GHG_national_Cornerstone_<year>` | `load_E_from_flowsa()` for v0.3 (`v0_3_umd_2024_ghgia`) |
+
+The FBS pin and the runtime loader are independent: bumping the pin updates the regeneration test golden file; production still follows the latest GCS upload until `load_E_from_flowsa` is wired to the pin.
 
 | Store | Releases (`v0`, `v0.1`, `v0.2`) | Test-only SHAs |
 |---|---|---|
@@ -243,6 +252,49 @@ The `generate_snapshots.py` script supports `--adhoc`, which uploads to `gs://co
 
 Adhoc snapshots are never wired into `.SNAPSHOT_KEY` or `releases.py`. They exist for ad-hoc diagnostic comparisons only.
 
+## Cornerstone GHG FBS pin
+
+[`cornerstone_ghg_fbs_2024_pin.json`](cornerstone_ghg_fbs_2024_pin.json) pins the `GHG_national_Cornerstone_2024` FlowBySector parquet that v0.3 loads from `gs://cornerstone-default/transform/output_data/`. [`test_fbs.py`](../../transform/__tests__/test_fbs.py) regenerates the method from YAML + GCS sources and asserts a byte-identical match to the pinned file (via [`fbs_pin.py`](fbs_pin.py)). The test runs on the weekday `test_integration` schedule alongside `test_usa.py`.
+
+### When to bump the pin
+
+Bump the pin when the team **intentionally** ships a new `GHG_national_Cornerstone_2024` FBS to GCS, for example:
+
+- Changes to [`GHG_national_Cornerstone_2024.yaml`](../../transform/ghg/GHG_national_Cornerstone_2024.yaml) or its upstream FBAs (UMD GHGIA, EPA attribution tables, MECS, etc.)
+- A refreshed upstream data drop uploaded as a new parquet
+
+Do **not** bump the pin to silence a failing test without diagnosing the diff. A red `test_generate_cornerstone_ghg_fbs_2024_matches_pinned_reference` means either regeneration is broken or the pin is stale relative to an upload that was already blessed.
+
+A pin bump is separate from a `.SNAPSHOT_KEY` bump. Snapshot tests cover the full pipeline; the FBS pin covers only whether `generateFlowBySector('GHG_national_Cornerstone_2024')` still reproduces the committed golden parquet.
+
+### How to bump the pin
+
+**1. Regenerate and upload.**
+
+Run `FlowBySector.generateFlowBySector('GHG_national_Cornerstone_2024', download_sources_ok=True)` locally (or via an internal job), then upload the parquet and metadata JSON to `gs://cornerstone-default/transform/output_data/`. Filenames follow `{method}_v{tool_version}_{git_hash}.parquet`.
+
+**2. Compute SHA256** of the uploaded parquet:
+
+```powershell
+uv run python -c "import hashlib, sys; p=sys.argv[1]; h=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(h)" path\to\GHG_national_Cornerstone_2024_....parquet
+```
+
+**3. Update** [`cornerstone_ghg_fbs_2024_pin.json`](cornerstone_ghg_fbs_2024_pin.json):
+
+- `filename` — exact GCS object name
+- `sha256` — 64-char hex digest from step 2
+- `method` and `gcs_sub_bucket` stay `GHG_national_Cornerstone_2024` and `transform/output_data` unless the bucket layout changes
+
+**4. Verify** on the pin-bump branch:
+
+```powershell
+uv run pytest bedrock/transform/__tests__/test_fbs.py -m eeio_integration -v
+```
+
+**5. Merge** the pin bump — in the same PR as the FBS regen/upload when possible, or immediately after. Keep the diff mechanical: the JSON pin file (and any upload-related method changes) only.
+
+After upload, `_load_cornerstone_ghg_fbs_from_gcs` picks up the new parquet on the next run (newest `base_name` match) even before the pin bump merges; the pin bump aligns CI with the blessed file.
+
 ## File map
 
 | File | Role |
@@ -255,3 +307,6 @@ Adhoc snapshots are never wired into `.SNAPSHOT_KEY` or `releases.py`. They exis
 | [`../config/usa_config.py`](../config/usa_config.py) | `USAConfig.snapshot_version_or_git_sha` `Literal` of allowed baseline SHAs |
 | [`../../../.github/workflows/generate_snapshots.yml`](../../../.github/workflows/generate_snapshots.yml) | `workflow_dispatch` CI that runs `generate_snapshots.py` |
 | [`../../../.github/workflows/test_integration.yml`](../../../.github/workflows/test_integration.yml) | Scheduled CI that diffs current pipeline output against `.SNAPSHOT_KEY` |
+| [`cornerstone_ghg_fbs_2024_pin.json`](cornerstone_ghg_fbs_2024_pin.json) | Pinned `GHG_national_Cornerstone_2024` parquet for FBS regen test |
+| [`fbs_pin.py`](fbs_pin.py) | Load pin JSON, download from GCS, verify SHA256 |
+| [`../../transform/__tests__/test_fbs.py`](../../transform/__tests__/test_fbs.py) | `eeio_integration` test: regen vs pinned FBS |

--- a/bedrock/utils/snapshots/cornerstone_ghg_fbs_2024_pin.json
+++ b/bedrock/utils/snapshots/cornerstone_ghg_fbs_2024_pin.json
@@ -1,0 +1,6 @@
+{
+  "method": "GHG_national_Cornerstone_2024",
+  "gcs_sub_bucket": "transform/output_data",
+  "filename": "GHG_national_Cornerstone_2024_v0.2_23b16cb.parquet",
+  "sha256": "315437db2e1252b780f47af244750b84b6dc6de3a4a17180d36f211b5a2306f4"
+}

--- a/bedrock/utils/snapshots/fbs_pin.py
+++ b/bedrock/utils/snapshots/fbs_pin.py
@@ -1,0 +1,65 @@
+"""Pinned Cornerstone GHG FBS parquets for integration tests."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from bedrock.utils.io.gcp import download_gcs_file
+
+_SNAPSHOT_BASE = Path(__file__).resolve().parent
+DEFAULT_CORNERSTONE_GHG_FBS_2024_PIN = (
+    _SNAPSHOT_BASE / 'cornerstone_ghg_fbs_2024_pin.json'
+)
+
+
+def load_cornerstone_ghg_fbs_pin(
+    pin_json_path: str | Path | None = None,
+) -> dict[str, str]:
+    """Load a committed FBS pin (method, GCS location, filename, SHA256)."""
+    path = Path(pin_json_path or DEFAULT_CORNERSTONE_GHG_FBS_2024_PIN)
+    raw = json.loads(path.read_text(encoding='utf-8'))
+    if not isinstance(raw, dict):
+        raise ValueError(f'FBS pin JSON must be an object, got {type(raw).__name__}')
+    required = ('method', 'gcs_sub_bucket', 'filename', 'sha256')
+    missing = [k for k in required if k not in raw]
+    if missing:
+        raise ValueError(f'Missing keys {missing!r} in FBS pin JSON {path!r}')
+    out = {k: str(raw[k]).strip() for k in required}
+    exp = out['sha256'].lower()
+    if len(exp) != 64 or any(c not in '0123456789abcdef' for c in exp):
+        raise ValueError('sha256 must be a 64-char lowercase hex string')
+    out['sha256'] = exp
+    return out
+
+
+def _file_sha256_hex(path: str | Path) -> str:
+    digest = hashlib.sha256()
+    with open(path, 'rb') as f:
+        for chunk in iter(lambda: f.read(65536), b''):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def download_pinned_cornerstone_ghg_fbs(
+    pin: dict[str, str],
+    local_dir: str | Path,
+) -> Path:
+    """Download the pinned parquet and verify SHA256 before returning the path."""
+    local_dir = Path(local_dir)
+    local_dir.mkdir(parents=True, exist_ok=True)
+    local_path = local_dir / pin['filename']
+    if local_path.is_file():
+        got = _file_sha256_hex(local_path)
+        if got.lower() != pin['sha256']:
+            local_path.unlink()
+    if not local_path.is_file():
+        download_gcs_file(pin['filename'], pin['gcs_sub_bucket'], str(local_path))
+    got = _file_sha256_hex(local_path)
+    if got.lower() != pin['sha256']:
+        raise ValueError(
+            f'Pinned FBS SHA256 mismatch for {pin["filename"]!r}: '
+            f'got {got}, expected {pin["sha256"]}'
+        )
+    return local_path


### PR DESCRIPTION
cc:
Closes: #332

## What changed? Why?

Pins the `GHG_national_Cornerstone_2024` FlowBySector parquet that v0.3 loads from GCS and adds an integration test that regenerates the method from YAML + upstream sources and asserts a match to that golden file.

### GCS upstream uploads (`flowsa/FlowByActivity`)

CI regeneration downloads the newest matching FBA per source. Two uploads were required so regen matches the pinned FBS:

| GCS object | Why |
|------------|-----|
| `EIA_MECS_Energy_Allocation_CEDA_2022_v0.2_0b42b62.parquet` | Cornerstone-schema MECS allocation FBA (405 sectors, `335220` appliance code). Built with `2025_usa_cornerstone_full_model.yaml`. |
| `USDA_CoA_Cropland_2022_v2.0.3_0b42b62.parquet` | Pin-era Census of Ag cropland commodity weights. Cold-regen from GCS QuickStats snapshot CSVs matches this file byte-for-byte; the prior `v2.0.2` artifact diverged (~6% lower national harvested-area pool) and caused a single-sector N2O drift on the `UMD_GHGIA_T_5_10` → `EPA_GHGI_T_5_18` → cropland attribution path. `v2.0.3` supersedes `v2.0.2` in version sort order - this is an artificial naming update as this was generated in bedrock (but a v0.1 or v0.2 object won't get picked up by the CI at this time). SHA256 `a4b35cac8d80a33e4e850053ede907c93e0ea42fd64573fd3ca56d18fc6c0ce5`. |

### Code and pin
- [`cornerstone_ghg_fbs_2024_pin.json`](bedrock/utils/snapshots/cornerstone_ghg_fbs_2024_pin.json) — `GHG_national_Cornerstone_2024_v0.2_23b16cb.parquet`, SHA256 `315437db2e1252b780f47af244750b84b6dc6de3a4a17180d36f211b5a2306f4`
- [`fbs_pin.py`](bedrock/utils/snapshots/fbs_pin.py) — load pin JSON, download from `transform/output_data`, verify SHA256
- [`test_fbs.py`](bedrock/transform/__tests__/test_fbs.py) — `test_generate_cornerstone_ghg_fbs_2024_matches_pinned_reference`; `isolated_fbs_dir` redirects only `FBS_DIR` so upstream FBAs load from GCS; coerces `Spread`/`Min`/`Max` to numeric before compare (pinned parquet stores `None` as object; regen uses float64/`NaN`)
- [`GHG_national_Cornerstone_2024.yaml`](bedrock/transform/ghg/GHG_national_Cornerstone_2024.yaml) — `geoscale: national` on `EIA_MECS_Energy_Allocation_CEDA` attribution config
- [`snapshots/README.md`](bedrock/utils/snapshots/README.md) — pins vs runtime loaders table and FBS pin bump playbook

**Runtime unchanged:** `_load_cornerstone_ghg_fbs_from_gcs` in `derived.py` still selects the newest matching upload for `load_E_from_flowsa()`. The pin guards CI regeneration only; full-pipeline reproducibility stays on `.SNAPSHOT_KEY`.

### Supplementary (integration CI hygiene)

Follow-on commits restore weekday `test_integration` after canonical config moved to v0.3.

Per-source EPA allocator functions (CH4/N2O/CO2/other_gases) and EPA_GHGI FBA regen are slated for deprecation — there is no EPA 2024 inventory extract path; v0.3 GHG loads pre-built FBS from GCS. The conftest pins below keep legacy integration guards green until those paths are removed.

| Change | Purpose |
|--------|---------|
| [`allocation/conftest.py`](bedrock/transform/allocation/conftest.py) | Pin CH4/N2O/CO2/other_gases `eeio_integration` to `test_usa_config` (EPA 2023) |
| [`extract/__tests__/conftest.py`](bedrock/extract/__tests__/conftest.py) | Pin EPA_GHGI FBA regen tests to 2023 config |
| [`derive_PRO_to_PUR_ratio.py`](bedrock/transform/iot/derive_PRO_to_PUR_ratio.py), [`derived_gross_industry_output.py`](bedrock/transform/iot/derived_gross_industry_output.py) | Cap Excel Phi panel years at gross-output availability (`update_inflation_factors` PI can run one year ahead of detail GO) |

## Testing

```powershell
uv run pytest bedrock/transform/__tests__/test_fbs.py -m eeio_integration -v
```

Long-running (~10+ min). Weekday `test_integration` workflow runs this alongside other `eeio_integration` tests.

```powershell
uv run pytest bedrock/transform/allocation/ch4/__tests__/ bedrock/transform/allocation/n2o/__tests__/ bedrock/transform/allocation/co2/__tests__/ bedrock/transform/allocation/other_gases/__tests__/ -m eeio_integration -q
```

Allocator integration subset (legacy EPA allocators; deprecation expected).

```powershell
uv run pytest bedrock/extract/__tests__/test_fba.py::test_generateFBA -m eeio_integration -v
```

```powershell
uv run pytest bedrock/publish/__tests__/test_excel_vs_snapshot.py::test_published_B_matches_snapshot -m eeio_integration -v
```

Publish B-vs-snapshot guard (Phi panel cap).