### PR TITLE
config: add v0.3 MECS step on the v0.2 footing

### DIFF
--- a/bedrock/utils/config/configs/2025_usa_cornerstone_full_model_v0_3_ghgi_mecs.yaml
+++ b/bedrock/utils/config/configs/2025_usa_cornerstone_full_model_v0_3_ghgi_mecs.yaml
@@ -1,0 +1,5 @@
+use_cornerstone_2026_model_schema: True
+load_E_from_flowsa: true
+update_mecs_method: true
+use_E_data_year_for_x_in_B: True
+implement_waste_disaggregation: True

--- a/bedrock/utils/config/configs/2025_usa_cornerstone_full_model_v0_3_ghgi_mecs.yaml
+++ b/bedrock/utils/config/configs/2025_usa_cornerstone_full_model_v0_3_ghgi_mecs.yaml
@@ -1,3 +1,11 @@
+# v0.3 release-deck MECS step on the v0.2 full-model footing.
+# Same non-GHG stack as v0.2 (schema, waste, use_E_data_year_for_x_in_B) with
+# update_mecs_method as the only GHG delta. Selects
+# GHG_national_Cornerstone_2023_ghgi_mecs (2022 MECS year) via flowsa.
+
+#####
+# Methodology selection
+#####
 use_cornerstone_2026_model_schema: True
 load_E_from_flowsa: true
 update_mecs_method: true


### PR DESCRIPTION
## Summary

Adds `2025_usa_cornerstone_full_model_v0_3_ghgi_mecs.yaml` so the MECS step sits on the same footing as the rest of the v0.3 diagnostics chain.

The previous MECS config (`2025_usa_cornerstone_ghg_mecs.yaml`) was fine as a standalone atomic test but two settings made it non-comparable to the other v0.3 steps:

1. It omitted the footing flags `use_E_data_year_for_x_in_B` and `implement_waste_disaggregation`.
2. It pinned the `fbs_schema` snapshot as its baseline instead of the default `v0`.

Both are corrected here. (`update_mecs_method` replaces `new_ghg_method` rather than being set alongside it, since the GHG-method selector is first-match-wins.) The original config is left untouched.

## Testing

- Dispatched `generate_diagnostics` from this branch against both CEDA and USEEIO baselines; both runs succeeded.
- `config_summary` confirms the intended flags and the `v0` baseline snapshot.