### PR TITLE
Add A_margin in prep for Margin EF calc

### DIFF
--- a/bedrock/transform/eeio/derived_cornerstone.py
+++ b/bedrock/transform/eeio/derived_cornerstone.py
@@ -705,7 +705,7 @@ def _margin_sector_commodity_output_ratio(
     """
     ratios: dict[str, float] = {}
     for codes in margin_sector_commodities.values():
-        group_q = q.loc[codes]
+        group_q = q.loc[list(codes)]
         group_total = group_q.sum()
         ratios.update((group_q / group_total).to_dict() if group_total else {})
     return pd.Series(ratios, dtype=float)
@@ -744,7 +744,8 @@ def derive_cornerstone_A_margin() -> pd.DataFrame:
 
     margin_allocation = pd.DataFrame(0.0, index=margin_types, columns=CS_COMMODITY_LIST)
     for margin_type, codes in margin_sector_commodities.items():
-        margin_allocation.loc[margin_type, codes] = output_ratio.loc[codes]
+        code_list = list(codes)
+        margin_allocation.loc[margin_type, code_list] = output_ratio.loc[code_list]
 
     margins_by_sector = margin_coefficients @ margin_allocation
 
@@ -752,7 +753,8 @@ def derive_cornerstone_A_margin() -> pd.DataFrame:
     A_margin.index.name = 'sector'
     A_margin.columns.name = 'sector'
     for codes in margin_sector_commodities.values():
-        A_margin.loc[codes, :] = margins_by_sector[codes].T
+        code_list = list(codes)
+        A_margin.loc[code_list, :] = margins_by_sector[code_list].T
     return A_margin
 
 

--- a/bedrock/transform/eeio/derived_cornerstone.py
+++ b/bedrock/transform/eeio/derived_cornerstone.py
@@ -26,6 +26,7 @@ Internal helpers live in sibling modules:
 from __future__ import annotations
 
 import functools
+import typing as ta
 from typing import cast
 
 import numpy as np
@@ -694,7 +695,7 @@ def derive_cornerstone_Aq_scaled() -> SingleRegionAqMatrixSet:
 
 
 def _margin_sector_commodity_output_ratio(
-    q: pd.Series[float], margin_sector_commodities: dict[str, list[str]]
+    q: pd.Series[float], margin_sector_commodities: ta.Mapping[str, ta.Sequence[str]]
 ) -> pd.Series[float]:
     """Each margin-sector commodity's share of its group's total ``q``.
 

--- a/bedrock/transform/eeio/derived_cornerstone.py
+++ b/bedrock/transform/eeio/derived_cornerstone.py
@@ -69,6 +69,9 @@ from bedrock.transform.eeio.derived_2017 import (
     derive_summary_Yimp_usa,
     derive_summary_Ytot_usa_matrix_set,
 )
+from bedrock.transform.iot.derive_PRO_to_PUR_ratio import (
+    derive_margins_cornerstone_usa,
+)
 from bedrock.transform.iot.derived_gross_industry_output import (
     derive_gross_output,
 )
@@ -119,6 +122,9 @@ from bedrock.utils.taxonomy.bea.v2017_final_demand import (
 )
 from bedrock.utils.taxonomy.bea_v2017_to_ceda_v7_helpers import (
     get_bea_v2017_summary_to_cornerstone_corresp_df,
+)
+from bedrock.utils.taxonomy.mappings.bea_v2017_sector__cornerstone_commodity import (
+    load_margin_type_to_cornerstone_commodity,
 )
 
 # ---------------------------------------------------------------------------
@@ -680,6 +686,73 @@ def derive_cornerstone_Aq_scaled() -> SingleRegionAqMatrixSet:
         Aimp=pt.DataFrame[CornerstoneAMatrix](Aimp),  # type: ignore[arg-type]
         scaled_q=q,
     )
+
+
+# ---------------------------------------------------------------------------
+# Margin A matrix (A_margin)
+# ---------------------------------------------------------------------------
+
+
+def _margin_sector_commodity_output_ratio(
+    q: pd.Series[float], margin_sector_commodities: dict[str, list[str]]
+) -> pd.Series[float]:
+    """Each margin-sector commodity's share of its group's total ``q``.
+
+    Analogous to useeior's ``calculateOutputRatio(model, output_type="Commodity")``
+    ``toSectorRatio`` column, restricted to the Transportation/Wholesale/Retail
+    BEA-Sector groups used to allocate margins.
+    """
+    ratios: dict[str, float] = {}
+    for codes in margin_sector_commodities.values():
+        group_q = q.loc[codes]
+        group_total = group_q.sum()
+        ratios.update((group_q / group_total).to_dict() if group_total else {})
+    return pd.Series(ratios, dtype=float)
+
+
+@functools.cache
+@pa.check_output(CornerstoneAMatrix.to_schema())
+def derive_cornerstone_A_margin() -> pd.DataFrame:
+    """Margin-provider A matrix (commodity supplying margin x commodity purchased).
+
+    Python port of useeior's ``calculateMarginSectorImpacts`` A_margin
+    construction: for each Cornerstone commodity, its Transportation/Wholesale/
+    Retail margin fraction of producer price (from ``derive_margins_cornerstone_usa()``,
+    the equivalent of ``model$Margins``) is allocated across the Cornerstone
+    commodities in the corresponding BEA-Sector margin group in proportion to
+    each commodity's share of that group's total ``derive_cornerstone_q()``
+    output (the equivalent of ``model$q``).
+
+    Row ``i`` (a margin-providing commodity) gives, for every column ``j``
+    (purchasing commodity), the fraction of ``j``'s producer-price purchase
+    that flows to commodity ``i`` to cover ``j``'s trade/transportation margin.
+    Non-margin-providing rows are all zero.
+    """
+    margins = derive_margins_cornerstone_usa()
+    margin_sector_commodities = load_margin_type_to_cornerstone_commodity()
+    margin_types = list(margin_sector_commodities)
+    margin_coefficients = (
+        margins[margin_types]
+        .div(margins["Producers' Value"], axis=0)
+        .replace([np.inf, -np.inf, np.nan], 0.0)
+    )
+
+    output_ratio = _margin_sector_commodity_output_ratio(
+        derive_cornerstone_q(), margin_sector_commodities
+    )
+
+    margin_allocation = pd.DataFrame(0.0, index=margin_types, columns=CS_COMMODITY_LIST)
+    for margin_type, codes in margin_sector_commodities.items():
+        margin_allocation.loc[margin_type, codes] = output_ratio.loc[codes]
+
+    margins_by_sector = margin_coefficients @ margin_allocation
+
+    A_margin = pd.DataFrame(0.0, index=CS_COMMODITY_LIST, columns=CS_COMMODITY_LIST)
+    A_margin.index.name = 'sector'
+    A_margin.columns.name = 'sector'
+    for codes in margin_sector_commodities.values():
+        A_margin.loc[codes, :] = margins_by_sector[codes].T
+    return A_margin
 
 
 # ---------------------------------------------------------------------------

--- a/bedrock/utils/taxonomy/mappings/bea_v2017_sector__cornerstone_commodity.py
+++ b/bedrock/utils/taxonomy/mappings/bea_v2017_sector__cornerstone_commodity.py
@@ -28,3 +28,21 @@ def load_bea_v2017_sector_commodity_to_cornerstone_commodity() -> (
         dangerously_skip_empty_mapping_check=True,
     )
     return mapping
+
+
+# Margin type (as named in derive_margins_cornerstone_usa()'s columns) to the
+# BEA 2017 Sector-level code of the commodities that supply that margin.
+MARGIN_TYPE_TO_BEA_SECTOR_CODE: ta.Dict[str, BEA_2017_SECTOR_COMMODITY_CODE] = {
+    'Transportation': '48TW',
+    'Wholesale': '42',
+    'Retail': '44RT',
+}
+
+
+def load_margin_type_to_cornerstone_commodity() -> ta.Dict[str, ta.List[COMMODITY]]:
+    """Transportation/Wholesale/Retail margin type name to its Cornerstone commodities."""
+    sector_to_commodities = load_bea_v2017_sector_commodity_to_cornerstone_commodity()
+    return {
+        margin_type: sector_to_commodities[sector_code]
+        for margin_type, sector_code in MARGIN_TYPE_TO_BEA_SECTOR_CODE.items()
+    }


### PR DESCRIPTION
Progress on: #434 

## Summary

Added `derive_cornerstone_A_margin()` in `bedrock/transform/eeio/derived_cornerstone.py`, a Python port of useeior's [`calculateMarginSectorImpacts`](https://github.com/cornerstone-data/useeior/blob/90f4d7a022a3ecb2043535c30b473cd1068078a8/R/CalculationFunctions.R#L487-L518) `A_margin` construction:

- Uses `derive_margins_cornerstone_usa()` as `model$Margins` and `derive_cornerstone_q()` as `model$q`.
- Added `MARGIN_TYPE_TO_BEA_SECTOR_CODE` and `load_margin_type_to_cornerstone_commodity()` to `bedrock/utils/taxonomy/mappings/bea_v2017_sector__cornerstone_commodity.py` — maps Transportation/Wholesale/Retail to their Cornerstone commodity members via the existing BEA-Sector crosswalk (48TW/42/44RT).
- `_margin_sector_commodity_output_ratio()` is the analog of `calculateOutputRatio(...)$toSectorRatio`, using q-share within each margin group.
- Verified against the real pipeline: 405×405 matrix, 29 nonzero margin-provider rows, no negatives, and column sums match the margin-coefficient totals to float precision.


## Testing
_Show that A has correct shape and has positive values for margins sectors_
```
from bedrock.transform.eeio.derived_cornerstone import derive_cornerstone_A_margin
>A = derive_cornerstone_A_margin()
>print(A.shape)
>print('row sums (margin providers) sample:')
>nz = A[(A.sum(axis=1) != 0)]
>print(nz.shape)
>print(A.sum().sum())
>print((A < 0).any().any())

handling duplicated codes ['221100', '4B0000']
2026-07-06 12:00:16 WARNING  Duplicate sector codes in gross output; aggregating by sum.
2026-07-06 12:00:17 WARNING  Duplicate sector codes in gross output; aggregating by sum.
(405, 405)
row sums (margin providers) sample:
(29, 405)
86.932895721939
False

```

_Verify column sums of A_margin match margin coefficient totals_
```
import numpy as np
from bedrock.transform.eeio.derived_cornerstone import derive_cornerstone_A_margin
from bedrock.transform.iot.derive_PRO_to_PUR_ratio import derive_margins_cornerstone_usa
A = derive_cornerstone_A_margin()
margins = derive_margins_cornerstone_usa()
mc = margins[['Transportation','Wholesale','Retail']].div(margins[\"Producers' Value\"], axis=0).replace([np.inf,-np.inf,np.nan],0.0)
expected_col_sum = mc.sum(axis=1)
actual_col_sum = A.sum(axis=0)
diff = (expected_col_sum - actual_col_sum).abs()
print('max diff (should be ~0 except where a margin group total q is 0):', diff.max())
print('num mismatched beyond 1e-9:', (diff > 1e-9).sum())
print(diff.sort_values(ascending=False).head(10))

max diff (should be ~0 except where a margin group total q is 0): 2.220446049250313e-16
num mismatched beyond 1e-9: 0

```
