### PR TITLE
config(diagnostics): v0.3 bedrock leave-one-out configs

### DIFF
--- a/bedrock/utils/config/configs/2025_usa_cornerstone_v0_3_minus_ceda_a_approach.yaml
+++ b/bedrock/utils/config/configs/2025_usa_cornerstone_v0_3_minus_ceda_a_approach.yaml
@@ -1,0 +1,33 @@
+# Leave-one-out: full v0.3 with the CEDA A approach removed
+# (scale_a_matrix_with_ceda_method_as_fallback + adjust_summary_A_and_q_dollar_year
+# True -> False, reverting the A matrix to the v0.2 method). All other v0.3
+# changes remain on.
+#####
+# Model base settings
+#####
+model_base_year: 2024
+
+#####
+# Data selection
+#####
+usa_ghg_data_year: 2024
+
+#####
+# Methodology selection
+#####
+use_cornerstone_2026_model_schema: True
+load_E_from_flowsa: True
+
+# GHG model: UMD GHGIA 2024 inventory (+ 2022 MECS attribution).
+v0_3_umd_2024_ghgia: True
+
+# A matrix: CEDA A approach REMOVED for this leave-one-out (revert to v0.2 A).
+scale_a_matrix_with_ceda_method_as_fallback: False
+adjust_summary_A_and_q_dollar_year: False
+
+# Inflation factors.
+update_inflation_factors: True
+
+# Shared full-model flags.
+use_E_data_year_for_x_in_B: True
+implement_waste_disaggregation: True

--- a/bedrock/utils/config/configs/2025_usa_cornerstone_v0_3_minus_ghg_2024_refresh.yaml
+++ b/bedrock/utils/config/configs/2025_usa_cornerstone_v0_3_minus_ghg_2024_refresh.yaml
@@ -1,0 +1,36 @@
+# Leave-one-out (GHG chain, step 1): full v0.3 with the 2024 GHG data refresh
+# removed by stepping the GHG inventory back from UMD GHGIA 2024 to UMD GHGIA
+# 2023 (both carry the 2022 MECS attribution -- MECS is not separable from UMD).
+#   v0_3_umd_2024_ghgia -> v0_3_umd_2023_ghgia, usa_ghg_data_year 2024 -> 2023.
+# The IO/dollar base year stays at 2024. All other v0.3 changes remain on.
+#
+# FINAL - this  = marginal effect of the 2024 GHG refresh.
+#####
+# Model base settings
+#####
+model_base_year: 2024
+
+#####
+# Data selection
+#####
+usa_ghg_data_year: 2023
+
+#####
+# Methodology selection
+#####
+use_cornerstone_2026_model_schema: True
+load_E_from_flowsa: True
+
+# GHG model: UMD GHGIA 2023 inventory (+ 2022 MECS attribution).
+v0_3_umd_2023_ghgia: True
+
+# A matrix: CEDA's A approach as fallback, with summary A/q dollar-year price adjustment.
+scale_a_matrix_with_ceda_method_as_fallback: True
+adjust_summary_A_and_q_dollar_year: True
+
+# Inflation factors.
+update_inflation_factors: True
+
+# Shared full-model flags.
+use_E_data_year_for_x_in_B: True
+implement_waste_disaggregation: True

--- a/bedrock/utils/config/configs/2025_usa_cornerstone_v0_3_minus_inflation_update.yaml
+++ b/bedrock/utils/config/configs/2025_usa_cornerstone_v0_3_minus_inflation_update.yaml
@@ -1,0 +1,31 @@
+# Leave-one-out: full v0.3 with the inflation-factor update removed
+# (update_inflation_factors True -> False). All other v0.3 changes remain on.
+#####
+# Model base settings
+#####
+model_base_year: 2024
+
+#####
+# Data selection
+#####
+usa_ghg_data_year: 2024
+
+#####
+# Methodology selection
+#####
+use_cornerstone_2026_model_schema: True
+load_E_from_flowsa: True
+
+# GHG model: UMD GHGIA 2024 inventory (+ 2022 MECS attribution).
+v0_3_umd_2024_ghgia: True
+
+# A matrix: CEDA's A approach as fallback, with summary A/q dollar-year price adjustment.
+scale_a_matrix_with_ceda_method_as_fallback: True
+adjust_summary_A_and_q_dollar_year: True
+
+# Inflation factors: REMOVED for this leave-one-out.
+update_inflation_factors: False
+
+# Shared full-model flags.
+use_E_data_year_for_x_in_B: True
+implement_waste_disaggregation: True

--- a/bedrock/utils/config/configs/2025_usa_cornerstone_v0_3_minus_io_base_year.yaml
+++ b/bedrock/utils/config/configs/2025_usa_cornerstone_v0_3_minus_io_base_year.yaml
@@ -1,0 +1,32 @@
+# Leave-one-out: full v0.3 with the 2024 IO/dollar base-year removed
+# (model_base_year 2024 -> 2023). The GHG inventory stays at UMD GHGIA 2024
+# (usa_ghg_data_year 2024). All other v0.3 changes remain on.
+#####
+# Model base settings
+#####
+model_base_year: 2023
+
+#####
+# Data selection
+#####
+usa_ghg_data_year: 2024
+
+#####
+# Methodology selection
+#####
+use_cornerstone_2026_model_schema: True
+load_E_from_flowsa: True
+
+# GHG model: UMD GHGIA 2024 inventory (+ 2022 MECS attribution).
+v0_3_umd_2024_ghgia: True
+
+# A matrix: CEDA's A approach as fallback, with summary A/q dollar-year price adjustment.
+scale_a_matrix_with_ceda_method_as_fallback: True
+adjust_summary_A_and_q_dollar_year: True
+
+# Inflation factors.
+update_inflation_factors: True
+
+# Shared full-model flags.
+use_E_data_year_for_x_in_B: True
+implement_waste_disaggregation: True

--- a/bedrock/utils/config/configs/2025_usa_cornerstone_v0_3_minus_umd_mecs.yaml
+++ b/bedrock/utils/config/configs/2025_usa_cornerstone_v0_3_minus_umd_mecs.yaml
@@ -1,0 +1,38 @@
+# Leave-one-out (GHG chain, step 2): full v0.3 with the entire UMD GHGIA + MECS
+# methodology removed, reverting the GHG inventory to the v0.2 EPA-GHGI method
+# (GHG_national_Cornerstone_2023). There is no EPA-GHGI-only 2024 inventory, so
+# this necessarily sits at usa_ghg_data_year 2023.
+#   v0_3_umd_2024_ghgia -> new_ghg_method, usa_ghg_data_year 2024 -> 2023.
+# The IO/dollar base year stays at 2024. All other v0.3 changes remain on.
+#
+# (minus_ghg_2024_refresh) - this  = marginal effect of adopting UMD GHGIA + MECS.
+# FINAL - this                     = full GHG-overhaul effect.
+#####
+# Model base settings
+#####
+model_base_year: 2024
+
+#####
+# Data selection
+#####
+usa_ghg_data_year: 2023
+
+#####
+# Methodology selection
+#####
+use_cornerstone_2026_model_schema: True
+load_E_from_flowsa: True
+
+# GHG model: v0.2 EPA-GHGI inventory (GHG_national_Cornerstone_2023), no MECS/UMD.
+new_ghg_method: True
+
+# A matrix: CEDA's A approach as fallback, with summary A/q dollar-year price adjustment.
+scale_a_matrix_with_ceda_method_as_fallback: True
+adjust_summary_A_and_q_dollar_year: True
+
+# Inflation factors.
+update_inflation_factors: True
+
+# Shared full-model flags.
+use_E_data_year_for_x_in_B: True
+implement_waste_disaggregation: True


### PR DESCRIPTION
## Summary

Adds five leave-one-out configs, each the full v0.3 model with exactly one change reverted, for attributing the marginal effect of each v0.3 step (FINAL − minus_X = marginal effect of X).

- `2025_usa_cornerstone_v0_3_minus_ceda_a_approach.yaml` — CEDA A approach removed (`scale_a_matrix_with_ceda_method_as_fallback` + `adjust_summary_A_and_q_dollar_year` -> False; A reverts to v0.2).
- `2025_usa_cornerstone_v0_3_minus_ghg_2024_refresh.yaml` — GHG inventory stepped UMD GHGIA 2024 -> 2023 (`usa_ghg_data_year` 2024 -> 2023); IO base year stays 2024.
- `2025_usa_cornerstone_v0_3_minus_inflation_update.yaml` — `update_inflation_factors` -> False.
- `2025_usa_cornerstone_v0_3_minus_io_base_year.yaml` — IO/dollar base year `model_base_year` 2024 -> 2023; GHG inventory stays UMD GHGIA 2024.
- `2025_usa_cornerstone_v0_3_minus_umd_mecs.yaml` — entire UMD GHGIA + MECS methodology removed, GHG reverts to v0.2 EPA-GHGI (`new_ghg_method`; `usa_ghg_data_year` 2023).

All five share the v0.3 framework flags (`use_cornerstone_2026_model_schema`, `load_E_from_flowsa`, `use_E_data_year_for_x_in_B`, `implement_waste_disaggregation`).

Made with [Cursor](https://cursor.com)