### PR TITLE
config: isolated GHG-allocation waterfall snapshot config

### DIFF
--- a/bedrock/utils/config/configs/2025_usa_cornerstone_waterfall_ghg_allocation.yaml
+++ b/bedrock/utils/config/configs/2025_usa_cornerstone_waterfall_ghg_allocation.yaml
@@ -1,0 +1,12 @@
+# v0.3 final-waterfall isolation config: GHG model allocation only.
+# Isolated single change on the bare Cornerstone base (~ CEDA v0 + GHG method):
+# the v0.2 GHG allocation (new_ghg_method -> GHG_national_Cornerstone_2023), with
+# no waste disaggregation, no B/IO-year adjustment, and no v0.3 changes.
+# Used to attribute the "GHG model allocation" bar in the v0->v0.3 BLy waterfall.
+
+#####
+# Methodology selection
+#####
+use_cornerstone_2026_model_schema: True
+load_E_from_flowsa: true
+new_ghg_method: true


### PR DESCRIPTION
## Summary

Adds `2025_usa_cornerstone_waterfall_ghg_allocation.yaml`, an isolated single-change config on the bare Cornerstone base used to generate the snapshot for the "GHG model allocation" bar in the v0->v0.3 BLy waterfall.

Flags set:
- `use_cornerstone_2026_model_schema: True`, `load_E_from_flowsa: true` (Cornerstone/MRIO framework)
- `new_ghg_method: true` (v0.2 GHG allocation), with no waste disaggregation, no B/IO-year adjustment, and no v0.3 changes.

Made with [Cursor](https://cursor.com)