### PR TITLE
feat(validation): add v0.3 release EF diagnostics tooling

### DIFF
--- a/.claude/skills/plot-ef-diagnostics/SKILL.md
+++ b/.claude/skills/plot-ef-diagnostics/SKILL.md
@@ -37,7 +37,7 @@ For Recipe B, surface the **dollar-year guard** (below) and ask whether to proce
 
 - **Fetch (parquet-cached):** `from bedrock.utils.validation.analysis.fetch import load_tab` → `load_tab(sheet_id, "N_and_diffs")` (pass `refresh=True` to re-pull).
 - **Plot primitives:** `from bedrock.utils.validation.analysis.plotting import setup_mpl, percent_histogram, apply_axis_fonts, save_and_close, DEFAULT_XLIM, TITLE_FONTSIZE`.
-- **Deck-panel extractor + constants:** `from bedrock.analysis.a_matrix_time_series.plot_v0_3_n_pct_hist import _pct_values` and `from bedrock.analysis.a_matrix_time_series.plot_ef_diagnostics import HIST_BINS, HIST_PCT_CLIP, HIST_FONT_SCALE, HIST_STATS_EXTRA_SCALE, STATS_FONTSIZE, TITLE_FONTSIZE, AXIS_LABEL_FONTSIZE, TICK_LABEL_FONTSIZE`.
+- **Deck-panel extractor + constants:** `from bedrock.utils.validation.analysis.ef_hist_panels import pct_values, draw_per_sector_pct_hist_panel, HIST_BINS, HIST_PCT_CLIP, HIST_FONT_SCALE, HIST_STATS_EXTRA_SCALE, PANEL_STATS_FONTSIZE, PANEL_TITLE_FONTSIZE, PANEL_AXIS_LABEL_FONTSIZE, PANEL_TICK_LABEL_FONTSIZE`.
 - **Approach palette** (`from bedrock.analysis.a_matrix_time_series.constants import APPROACH_COLORS`): `useeio #7f7f7f`, `ceda_default #bcbd22`, `summary_tables #1f77b4`, `industry_price_index #9467bd`, `commodity_price_index #2ca02c`, `useeio_nowcast #ff7f0e`.
 
 ## Recipe A — single sheet, N/D vs CEDA v0 (full suite)
@@ -59,10 +59,10 @@ Reuse `load_tab` + `percent_histogram`: produce a log-log scatter (`x = baseline
 
 ## Recipe C — deck histogram style (match the slides)
 
-Deck panels (e.g. "[CEDA as baseline] Bundled effect in N", titled by approach) come from `plot_ef_diagnostics._hist_panel` / `plot_v0_3_n_pct_hist._render`: each panel is one sheet's `N_perc_diff`, clipped to ±`HIST_PCT_CLIP` (100%), `HIST_BINS` (60) bins, zero line, `PercentFormatter` x-axis "Percentage Diff (%)", y "sector count", an `n / median / p95(|·|)` white box top-left, title + bar color from the approach.
+Deck panels (e.g. "[CEDA as baseline] Bundled effect in N", titled by approach) use `draw_per_sector_pct_hist_panel` from `ef_hist_panels` (also used by `plot_v0_3_n_pct_hist` and A-matrix `plot_ef_diagnostics` histogram grids): each panel is one sheet's `N_perc_diff`, clipped to ±`HIST_PCT_CLIP` (100%), `HIST_BINS` (60) bins, zero line, `PercentFormatter` x-axis "Percentage Diff (%)", y "sector count", an `n / median / p95(|·|)` white box top-left, title + bar color from the approach.
 
 - Single sheet, exact deck style: `python -m bedrock.analysis.a_matrix_time_series.plot_v0_3_n_pct_hist <SHEET_ID>`.
-- **Color override** (the script colors by approach, grey for unrecognized configs): replicate the `_render` body in a small figure, pulling pct via `_pct_values(load_tab(sid, "N_and_diffs"), "N")`, and pass an explicit color. **Orange = `#ff7f0e`** (the `useeio_nowcast` entry).
+- **Color override** (the script colors by approach, grey for unrecognized configs): replicate the `_render` body in a small figure, pulling pct via `pct_values(load_tab(sid, "N_and_diffs"), "N")`, and pass an explicit color. **Orange = `#ff7f0e`** (the `useeio_nowcast` entry).
 - **Side-by-side** (e.g. "v0.2 vs new"): lay panels out 1×N reusing the same constants so output matches the deck. Keep v0.2 blue (`#1f77b4`); color the new scenario as requested.
 
 ## Recipe D — release-progression panels (one panel per scenario step)
@@ -102,7 +102,7 @@ uv run python -m bedrock.utils.validation.analysis.overlay_ef_hist \
 
 ## Reference
 
-- `bedrock/utils/validation/analysis/`: `diagnostics_plots.py` (single-sheet CLI), `overlay_ef_hist.py` (version-overlay CLI), `bly_plots.py` (`build_sector_stack_frame`), `plotting.py` (primitives: `percent_histogram`, `overlay_pct_diff_histogram`, `plot_stacked_net_change`), `fetch.py` (cached loader).
-- `bedrock/analysis/a_matrix_time_series/`: `plot_ef_diagnostics.py` (`_hist_panel`, `_scatter_panel`, constants), `plot_v0_3_n_pct_hist.py` (`_render`, `_pct_values`), `constants.py` (`APPROACH_COLORS`).
+- `bedrock/utils/validation/analysis/`: `diagnostics_plots.py` (single-sheet CLI), `overlay_ef_hist.py` (version-overlay CLI), `ef_hist_panels.py` (`pct_values`, `draw_per_sector_pct_hist_panel`), `bly_plots.py` (`build_sector_stack_frame`), `plotting.py` (primitives: `percent_histogram`, `overlay_pct_diff_histogram`, `plot_stacked_net_change`), `fetch.py` (cached loader).
+- `bedrock/analysis/a_matrix_time_series/`: `plot_ef_diagnostics.py` (A-matrix scatter + histogram grids), `plot_v0_3_n_pct_hist.py` (single-sheet CLI), `constants.py` (`APPROACH_COLORS`).
 - `bedrock/utils/config/usa_config.py`: `_load_usa_config_from_file_name("<name>.yaml")` to resolve a config's intrinsic dollar years.
 - Sheets come from the `dispatch-ef-diagnostics` skill / `generate_diagnostics` workflow.

--- a/bedrock/analysis/a_matrix_time_series/plot_ef_diagnostics.py
+++ b/bedrock/analysis/a_matrix_time_series/plot_ef_diagnostics.py
@@ -37,11 +37,9 @@ import logging
 import typing as ta
 
 import matplotlib.pyplot as plt
-import numpy as np
 import pandas as pd
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
-from matplotlib.ticker import PercentFormatter
 
 from bedrock.analysis.a_matrix_time_series.compile_ef_diagnostics import (
     EF_SCATTER_COORDS_PATH,
@@ -50,6 +48,11 @@ from bedrock.analysis.a_matrix_time_series.compile_ef_diagnostics import (
 from bedrock.analysis.a_matrix_time_series.constants import (
     APPROACH_COLORS,
     PLOTS_DIR,
+)
+from bedrock.utils.validation.analysis.ef_hist_panels import (
+    EF_KIND_LABEL,
+    HIST_FONT_SCALE,
+    draw_per_sector_pct_hist_panel,
 )
 
 logger = logging.getLogger(__name__)
@@ -71,7 +74,6 @@ APPROACH_ORDER: tuple[str, ...] = (
     "useeio_nowcast",
 )
 BASELINE_LABEL: dict[str, str] = {"ceda": "CEDA-US (v0)", "useeio": "USEEIO"}
-EF_KIND_LABEL: dict[str, str] = {"N": "total EF (N)", "D": "direct EF (D)"}
 SCENARIO_LABEL: dict[str, str] = {
     "isolate_a_matrix": "isolate A-matrix method",
     "bundle_v0_3": "A-matrix method bundled with bedrock v0.3",
@@ -84,64 +86,6 @@ SUPTITLE_FONTSIZE = 14
 STATS_FONTSIZE = 10
 LEGEND_FONTSIZE = 9
 TICK_LABEL_FONTSIZE = 10
-
-# Histograms enlarge text 2× for readability in side-by-side reports.
-HIST_FONT_SCALE = 2.0
-# Stats annotation gets an extra 2× on top of HIST_FONT_SCALE so the per-
-# panel n / median / p95 box is easy to read at a glance.
-HIST_STATS_EXTRA_SCALE = 2.0
-
-HIST_PCT_CLIP = 100.0
-HIST_BINS = 60
-
-
-def draw_per_sector_pct_hist_panel(
-    ax: Axes,
-    pct_fraction: np.ndarray,
-    *,
-    title: str,
-    color: str,
-    font_scale: float = 1.0,
-    ylabel: str = "sector count",
-) -> None:
-    """Draw one clipped per-sector % diff histogram on ``ax``.
-
-    Shared by A-matrix bundle panels (``_hist_panel``), single-sheet renders
-    (``plot_v0_3_n_pct_hist._render``), and release-progression grids.
-    ``pct_fraction`` values are unit fractions (0.15 = 15%).
-    """
-    pct_percent = np.asarray(pct_fraction, dtype=float) * 100.0
-    finite = pct_percent[np.isfinite(pct_percent)]
-    if finite.size == 0:
-        ax.text(0.5, 0.5, "no data", transform=ax.transAxes, ha="center", va="center")
-        ax.set_title(title, fontsize=TITLE_FONTSIZE * font_scale, color="black")
-        return
-    clipped = np.clip(finite, -HIST_PCT_CLIP, HIST_PCT_CLIP)
-    ax.hist(clipped, bins=HIST_BINS, color=color, alpha=0.85)
-    ax.axvline(0, color="k", lw=1.0)
-    ax.set_xlim(-HIST_PCT_CLIP, HIST_PCT_CLIP)
-    ax.xaxis.set_major_formatter(PercentFormatter(decimals=0))
-    ax.grid(True, ls=":", alpha=0.3)
-    ax.text(
-        0.04,
-        0.96,
-        (
-            f"n={len(finite)}\n"
-            f"median={np.median(finite):.1f}%\n"
-            f"p95(|·|)={np.quantile(np.abs(finite), 0.95):.1f}%"
-        ),
-        transform=ax.transAxes,
-        fontsize=STATS_FONTSIZE * font_scale * HIST_STATS_EXTRA_SCALE,
-        va="top",
-        ha="left",
-        bbox=dict(
-            boxstyle="round,pad=0.3", facecolor="white", alpha=0.4, edgecolor="0.7"
-        ),
-    )
-    ax.set_title(title, fontsize=TITLE_FONTSIZE * font_scale, color="black")
-    ax.set_xlabel("Percentage Diff (%)", fontsize=AXIS_LABEL_FONTSIZE * font_scale)
-    ax.set_ylabel(ylabel, fontsize=AXIS_LABEL_FONTSIZE * font_scale)
-    ax.tick_params(axis="both", labelsize=TICK_LABEL_FONTSIZE * font_scale)
 
 
 def _panel_stats(panel_df: pd.DataFrame) -> dict[str, float]:

--- a/bedrock/analysis/a_matrix_time_series/plot_ef_diagnostics.py
+++ b/bedrock/analysis/a_matrix_time_series/plot_ef_diagnostics.py
@@ -95,6 +95,55 @@ HIST_PCT_CLIP = 100.0
 HIST_BINS = 60
 
 
+def draw_per_sector_pct_hist_panel(
+    ax: Axes,
+    pct_fraction: np.ndarray,
+    *,
+    title: str,
+    color: str,
+    font_scale: float = 1.0,
+    ylabel: str = "sector count",
+) -> None:
+    """Draw one clipped per-sector % diff histogram on ``ax``.
+
+    Shared by A-matrix bundle panels (``_hist_panel``), single-sheet renders
+    (``plot_v0_3_n_pct_hist._render``), and release-progression grids.
+    ``pct_fraction`` values are unit fractions (0.15 = 15%).
+    """
+    pct_percent = np.asarray(pct_fraction, dtype=float) * 100.0
+    finite = pct_percent[np.isfinite(pct_percent)]
+    if finite.size == 0:
+        ax.text(0.5, 0.5, "no data", transform=ax.transAxes, ha="center", va="center")
+        ax.set_title(title, fontsize=TITLE_FONTSIZE * font_scale, color="black")
+        return
+    clipped = np.clip(finite, -HIST_PCT_CLIP, HIST_PCT_CLIP)
+    ax.hist(clipped, bins=HIST_BINS, color=color, alpha=0.85)
+    ax.axvline(0, color="k", lw=1.0)
+    ax.set_xlim(-HIST_PCT_CLIP, HIST_PCT_CLIP)
+    ax.xaxis.set_major_formatter(PercentFormatter(decimals=0))
+    ax.grid(True, ls=":", alpha=0.3)
+    ax.text(
+        0.04,
+        0.96,
+        (
+            f"n={len(finite)}\n"
+            f"median={np.median(finite):.1f}%\n"
+            f"p95(|·|)={np.quantile(np.abs(finite), 0.95):.1f}%"
+        ),
+        transform=ax.transAxes,
+        fontsize=STATS_FONTSIZE * font_scale * HIST_STATS_EXTRA_SCALE,
+        va="top",
+        ha="left",
+        bbox=dict(
+            boxstyle="round,pad=0.3", facecolor="white", alpha=0.4, edgecolor="0.7"
+        ),
+    )
+    ax.set_title(title, fontsize=TITLE_FONTSIZE * font_scale, color="black")
+    ax.set_xlabel("Percentage Diff (%)", fontsize=AXIS_LABEL_FONTSIZE * font_scale)
+    ax.set_ylabel(ylabel, fontsize=AXIS_LABEL_FONTSIZE * font_scale)
+    ax.tick_params(axis="both", labelsize=TICK_LABEL_FONTSIZE * font_scale)
+
+
 def _panel_stats(panel_df: pd.DataFrame) -> dict[str, float]:
     """``R²`` against ``y=x``, ``p95`` of ``|y-x|/|x|``, and ``n_significant``.
 
@@ -170,29 +219,17 @@ def _hist_panel(
         ax.text(0.5, 0.5, "no data", transform=ax.transAxes, ha="center", va="center")
         ax.set_title(approach, fontsize=TITLE_FONTSIZE * font_scale, color="black")
         return
-    pct = ((df["y_approach"] - df["x_baseline"]) / df["x_baseline"].abs()).to_numpy(
-        dtype=float
-    ) * 100.0
-    finite = pct[np.isfinite(pct)]
-    clipped = np.clip(finite, -HIST_PCT_CLIP, HIST_PCT_CLIP)
-    ax.hist(clipped, bins=HIST_BINS, color=color, alpha=0.85)
-    ax.axvline(0, color="k", lw=1.0)
-    ax.set_xlim(-HIST_PCT_CLIP, HIST_PCT_CLIP)
-    ax.xaxis.set_major_formatter(PercentFormatter(decimals=0))
-    ax.grid(True, ls=":", alpha=0.3)
-    ax.text(
-        0.04,
-        0.96,
-        f"n={len(finite)}\nmedian={np.median(finite):.1f}%\np95(|·|)={np.quantile(np.abs(finite), 0.95):.1f}%",
-        transform=ax.transAxes,
-        fontsize=STATS_FONTSIZE * font_scale * HIST_STATS_EXTRA_SCALE,
-        va="top",
-        ha="left",
-        bbox=dict(
-            boxstyle="round,pad=0.3", facecolor="white", alpha=0.4, edgecolor="0.7"
-        ),
+    pct_fraction = (
+        (df["y_approach"] - df["x_baseline"]) / df["x_baseline"].abs()
+    ).to_numpy(dtype=float)
+    draw_per_sector_pct_hist_panel(
+        ax,
+        pct_fraction,
+        title=approach,
+        color=color,
+        font_scale=font_scale,
+        ylabel="",
     )
-    ax.set_title(approach, fontsize=TITLE_FONTSIZE * font_scale, color="black")
 
 
 def _latest_year_in(sub: pd.DataFrame) -> str:

--- a/bedrock/analysis/a_matrix_time_series/plot_v0_3_n_pct_hist.py
+++ b/bedrock/analysis/a_matrix_time_series/plot_v0_3_n_pct_hist.py
@@ -38,7 +38,6 @@ import sys
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-from matplotlib.ticker import PercentFormatter
 
 from bedrock.analysis.a_matrix_time_series.compile_ef_diagnostics import (
     _coerce_numeric,
@@ -48,16 +47,10 @@ from bedrock.analysis.a_matrix_time_series.constants import (
     PLOTS_DIR,
 )
 from bedrock.analysis.a_matrix_time_series.plot_ef_diagnostics import (
-    AXIS_LABEL_FONTSIZE,
     EF_KIND_LABEL,
-    HIST_BINS,
     HIST_FONT_SCALE,
-    HIST_PCT_CLIP,
-    HIST_STATS_EXTRA_SCALE,
-    STATS_FONTSIZE,
     SUPTITLE_FONTSIZE,
-    TICK_LABEL_FONTSIZE,
-    TITLE_FONTSIZE,
+    draw_per_sector_pct_hist_panel,
 )
 from bedrock.utils.io.gcp import read_sheet_tab
 
@@ -159,36 +152,16 @@ def _render(
     # ``cornerstone_default`` — visually signals "no scaling flag set".
     color = APPROACH_COLORS.get(approach, "#7f7f7f")
     kind_label = EF_KIND_LABEL[ef_kind]
-    pct_percent = pct * 100.0
-    clipped = np.clip(pct_percent, -HIST_PCT_CLIP, HIST_PCT_CLIP)
-
     font_scale = HIST_FONT_SCALE
+
     fig, ax = plt.subplots(figsize=(11.0 * font_scale * 0.6, 10.5 * font_scale * 0.6))
-    ax.hist(clipped, bins=HIST_BINS, color=color, alpha=0.85)
-    ax.axvline(0, color="k", lw=1.0)
-    ax.set_xlim(-HIST_PCT_CLIP, HIST_PCT_CLIP)
-    ax.xaxis.set_major_formatter(PercentFormatter(decimals=0))
-    ax.grid(True, ls=":", alpha=0.3)
-    ax.text(
-        0.04,
-        0.96,
-        (
-            f"n={len(pct_percent)}\n"
-            f"median={np.median(pct_percent):.1f}%\n"
-            f"p95(|·|)={np.quantile(np.abs(pct_percent), 0.95):.1f}%"
-        ),
-        transform=ax.transAxes,
-        fontsize=STATS_FONTSIZE * font_scale * HIST_STATS_EXTRA_SCALE,
-        va="top",
-        ha="left",
-        bbox=dict(
-            boxstyle="round,pad=0.3", facecolor="white", alpha=0.4, edgecolor="0.7"
-        ),
+    draw_per_sector_pct_hist_panel(
+        ax,
+        pct,
+        title=approach,
+        color=color,
+        font_scale=font_scale,
     )
-    ax.set_title(approach, fontsize=TITLE_FONTSIZE * font_scale, color="black")
-    ax.set_xlabel("Percentage Diff (%)", fontsize=AXIS_LABEL_FONTSIZE * font_scale)
-    ax.set_ylabel("sector count", fontsize=AXIS_LABEL_FONTSIZE * font_scale)
-    ax.tick_params(axis="both", labelsize=TICK_LABEL_FONTSIZE * font_scale)
 
     fig.suptitle(
         f"{kind_label} per-sector % diff distribution — vs CEDA-US (v0) "

--- a/bedrock/analysis/a_matrix_time_series/plot_v0_3_n_pct_hist.py
+++ b/bedrock/analysis/a_matrix_time_series/plot_v0_3_n_pct_hist.py
@@ -39,44 +39,25 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
-from bedrock.analysis.a_matrix_time_series.compile_ef_diagnostics import (
-    _coerce_numeric,
-)
 from bedrock.analysis.a_matrix_time_series.constants import (
     APPROACH_COLORS,
     PLOTS_DIR,
 )
-from bedrock.analysis.a_matrix_time_series.plot_ef_diagnostics import (
+from bedrock.utils.io.gcp import read_sheet_tab
+from bedrock.utils.validation.analysis.ef_hist_panels import (
     EF_KIND_LABEL,
     HIST_FONT_SCALE,
-    SUPTITLE_FONTSIZE,
+    PANEL_SUPTITLE_FONTSIZE,
     draw_per_sector_pct_hist_panel,
+    pct_values,
 )
-from bedrock.utils.io.gcp import read_sheet_tab
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_SHEET_ID = "1pCSgLD14lmrQg3OtfHvnK4lQrFtqiavrjCt-C3R_bSw"
 CONFIG_TAB = "config_summary"
 
-# Per-EF-kind tab name and the columns we read from it. ``D`` mirrors ``N``
-# in the diagnostics schema (`compile_ef_diagnostics._read_pair`).
-_KIND_SPEC: dict[str, dict[str, object]] = {
-    "N": {
-        "tab": "N_and_diffs",
-        "pct_col": "N_perc_diff",
-        "new_col": "N_new",
-        "old_col": "N_old_inflated",
-        "numeric_cols": ("N_new", "N_old", "N_old_inflated", "N_perc_diff"),
-    },
-    "D": {
-        "tab": "D_and_diffs",
-        "pct_col": "D_perc_diff",
-        "new_col": "D_new",
-        "old_col": "D_old_inflated",
-        "numeric_cols": ("D_new", "D_old", "D_old_inflated", "D_perc_diff"),
-    },
-}
+_KIND_TAB = {"N": "N_and_diffs", "D": "D_and_diffs"}
 
 # Map config_summary flag → display approach name. The flag set in the
 # v0.3 config_summary mirrors the YAML names referenced in epic #337.
@@ -110,30 +91,6 @@ def _approach_from_config(config_df: pd.DataFrame) -> str:
     return _DEFAULT_APPROACH_LABEL
 
 
-def _pct_values(df: pd.DataFrame, ef_kind: str) -> np.ndarray:
-    """Return per-sector pct diff as a fraction array (not percent)."""
-    spec = _KIND_SPEC[ef_kind]
-    pct_col = str(spec["pct_col"])
-    new_col = str(spec["new_col"])
-    old_col = str(spec["old_col"])
-    numeric_cols = spec["numeric_cols"]
-    assert isinstance(numeric_cols, tuple)
-    df = _coerce_numeric(df.copy(), numeric_cols)
-    if pct_col in df.columns:
-        series = pd.Series(pd.to_numeric(df[pct_col], errors="coerce")).dropna()
-    elif new_col in df.columns and old_col in df.columns:
-        new = pd.Series(pd.to_numeric(df[new_col], errors="coerce"))
-        old = pd.Series(pd.to_numeric(df[old_col], errors="coerce"))
-        series = ((new - old) / old.abs()).dropna()
-    else:
-        raise KeyError(
-            f"Tab {spec['tab']!r} has neither {pct_col!r} nor "
-            f"({new_col!r}, {old_col!r}); got columns: {list(df.columns)}"
-        )
-    arr = series.to_numpy(dtype=float)
-    return arr[np.isfinite(arr)]
-
-
 def _render(
     pct: np.ndarray,
     approach: str,
@@ -144,9 +101,9 @@ def _render(
     """Render a single-panel histogram matching the per-panel style of
     ``ef_pct_hist_*`` figures.
 
-    Font scale, bins, clipping, stats-box layout, and percent x-axis are
-    pulled from ``plot_ef_diagnostics`` so this output reads as one of the
-    four panels in the reference bundle plot.
+    Font scale, bins, clipping, stats-box layout, and percent x-axis match
+    ``ef_hist_panels.draw_per_sector_pct_hist_panel`` so this output reads as
+    one of the four panels in the reference bundle plot.
     """
     # Fall back to grey (the useeio palette entry) for unknown approaches like
     # ``cornerstone_default`` — visually signals "no scaling flag set".
@@ -166,7 +123,7 @@ def _render(
     fig.suptitle(
         f"{kind_label} per-sector % diff distribution — vs CEDA-US (v0) "
         f"[A-matrix method bundled with bedrock v0.3] — sheet {sheet_id[:10]}…",
-        fontsize=SUPTITLE_FONTSIZE * font_scale,
+        fontsize=PANEL_SUPTITLE_FONTSIZE * font_scale,
         y=1.0,
     )
     fig.tight_layout()
@@ -194,13 +151,12 @@ def main(sheet_id: str = DEFAULT_SHEET_ID) -> None:
     logger.info("Resolved approach=%r for sheet=%s", approach, sheet_id)
 
     for ef_kind in ("N", "D"):
-        spec = _KIND_SPEC[ef_kind]
-        tab = str(spec["tab"])
+        tab = _KIND_TAB[ef_kind]
         df = read_sheet_tab(sheet_id, tab)
         if df.empty:
             logger.warning("Tab %r in sheet %s is empty; skipping.", tab, sheet_id)
             continue
-        pct = _pct_values(df, ef_kind)
+        pct = pct_values(df, ef_kind)
         if pct.size == 0:
             logger.warning(
                 "No finite pct values in %r of sheet %s; skipping.", tab, sheet_id

--- a/bedrock/analysis/v0_3/README.md
+++ b/bedrock/analysis/v0_3/README.md
@@ -1,6 +1,6 @@
 # v0.3 release diagnostics
 
-Plot and dispatch scripts for the v0.3 release-deck EF diagnostics
+Plot and dispatch scripts for the v0.3 release EF diagnostics
 progression. They read or dispatch Google Sheets produced by
 `bedrock.utils.validation.generate_diagnostics` and reuse shared loaders in
 `bedrock.utils.validation.analysis` (`fetch`, `plotting`, `bly_plots`, etc.).
@@ -15,16 +15,20 @@ Plot, dispatch, and merged workbooks all land in `output/release_v0_3/`
 
 | Script | Purpose |
 |--------|---------|
-| `plot_ef_release_v0_3.py` | Deck-style progression histograms, FINAL v0.2 vs v0.3 overlays, and BLy charts from registered sheets. |
+| `plot_ef_release_v0_3.py` | Release progression histograms, FINAL v0.2 vs v0.3 overlays, and BLy charts from registered sheets. |
 | `dispatch_ef_release_v0_3.py` | Dispatch v0.3 release steps (MECS through FINAL) to the EF time-series Drive folder; appends to `output/release_v0_3/ef_run_index_release_v0_3.csv`. |
 
 ## Plot
 
 ```powershell
 uv run python -m bedrock.analysis.v0_3.plot_ef_release_v0_3
+uv run python -m bedrock.analysis.v0_3.plot_ef_release_v0_3 --compare-to v0.2
 ```
 
 Pass `--skip-progression`, `--skip-overlay`, or `--skip-bly` to omit figure groups.
+`--compare-to v0` (default) uses each sheet's in-tab diff vs CEDA v0 / USEEIO.
+`--compare-to v0.2` recomputes each v0.3 step vs FINAL v0.2 (2024 steps get
+`[+1yr infl]` on the panel title where applicable).
 
 ## Dispatch
 

--- a/bedrock/analysis/v0_3/README.md
+++ b/bedrock/analysis/v0_3/README.md
@@ -1,0 +1,53 @@
+# v0.3 release diagnostics
+
+Plot and dispatch scripts for the v0.3 release-deck EF diagnostics
+progression. They read or dispatch Google Sheets produced by
+`bedrock.utils.validation.generate_diagnostics` and reuse shared loaders in
+`bedrock.utils.validation.analysis` (`fetch`, `plotting`, `bly_plots`, etc.).
+
+The sheet registry (`release_v0_3_progression.py`) lives in
+`bedrock.utils.validation.analysis` so combine combos stay self-contained.
+
+Plot, dispatch, and merged workbooks all land in `output/release_v0_3/`
+(gitignored).
+
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `plot_ef_release_v0_3.py` | Deck-style progression histograms, FINAL v0.2 vs v0.3 overlays, and BLy charts from registered sheets. |
+| `dispatch_ef_release_v0_3.py` | Dispatch v0.3 release steps (MECS through FINAL) to the EF time-series Drive folder; appends to `output/release_v0_3/ef_run_index_release_v0_3.csv`. |
+
+## Plot
+
+```powershell
+uv run python -m bedrock.analysis.v0_3.plot_ef_release_v0_3
+```
+
+Pass `--skip-progression`, `--skip-overlay`, or `--skip-bly` to omit figure groups.
+
+## Dispatch
+
+```powershell
+uv run python -m bedrock.analysis.v0_3.dispatch_ef_release_v0_3 --dry-run
+uv run python -m bedrock.analysis.v0_3.dispatch_ef_release_v0_3 `
+    --only-configs 2025_usa_cornerstone_full_model_v0_3_ghgi_mecs
+```
+
+## Combine
+
+Merged workbooks use combos in `bedrock.utils.validation.analysis.combinations`
+(`v0.2_to_v0.3_ceda`, `v0.2_to_v0.3_useeio`), which read sheet IDs from
+`release_v0_3_progression.py` in that package:
+
+```powershell
+uv run python -m bedrock.utils.validation.analysis.combine_ef_diagnostics `
+    --combo v0.2_to_v0.3_ceda `
+    --output-xlsx bedrock/analysis/v0_3/output/release_v0_3/ef_diagnostics_merged_v0_2_to_v0_3_ceda.xlsx
+
+uv run python -m bedrock.utils.validation.analysis.combine_ef_diagnostics `
+    --combo v0.2_to_v0.3_useeio `
+    --output-xlsx bedrock/analysis/v0_3/output/release_v0_3/ef_diagnostics_merged_v0_2_to_v0_3_useeio.xlsx
+```
+
+Re-run with `--refresh` after sheet tab content changes.

--- a/bedrock/analysis/v0_3/dispatch_ef_release_v0_3.py
+++ b/bedrock/analysis/v0_3/dispatch_ef_release_v0_3.py
@@ -1,0 +1,228 @@
+"""Dispatch v0.3 release-progression EF diagnostics.
+
+Five configs × two baselines (CEDA v0 + USEEIO) → ten Sheets in the
+EF time-series Drive folder. Persists to
+``output/release_v0_3/ef_run_index_release_v0_3.csv`` (not the time-series
+``ef_run_index.csv``).
+
+Usage:
+    uv run python -m bedrock.analysis.v0_3.dispatch_ef_release_v0_3 --dry-run
+    uv run python -m bedrock.analysis.v0_3.dispatch_ef_release_v0_3
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+import pandas as pd
+
+from bedrock.analysis.a_matrix_time_series.dispatch_ef_time_series import (
+    EF_TIME_SERIES_DRIVE_FOLDER_ID,
+    _create_sheet,
+    _throttle,
+    _trigger_workflow,
+)
+from bedrock.utils.config.usa_config import _load_usa_config_from_file_name
+
+logger = logging.getLogger(__name__)
+
+_RELEASE_DIR = Path(__file__).resolve().parent / "output" / "release_v0_3"
+RELEASE_INDEX_PATH = _RELEASE_DIR / "ef_run_index_release_v0_3.csv"
+
+INDEX_COLUMNS = (
+    "config_name",
+    "baseline",
+    "sheet_id",
+    "sheet_title",
+    "useeio_box_ticked",
+    "model_base_year",
+    "usa_ghg_data_year",
+    "git_ref",
+    "triggered_at",
+)
+
+
+@dataclass(frozen=True)
+class ReleaseCell:
+    config_name: str
+    step_label: str
+    title_year: int  # year token in the sheet title (bedrock repo, {year}, …)
+
+
+RELEASE_STEPS: tuple[ReleaseCell, ...] = (
+    ReleaseCell("2025_usa_cornerstone_full_model_v0_3_ghgi_mecs", "MECS adjustment", 2023),
+    ReleaseCell(
+        "2025_usa_cornerstone_full_model_v0_3_umd_2023_ghgia",
+        "Switch to 2023 UMD data",
+        2023,
+    ),
+    ReleaseCell(
+        "2025_usa_cornerstone_full_model_v0_3_umd_2024_ghgia",
+        "Update to 2024 UMD data",
+        2024,
+    ),
+    ReleaseCell(
+        "2025_usa_cornerstone_full_model_v0_3_2024_io_ghg",
+        "2024 US IO+GHG data",
+        2024,
+    ),
+    ReleaseCell("2025_usa_cornerstone_v0_3", "FINAL v0.3", 2024),
+)
+
+
+def _sheet_title(*, today: str, title_year: int, baseline: str, step_label: str) -> str:
+    return (
+        f"[{today}, bedrock repo, {title_year}, {baseline} based, "
+        f"v0.3 / {step_label}] EFs diagnostics"
+    )
+
+
+def _years_for_config(config_name: str) -> tuple[int, int]:
+    cfg = _load_usa_config_from_file_name(f"{config_name}.yaml")
+    return cfg.model_base_year, cfg.usa_ghg_data_year
+
+
+def _load_index() -> pd.DataFrame:
+    if RELEASE_INDEX_PATH.exists():
+        df = pd.read_csv(RELEASE_INDEX_PATH)
+    else:
+        df = pd.DataFrame(columns=list(INDEX_COLUMNS))
+    for col in INDEX_COLUMNS:
+        if col not in df.columns:
+            df[col] = ""
+    return df
+
+
+def _append_index_row(row: dict[str, object]) -> None:
+    df = _load_index()
+    df = pd.concat([df, pd.DataFrame([row])], ignore_index=True)
+    RELEASE_INDEX_PATH.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(RELEASE_INDEX_PATH, index=False)
+
+
+def _already_recorded(df: pd.DataFrame, sheet_title: str) -> bool:
+    if df.empty:
+        return False
+    return bool((df["sheet_title"] == sheet_title).any())
+
+
+def dispatch_release(
+    *,
+    git_ref: str = "main",
+    dry_run: bool = False,
+    throttle: str = "poll",
+    only_configs: tuple[str, ...] | None = None,
+    title_date: str | None = None,
+    only_baselines: tuple[str, ...] | None = None,
+) -> None:
+    today = title_date or dt.datetime.utcnow().strftime("%Y-%m-%d")
+    n_dispatched = 0
+
+    steps = RELEASE_STEPS
+    if only_configs:
+        only_set = set(only_configs)
+        steps = tuple(c for c in RELEASE_STEPS if c.config_name in only_set)
+        if not steps:
+            raise ValueError(f"No RELEASE_STEPS match --only-configs {only_configs!r}")
+
+    for cell in steps:
+        model_base_year, usa_ghg_data_year = _years_for_config(cell.config_name)
+        for use_useeio in (False, True):
+            baseline_name = "USEEIO" if use_useeio else "CEDA"
+            baseline_key = "useeio" if use_useeio else "ceda"
+            if only_baselines and baseline_key not in only_baselines:
+                continue
+            title = _sheet_title(
+                today=today,
+                title_year=cell.title_year,
+                baseline=baseline_name,
+                step_label=cell.step_label,
+            )
+            index_df = _load_index()
+            if _already_recorded(index_df, title):
+                logger.info("Skip already-recorded: %s", title)
+                continue
+
+            if dry_run:
+                logger.info(
+                    "DRY-RUN would create: %s | config=%s use_useeio=%s "
+                    "model_base_year=%d usa_ghg_data_year=%d",
+                    title,
+                    cell.config_name,
+                    use_useeio,
+                    model_base_year,
+                    usa_ghg_data_year,
+                )
+                n_dispatched += 1
+                continue
+
+            _throttle(throttle)
+
+            sheet_id = _create_sheet(EF_TIME_SERIES_DRIVE_FOLDER_ID, title)
+            logger.info("Created sheet %s: %s", sheet_id, title)
+            _trigger_workflow(
+                git_ref=git_ref,
+                config_name=cell.config_name,
+                sheet_id=sheet_id,
+                model_base_year=model_base_year,
+                use_useeio_baseline=use_useeio,
+                usa_ghg_data_year=usa_ghg_data_year,
+            )
+            _append_index_row(
+                {
+                    "config_name": cell.config_name,
+                    "baseline": baseline_key,
+                    "sheet_id": sheet_id,
+                    "sheet_title": title,
+                    "useeio_box_ticked": str(use_useeio).lower(),
+                    "model_base_year": model_base_year,
+                    "usa_ghg_data_year": usa_ghg_data_year,
+                    "git_ref": git_ref,
+                    "triggered_at": dt.datetime.utcnow().isoformat() + "Z",
+                }
+            )
+            n_dispatched += 1
+
+    logger.info("Done. cells=%d", n_dispatched)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--git-ref", default="main")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--throttle", default="poll")
+    parser.add_argument(
+        "--only-configs",
+        default="",
+        help="Comma-separated config_name stems to dispatch (default: all five).",
+    )
+    parser.add_argument(
+        "--title-date",
+        default="",
+        help="YYYY-MM-DD prefix for sheet titles (default: UTC today).",
+    )
+    parser.add_argument(
+        "--only-baselines",
+        default="",
+        help="Comma-separated baseline keys to dispatch: ceda, useeio (default: both).",
+    )
+    args = parser.parse_args()
+    only = tuple(s.strip() for s in args.only_configs.split(",") if s.strip()) or None
+    baselines = tuple(s.strip() for s in args.only_baselines.split(",") if s.strip()) or None
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    dispatch_release(
+        git_ref=args.git_ref,
+        dry_run=args.dry_run,
+        throttle=args.throttle,
+        only_configs=only,
+        title_date=args.title_date or None,
+        only_baselines=baselines,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/bedrock/analysis/v0_3/dispatch_ef_release_v0_3.py
+++ b/bedrock/analysis/v0_3/dispatch_ef_release_v0_3.py
@@ -54,7 +54,9 @@ class ReleaseCell:
 
 
 RELEASE_STEPS: tuple[ReleaseCell, ...] = (
-    ReleaseCell("2025_usa_cornerstone_full_model_v0_3_ghgi_mecs", "MECS adjustment", 2023),
+    ReleaseCell(
+        "2025_usa_cornerstone_full_model_v0_3_ghgi_mecs", "MECS adjustment", 2023
+    ),
     ReleaseCell(
         "2025_usa_cornerstone_full_model_v0_3_umd_2023_ghgia",
         "Switch to 2023 UMD data",
@@ -212,7 +214,9 @@ def main() -> None:
     )
     args = parser.parse_args()
     only = tuple(s.strip() for s in args.only_configs.split(",") if s.strip()) or None
-    baselines = tuple(s.strip() for s in args.only_baselines.split(",") if s.strip()) or None
+    baselines = (
+        tuple(s.strip() for s in args.only_baselines.split(",") if s.strip()) or None
+    )
     logging.basicConfig(level=logging.INFO, format="%(message)s")
     dispatch_release(
         git_ref=args.git_ref,

--- a/bedrock/analysis/v0_3/plot_ef_release_v0_3.py
+++ b/bedrock/analysis/v0_3/plot_ef_release_v0_3.py
@@ -26,11 +26,15 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
-from bedrock.analysis.a_matrix_time_series.plot_ef_diagnostics import (
+from bedrock.utils.validation.analysis.bly_plots import (
+    TAB_BLY,
+    build_sector_stack_frame,
+)
+from bedrock.utils.validation.analysis.diagnostics_plots import bly_figsize
+from bedrock.utils.validation.analysis.ef_hist_panels import (
     EF_KIND_LABEL,
     draw_per_sector_pct_hist_panel,
 )
-from bedrock.utils.validation.analysis.bly_plots import TAB_BLY, build_sector_stack_frame
 from bedrock.utils.validation.analysis.ef_progression import (
     pct_fractions_useeio_purchaser_vs_v0,
     pct_fractions_vs_baseline_sheet,
@@ -44,13 +48,12 @@ from bedrock.utils.validation.analysis.plotting import (
     save_and_close,
     setup_mpl,
 )
-from bedrock.utils.validation.analysis.diagnostics_plots import bly_figsize
 from bedrock.utils.validation.analysis.release_v0_3_progression import (
-    ProgressionSheet,
     V02_FINAL_CEDA,
     V02_FINAL_USEEIO,
     V03_CEDA_STEPS,
     V03_USEEIO_STEPS,
+    ProgressionSheet,
 )
 
 logger = logging.getLogger(__name__)
@@ -149,7 +152,9 @@ def _plot_progression_grid(
     for i, step in enumerate(steps):
         ax = flat[i]
         loaded = panel_loader(step.sheet_id)
-        title = _panel_title(step.step_label, inflation_applied=loaded.inflation_applied)
+        title = _panel_title(
+            step.step_label, inflation_applied=loaded.inflation_applied
+        )
         draw_per_sector_pct_hist_panel(
             ax,
             loaded.fractions,
@@ -291,8 +296,16 @@ def _plot_bly_pair(
     bly_max_sectors: int,
 ) -> None:
     runs = (
-        ("v0.2", FINAL_V02_CEDA, "[GROUP: v0.2 FINAL vs CEDA v0] BLy net change by sector"),
-        ("v0.3", FINAL_V03_CEDA, "[GROUP: v0.3 FINAL vs CEDA v0] BLy net change by sector"),
+        (
+            "v0.2",
+            FINAL_V02_CEDA,
+            "[GROUP: v0.2 FINAL vs CEDA v0] BLy net change by sector",
+        ),
+        (
+            "v0.3",
+            FINAL_V03_CEDA,
+            "[GROUP: v0.3 FINAL vs CEDA v0] BLy net change by sector",
+        ),
     )
     fig, axes = plt.subplots(1, 2, figsize=(2 * 7.5, bly_figsize(bly_max_sectors)[1]))
     for ax, (version, sheet_id, title) in zip(axes, runs, strict=True):

--- a/bedrock/analysis/v0_3/plot_ef_release_v0_3.py
+++ b/bedrock/analysis/v0_3/plot_ef_release_v0_3.py
@@ -1,4 +1,4 @@
-"""Release-deck EF plots for the v0.3 diagnostics progression.
+"""Release EF progression plots for the v0.3 diagnostics refresh.
 
 Uses existing diagnostics Sheets on Drive (no re-dispatch). Figures:
 
@@ -9,6 +9,7 @@ Uses existing diagnostics Sheets on Drive (no re-dispatch). Figures:
 
 Usage:
     uv run python -m bedrock.analysis.v0_3.plot_ef_release_v0_3
+    uv run python -m bedrock.analysis.v0_3.plot_ef_release_v0_3 --compare-to v0.2
 """
 
 from __future__ import annotations
@@ -16,30 +17,24 @@ from __future__ import annotations
 import logging
 import math
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
 import click
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-from matplotlib.ticker import PercentFormatter
 
 from bedrock.analysis.a_matrix_time_series.plot_ef_diagnostics import (
-    AXIS_LABEL_FONTSIZE,
     EF_KIND_LABEL,
-    HIST_BINS,
-    HIST_PCT_CLIP,
-    HIST_STATS_EXTRA_SCALE,
-    STATS_FONTSIZE,
-    TICK_LABEL_FONTSIZE,
-    TITLE_FONTSIZE,
+    draw_per_sector_pct_hist_panel,
 )
-from bedrock.analysis.a_matrix_time_series.plot_v0_3_n_pct_hist import _pct_values
 from bedrock.utils.validation.analysis.bly_plots import TAB_BLY, build_sector_stack_frame
-from bedrock.utils.validation.analysis.diagnostics_plots import (
-    _drop_old_only,
-    _normalize_schema,
-    bly_figsize,
+from bedrock.utils.validation.analysis.ef_progression import (
+    pct_fractions_useeio_purchaser_vs_v0,
+    pct_fractions_vs_baseline_sheet,
+    pct_fractions_vs_v0,
 )
 from bedrock.utils.validation.analysis.fetch import load_tab
 from bedrock.utils.validation.analysis.overlay_ef_hist import _series_for_kind
@@ -49,6 +44,7 @@ from bedrock.utils.validation.analysis.plotting import (
     save_and_close,
     setup_mpl,
 )
+from bedrock.utils.validation.analysis.diagnostics_plots import bly_figsize
 from bedrock.utils.validation.analysis.release_v0_3_progression import (
     ProgressionSheet,
     V02_FINAL_CEDA,
@@ -63,62 +59,74 @@ OUT_DIR = Path(__file__).resolve().parent / "output" / "release_v0_3"
 
 CEDA_BAR = "#1f77b4"
 USEEIO_BAR = "#ff7f0e"
+PANEL_FONT_SCALE = 0.85
+
+CompareTo = Literal["v0", "v0.2"]
 
 FINAL_V02_CEDA = V02_FINAL_CEDA.sheet_id
 FINAL_V03_CEDA = V03_CEDA_STEPS[-1].sheet_id
 FINAL_V02_USEEIO = V02_FINAL_USEEIO.sheet_id
 FINAL_V03_USEEIO = V03_USEEIO_STEPS[-1].sheet_id
 
-
-def _ceda_kind_fractions(sheet_id: str, ef_kind: str) -> np.ndarray:
-    tab = f"{ef_kind}_and_diffs"
-    df = _drop_old_only(_normalize_schema(load_tab(sheet_id, tab)))
-    return _pct_values(df, ef_kind)
+V02_BASELINE_YEAR = 2023
 
 
-def _useeio_purchaser_fractions(sheet_id: str) -> np.ndarray:
-    df = _drop_old_only(_normalize_schema(load_tab(sheet_id, "N_and_diffs")))
-    num = pd.to_numeric(df["N_new_purchaser"], errors="coerce")
-    den = pd.to_numeric(df["N_old_purchaser"], errors="coerce")
-    return ((num - den) / den.abs()).dropna().to_numpy(dtype=float)
+@dataclass(frozen=True)
+class PanelLoad:
+    fractions: np.ndarray
+    inflation_applied: bool = False
 
 
-def _draw_deck_panel(
-    ax: plt.Axes,
-    pct_fraction: np.ndarray,
-    title: str,
+def _ref_2023_sheet_id(steps: tuple[ProgressionSheet, ...]) -> str | None:
+    for step in steps:
+        if "umd_2023_ghgia" in step.config_name:
+            return step.sheet_id
+    return steps[0].sheet_id if steps else None
+
+
+def _panel_title(step_label: str, *, inflation_applied: bool) -> str:
+    if inflation_applied:
+        return f"{step_label} [+1yr infl]"
+    return step_label
+
+
+def _loader_ceda_v0(ef_kind: str) -> Callable[[str], PanelLoad]:
+    def load(sheet_id: str) -> PanelLoad:
+        return PanelLoad(pct_fractions_vs_v0(sheet_id, ef_kind))
+
+    return load
+
+
+def _loader_useeio_purchaser_v0() -> Callable[[str], PanelLoad]:
+    def load(sheet_id: str) -> PanelLoad:
+        return PanelLoad(pct_fractions_useeio_purchaser_vs_v0(sheet_id))
+
+    return load
+
+
+def _loader_vs_v02(
+    baseline_sheet_id: str,
+    ef_kind: str,
     *,
-    bar_color: str,
-    font_scale: float = 1.0,
-) -> None:
-    pct_percent = pct_fraction * 100.0
-    finite = pct_percent[np.isfinite(pct_percent)]
-    clipped = np.clip(finite, -HIST_PCT_CLIP, HIST_PCT_CLIP)
-    ax.hist(clipped, bins=HIST_BINS, color=bar_color, alpha=0.85)
-    ax.axvline(0, color="k", lw=1.0)
-    ax.set_xlim(-HIST_PCT_CLIP, HIST_PCT_CLIP)
-    ax.xaxis.set_major_formatter(PercentFormatter(decimals=0))
-    ax.grid(True, ls=":", alpha=0.3)
-    ax.text(
-        0.04,
-        0.96,
-        (
-            f"n={len(finite)}\n"
-            f"median={np.median(finite):.1f}%\n"
-            f"p95(|·|)={np.quantile(np.abs(finite), 0.95):.1f}%"
-        ),
-        transform=ax.transAxes,
-        fontsize=STATS_FONTSIZE * font_scale * HIST_STATS_EXTRA_SCALE,
-        va="top",
-        ha="left",
-        bbox=dict(
-            boxstyle="round,pad=0.3", facecolor="white", alpha=0.4, edgecolor="0.7"
-        ),
-    )
-    ax.set_title(title, fontsize=TITLE_FONTSIZE * font_scale, color="black")
-    ax.set_xlabel("Percentage Diff (%)", fontsize=AXIS_LABEL_FONTSIZE * font_scale)
-    ax.set_ylabel("sector count", fontsize=AXIS_LABEL_FONTSIZE * font_scale)
-    ax.tick_params(axis="both", labelsize=TICK_LABEL_FONTSIZE * font_scale)
+    ref_2023_sheet_id: str | None,
+    prefer_purchaser: bool = False,
+) -> Callable[[str], PanelLoad]:
+    def load(sheet_id: str) -> PanelLoad:
+        fractions, inflation_applied = pct_fractions_vs_baseline_sheet(
+            sheet_id,
+            baseline_sheet_id,
+            ef_kind,
+            ref_2023_sheet_id=ref_2023_sheet_id,
+            baseline_year=V02_BASELINE_YEAR,
+            prefer_purchaser=prefer_purchaser,
+        )
+        return PanelLoad(fractions, inflation_applied=inflation_applied)
+
+    return load
+
+
+def _useeio_purchaser_series_percent(sheet_id: str) -> pd.Series[float]:
+    return pd.Series(pct_fractions_useeio_purchaser_vs_v0(sheet_id) * 100.0)
 
 
 def _plot_progression_grid(
@@ -127,7 +135,7 @@ def _plot_progression_grid(
     group_title: str,
     out_path: Path,
     bar_color: str,
-    pct_loader: Callable[[str], np.ndarray],
+    panel_loader: Callable[[str], PanelLoad],
     ncols: int = 3,
 ) -> None:
     n = len(steps)
@@ -140,8 +148,15 @@ def _plot_progression_grid(
     ymax = 0.0
     for i, step in enumerate(steps):
         ax = flat[i]
-        pct = pct_loader(step.sheet_id)
-        _draw_deck_panel(ax, pct, step.step_label, bar_color=bar_color, font_scale=0.85)
+        loaded = panel_loader(step.sheet_id)
+        title = _panel_title(step.step_label, inflation_applied=loaded.inflation_applied)
+        draw_per_sector_pct_hist_panel(
+            ax,
+            loaded.fractions,
+            title=title,
+            color=bar_color,
+            font_scale=PANEL_FONT_SCALE,
+        )
         ymax = max(ymax, ax.get_ylim()[1])
     for i in range(n):
         flat[i].set_ylim(0, ymax)
@@ -153,48 +168,84 @@ def _plot_progression_grid(
     print(f"Wrote: {out_path}")
 
 
-def _plot_v03_progressions(out_dir: Path) -> None:
-    for ef_kind in ("N", "D"):
+def _baseline_label(compare_to: CompareTo) -> str:
+    return "CEDA-US (v0)" if compare_to == "v0" else "v0.2 FINAL"
 
-        def ceda_loader(sid: str, kind: str = ef_kind) -> np.ndarray:
-            return _ceda_kind_fractions(sid, kind)
+
+def _compare_slug(compare_to: CompareTo) -> str:
+    return "" if compare_to == "v0" else "_vs_v02"
+
+
+def _plot_v03_progressions(out_dir: Path, compare_to: CompareTo) -> None:
+    slug = _compare_slug(compare_to)
+    baseline_label = _baseline_label(compare_to)
+
+    ceda_ref_2023 = _ref_2023_sheet_id(V03_CEDA_STEPS)
+    useeio_ref_2023 = _ref_2023_sheet_id(V03_USEEIO_STEPS)
+
+    for ef_kind in ("N", "D"):
+        if compare_to == "v0":
+            loader = _loader_ceda_v0(ef_kind)
+        else:
+            loader = _loader_vs_v02(
+                FINAL_V02_CEDA,
+                ef_kind,
+                ref_2023_sheet_id=ceda_ref_2023,
+            )
 
         _plot_progression_grid(
             V03_CEDA_STEPS,
             group_title=(
-                f"[GROUP: v0.3 · baseline: CEDA-US (v0)] per-sector {ef_kind} % diff, "
+                f"[GROUP: v0.3 · baseline: {baseline_label}] per-sector {ef_kind} % diff, "
                 "by release step"
             ),
-            out_path=out_dir / f"progression_v03_ceda_{ef_kind}.png",
+            out_path=out_dir / f"progression_v03_ceda_{ef_kind}{slug}.png",
             bar_color=CEDA_BAR,
-            pct_loader=ceda_loader,
+            panel_loader=loader,
+        )
+
+    if compare_to == "v0":
+        useeio_n_loader = _loader_useeio_purchaser_v0()
+    else:
+        useeio_n_loader = _loader_vs_v02(
+            FINAL_V02_USEEIO,
+            "N",
+            ref_2023_sheet_id=useeio_ref_2023,
+            prefer_purchaser=True,
         )
 
     _plot_progression_grid(
         V03_USEEIO_STEPS,
         group_title=(
-            "[GROUP: v0.3 · baseline: USEEIO (purchaser)] per-sector N % diff, "
-            "by release step"
+            f"[GROUP: v0.3 · baseline: {'USEEIO (purchaser)' if compare_to == 'v0' else 'v0.2 FINAL (purchaser)'}] "
+            "per-sector N % diff, by release step"
         ),
-        out_path=out_dir / "progression_v03_useeio_N.png",
+        out_path=out_dir / f"progression_v03_useeio_N{slug}.png",
         bar_color=USEEIO_BAR,
-        pct_loader=_useeio_purchaser_fractions,
+        panel_loader=useeio_n_loader,
     )
+
+    if compare_to == "v0":
+        useeio_d_loader = _loader_ceda_v0("D")
+        d_subtitle = "by release step (producer / CEDA v0)"
+    else:
+        useeio_d_loader = _loader_vs_v02(
+            FINAL_V02_CEDA,
+            "D",
+            ref_2023_sheet_id=ceda_ref_2023,
+        )
+        d_subtitle = "by release step (producer / vs v0.2 FINAL)"
 
     _plot_progression_grid(
         V03_USEEIO_STEPS,
         group_title=(
-            "[GROUP: v0.3 · baseline: USEEIO (purchaser)] per-sector D % diff, "
-            "by release step (producer / CEDA v0)"
+            f"[GROUP: v0.3 · baseline: {baseline_label}] per-sector D % diff, "
+            f"{d_subtitle}"
         ),
-        out_path=out_dir / "progression_v03_useeio_D.png",
+        out_path=out_dir / f"progression_v03_useeio_D{slug}.png",
         bar_color=USEEIO_BAR,
-        pct_loader=lambda sid: _ceda_kind_fractions(sid, "D"),
+        panel_loader=useeio_d_loader,
     )
-
-
-def _useeio_purchaser_series_percent(sheet_id: str) -> "pd.Series[float]":
-    return pd.Series(_useeio_purchaser_fractions(sheet_id) * 100.0)
 
 
 def _plot_final_overlays(out_dir: Path) -> None:
@@ -269,6 +320,16 @@ def _plot_bly_pair(
     default=OUT_DIR,
     show_default=True,
 )
+@click.option(
+    "--compare-to",
+    type=click.Choice(["v0", "v0.2"], case_sensitive=False),
+    default="v0",
+    show_default=True,
+    help=(
+        "Baseline for progression panels: in-sheet diff vs v0 (default) or "
+        "cross-sheet diff vs FINAL v0.2 (with 2023→2024 inflation on 2024 steps)."
+    ),
+)
 @click.option("--skip-progression", is_flag=True)
 @click.option("--skip-overlay", is_flag=True)
 @click.option("--skip-bly", is_flag=True)
@@ -276,6 +337,7 @@ def _plot_bly_pair(
 @click.option("--bly-max-sectors", type=int, default=0, show_default=True)
 def main(
     out_dir: Path,
+    compare_to: str,
     skip_progression: bool,
     skip_overlay: bool,
     skip_bly: bool,
@@ -284,9 +346,10 @@ def main(
 ) -> None:
     setup_mpl(font_size=13)
     out_dir.mkdir(parents=True, exist_ok=True)
+    compare: CompareTo = "v0.2" if compare_to.lower() == "v0.2" else "v0"
 
     if not skip_progression:
-        _plot_v03_progressions(out_dir)
+        _plot_v03_progressions(out_dir, compare)
     if not skip_overlay:
         _plot_final_overlays(out_dir)
     if not skip_bly:

--- a/bedrock/analysis/v0_3/plot_ef_release_v0_3.py
+++ b/bedrock/analysis/v0_3/plot_ef_release_v0_3.py
@@ -1,0 +1,302 @@
+"""Release-deck EF plots for the v0.3 diagnostics progression.
+
+Uses existing diagnostics Sheets on Drive (no re-dispatch). Figures:
+
+- v0.3 progression grids (CEDA 7-step N+D; USEEIO 7-step N purchaser + D)
+- FINAL v0.2 vs v0.3 overlays vs CEDA v0 (N and D)
+- FINAL v0.2 vs v0.3 overlay vs USEEIO purchaser (N)
+- BLy pair: FINAL v0.2 + v0.3 (CEDA baseline runs only)
+
+Usage:
+    uv run python -m bedrock.analysis.v0_3.plot_ef_release_v0_3
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from collections.abc import Callable
+from pathlib import Path
+
+import click
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from matplotlib.ticker import PercentFormatter
+
+from bedrock.analysis.a_matrix_time_series.plot_ef_diagnostics import (
+    AXIS_LABEL_FONTSIZE,
+    EF_KIND_LABEL,
+    HIST_BINS,
+    HIST_PCT_CLIP,
+    HIST_STATS_EXTRA_SCALE,
+    STATS_FONTSIZE,
+    TICK_LABEL_FONTSIZE,
+    TITLE_FONTSIZE,
+)
+from bedrock.analysis.a_matrix_time_series.plot_v0_3_n_pct_hist import _pct_values
+from bedrock.utils.validation.analysis.bly_plots import TAB_BLY, build_sector_stack_frame
+from bedrock.utils.validation.analysis.diagnostics_plots import (
+    _drop_old_only,
+    _normalize_schema,
+    bly_figsize,
+)
+from bedrock.utils.validation.analysis.fetch import load_tab
+from bedrock.utils.validation.analysis.overlay_ef_hist import _series_for_kind
+from bedrock.utils.validation.analysis.plotting import (
+    overlay_pct_diff_histogram,
+    plot_stacked_net_change,
+    save_and_close,
+    setup_mpl,
+)
+from bedrock.utils.validation.analysis.release_v0_3_progression import (
+    ProgressionSheet,
+    V02_FINAL_CEDA,
+    V02_FINAL_USEEIO,
+    V03_CEDA_STEPS,
+    V03_USEEIO_STEPS,
+)
+
+logger = logging.getLogger(__name__)
+
+OUT_DIR = Path(__file__).resolve().parent / "output" / "release_v0_3"
+
+CEDA_BAR = "#1f77b4"
+USEEIO_BAR = "#ff7f0e"
+
+FINAL_V02_CEDA = V02_FINAL_CEDA.sheet_id
+FINAL_V03_CEDA = V03_CEDA_STEPS[-1].sheet_id
+FINAL_V02_USEEIO = V02_FINAL_USEEIO.sheet_id
+FINAL_V03_USEEIO = V03_USEEIO_STEPS[-1].sheet_id
+
+
+def _ceda_kind_fractions(sheet_id: str, ef_kind: str) -> np.ndarray:
+    tab = f"{ef_kind}_and_diffs"
+    df = _drop_old_only(_normalize_schema(load_tab(sheet_id, tab)))
+    return _pct_values(df, ef_kind)
+
+
+def _useeio_purchaser_fractions(sheet_id: str) -> np.ndarray:
+    df = _drop_old_only(_normalize_schema(load_tab(sheet_id, "N_and_diffs")))
+    num = pd.to_numeric(df["N_new_purchaser"], errors="coerce")
+    den = pd.to_numeric(df["N_old_purchaser"], errors="coerce")
+    return ((num - den) / den.abs()).dropna().to_numpy(dtype=float)
+
+
+def _draw_deck_panel(
+    ax: plt.Axes,
+    pct_fraction: np.ndarray,
+    title: str,
+    *,
+    bar_color: str,
+    font_scale: float = 1.0,
+) -> None:
+    pct_percent = pct_fraction * 100.0
+    finite = pct_percent[np.isfinite(pct_percent)]
+    clipped = np.clip(finite, -HIST_PCT_CLIP, HIST_PCT_CLIP)
+    ax.hist(clipped, bins=HIST_BINS, color=bar_color, alpha=0.85)
+    ax.axvline(0, color="k", lw=1.0)
+    ax.set_xlim(-HIST_PCT_CLIP, HIST_PCT_CLIP)
+    ax.xaxis.set_major_formatter(PercentFormatter(decimals=0))
+    ax.grid(True, ls=":", alpha=0.3)
+    ax.text(
+        0.04,
+        0.96,
+        (
+            f"n={len(finite)}\n"
+            f"median={np.median(finite):.1f}%\n"
+            f"p95(|·|)={np.quantile(np.abs(finite), 0.95):.1f}%"
+        ),
+        transform=ax.transAxes,
+        fontsize=STATS_FONTSIZE * font_scale * HIST_STATS_EXTRA_SCALE,
+        va="top",
+        ha="left",
+        bbox=dict(
+            boxstyle="round,pad=0.3", facecolor="white", alpha=0.4, edgecolor="0.7"
+        ),
+    )
+    ax.set_title(title, fontsize=TITLE_FONTSIZE * font_scale, color="black")
+    ax.set_xlabel("Percentage Diff (%)", fontsize=AXIS_LABEL_FONTSIZE * font_scale)
+    ax.set_ylabel("sector count", fontsize=AXIS_LABEL_FONTSIZE * font_scale)
+    ax.tick_params(axis="both", labelsize=TICK_LABEL_FONTSIZE * font_scale)
+
+
+def _plot_progression_grid(
+    steps: tuple[ProgressionSheet, ...],
+    *,
+    group_title: str,
+    out_path: Path,
+    bar_color: str,
+    pct_loader: Callable[[str], np.ndarray],
+    ncols: int = 3,
+) -> None:
+    n = len(steps)
+    cols = min(ncols, n)
+    rows = math.ceil(n / cols)
+    fig, axes = plt.subplots(
+        rows, cols, figsize=(5.5 * cols, 4.8 * rows), squeeze=False
+    )
+    flat = list(axes.flat)
+    ymax = 0.0
+    for i, step in enumerate(steps):
+        ax = flat[i]
+        pct = pct_loader(step.sheet_id)
+        _draw_deck_panel(ax, pct, step.step_label, bar_color=bar_color, font_scale=0.85)
+        ymax = max(ymax, ax.get_ylim()[1])
+    for i in range(n):
+        flat[i].set_ylim(0, ymax)
+    for ax in flat[n:]:
+        ax.axis("off")
+    fig.suptitle(group_title, fontsize=14, y=1.02)
+    fig.tight_layout()
+    save_and_close(fig, out_path)
+    print(f"Wrote: {out_path}")
+
+
+def _plot_v03_progressions(out_dir: Path) -> None:
+    for ef_kind in ("N", "D"):
+
+        def ceda_loader(sid: str, kind: str = ef_kind) -> np.ndarray:
+            return _ceda_kind_fractions(sid, kind)
+
+        _plot_progression_grid(
+            V03_CEDA_STEPS,
+            group_title=(
+                f"[GROUP: v0.3 · baseline: CEDA-US (v0)] per-sector {ef_kind} % diff, "
+                "by release step"
+            ),
+            out_path=out_dir / f"progression_v03_ceda_{ef_kind}.png",
+            bar_color=CEDA_BAR,
+            pct_loader=ceda_loader,
+        )
+
+    _plot_progression_grid(
+        V03_USEEIO_STEPS,
+        group_title=(
+            "[GROUP: v0.3 · baseline: USEEIO (purchaser)] per-sector N % diff, "
+            "by release step"
+        ),
+        out_path=out_dir / "progression_v03_useeio_N.png",
+        bar_color=USEEIO_BAR,
+        pct_loader=_useeio_purchaser_fractions,
+    )
+
+    _plot_progression_grid(
+        V03_USEEIO_STEPS,
+        group_title=(
+            "[GROUP: v0.3 · baseline: USEEIO (purchaser)] per-sector D % diff, "
+            "by release step (producer / CEDA v0)"
+        ),
+        out_path=out_dir / "progression_v03_useeio_D.png",
+        bar_color=USEEIO_BAR,
+        pct_loader=lambda sid: _ceda_kind_fractions(sid, "D"),
+    )
+
+
+def _useeio_purchaser_series_percent(sheet_id: str) -> "pd.Series[float]":
+    return pd.Series(_useeio_purchaser_fractions(sheet_id) * 100.0)
+
+
+def _plot_final_overlays(out_dir: Path) -> None:
+    for ef_kind in ("N", "D"):
+        series_by_label = {
+            "v0.2": _series_for_kind(FINAL_V02_CEDA, ef_kind),
+            "v0.3": _series_for_kind(FINAL_V03_CEDA, ef_kind),
+        }
+        fig, ax = plt.subplots(figsize=(11, 6.5))
+        kind_label = EF_KIND_LABEL[ef_kind]
+        overlay_pct_diff_histogram(
+            ax,
+            series_by_label,
+            xlabel="EF change vs CEDA v0 baseline (%)",
+            title=f"{kind_label} per-sector % diff vs CEDA v0 — v0.2 vs v0.3",
+        )
+        fig.tight_layout()
+        out = out_dir / f"overlay_final_ceda_{ef_kind}.png"
+        save_and_close(fig, out)
+        print(f"Wrote: {out}")
+
+    series_by_label = {
+        "v0.2": _useeio_purchaser_series_percent(FINAL_V02_USEEIO),
+        "v0.3": _useeio_purchaser_series_percent(FINAL_V03_USEEIO),
+    }
+    fig, ax = plt.subplots(figsize=(11, 6.5))
+    overlay_pct_diff_histogram(
+        ax,
+        series_by_label,
+        xlabel="EF change vs USEEIO baseline (purchaser, %)",
+        title=f"{EF_KIND_LABEL['N']} per-sector % diff vs USEEIO — v0.2 vs v0.3",
+    )
+    fig.tight_layout()
+    out = out_dir / "overlay_final_useeio_N.png"
+    save_and_close(fig, out)
+    print(f"Wrote: {out}")
+
+
+def _plot_bly_pair(
+    out_dir: Path,
+    *,
+    bly_group_small_threshold: float,
+    bly_max_sectors: int,
+) -> None:
+    runs = (
+        ("v0.2", FINAL_V02_CEDA, "[GROUP: v0.2 FINAL vs CEDA v0] BLy net change by sector"),
+        ("v0.3", FINAL_V03_CEDA, "[GROUP: v0.3 FINAL vs CEDA v0] BLy net change by sector"),
+    )
+    fig, axes = plt.subplots(1, 2, figsize=(2 * 7.5, bly_figsize(bly_max_sectors)[1]))
+    for ax, (version, sheet_id, title) in zip(axes, runs, strict=True):
+        bly_frame = build_sector_stack_frame(
+            load_tab(sheet_id, TAB_BLY),
+            group_small_threshold=bly_group_small_threshold,
+            max_sectors=bly_max_sectors,
+        )
+        plot_stacked_net_change(
+            ax,
+            bly_frame,
+            title=title,
+            ylabel="Gross change (MMT CO2e)",
+        )
+    fig.tight_layout()
+    out = out_dir / "bly_final_v02_v03_ceda.png"
+    save_and_close(fig, out)
+    print(f"Wrote: {out}")
+
+
+@click.command()
+@click.option(
+    "--out-dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=OUT_DIR,
+    show_default=True,
+)
+@click.option("--skip-progression", is_flag=True)
+@click.option("--skip-overlay", is_flag=True)
+@click.option("--skip-bly", is_flag=True)
+@click.option("--bly-group-small-threshold", type=float, default=3.0, show_default=True)
+@click.option("--bly-max-sectors", type=int, default=0, show_default=True)
+def main(
+    out_dir: Path,
+    skip_progression: bool,
+    skip_overlay: bool,
+    skip_bly: bool,
+    bly_group_small_threshold: float,
+    bly_max_sectors: int,
+) -> None:
+    setup_mpl(font_size=13)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    if not skip_progression:
+        _plot_v03_progressions(out_dir)
+    if not skip_overlay:
+        _plot_final_overlays(out_dir)
+    if not skip_bly:
+        _plot_bly_pair(
+            out_dir,
+            bly_group_small_threshold=bly_group_small_threshold,
+            bly_max_sectors=bly_max_sectors,
+        )
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    main()

--- a/bedrock/utils/validation/analysis/README.md
+++ b/bedrock/utils/validation/analysis/README.md
@@ -11,6 +11,9 @@ back, caches them locally as parquet, and renders analysis figures.
 
 - `plotting.py` — shared matplotlib primitives (percent histogram, absolute-change
   histogram, reference lines, styled text boxes).
+- `ef_hist_panels.py` — clipped per-sector % diff histogram panels and
+  ``pct_values`` for diagnostics ``N_and_diffs`` / ``D_and_diffs`` tabs
+  (release-progression grids, single-sheet renders, A-matrix bundle histograms).
 - `fetch.py` — `load_tab` / `load_tabs` read Sheet tabs via
   `bedrock.utils.io.gcp.read_sheet_tab`, coerce numerics, and cache as parquet
   under `.cache/<sheet_id>/<tab>.parquet`.

--- a/bedrock/utils/validation/analysis/README.md
+++ b/bedrock/utils/validation/analysis/README.md
@@ -71,6 +71,12 @@ back, caches them locally as parquet, and renders analysis figures.
   Sheet titles, and per-`config_name` target mapping. The destination Sheet
   for merged output is always passed on the command line via
   `--output-sheet-id`.
+- `release_v0_3_progression.py` — v0.3 release-deck sheet registry (IDs,
+  titles, `config_name` per step). Consumed by `combinations.py` and
+  `bedrock.analysis.v0_3.plot_ef_release_v0_3`. v0.2 FINAL sheets record
+  `config_name` `2025_usa_cornerstone_full_model` (renamed to
+  `2025_usa_cornerstone_v0_2` in configs after dispatch). Atomic v0.3 steps
+  (inflation, A/price, MECS) net-diff against that column, not stepwise.
 
 ## Running
 
@@ -123,3 +129,23 @@ uv run python -m bedrock.utils.validation.analysis.combine_ef_diagnostics \
     --combo v0.2 \
     --output-sheet-id 1TOLpjg80GBeb3C8sVKGvYRL9U5HfUgKSz_IHoWHainY
 ```
+
+### v0.3 release
+
+Plot, dispatch, and sheet registry live in `bedrock/analysis/v0_3/` — see
+[`bedrock/analysis/v0_3/README.md`](../../../analysis/v0_3/README.md).
+
+Combine v0 baseline through v0.3 (CEDA) or FINAL v0.2 through v0.3
+(USEEIO) from this package:
+
+```bash
+uv run python -m bedrock.utils.validation.analysis.combine_ef_diagnostics \
+    --combo v0.2_to_v0.3_ceda \
+    --output-xlsx bedrock/analysis/v0_3/output/release_v0_3/ef_diagnostics_merged_v0_2_to_v0_3_ceda.xlsx
+
+uv run python -m bedrock.utils.validation.analysis.combine_ef_diagnostics \
+    --combo v0.2_to_v0.3_useeio \
+    --output-xlsx bedrock/analysis/v0_3/output/release_v0_3/ef_diagnostics_merged_v0_2_to_v0_3_useeio.xlsx
+```
+
+Re-run with `--refresh` after sheet tabs change.

--- a/bedrock/utils/validation/analysis/combinations.py
+++ b/bedrock/utils/validation/analysis/combinations.py
@@ -20,6 +20,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from bedrock.utils.validation.analysis.release_v0_3_progression import (
+    CEDA_V02_TO_V03_SHEETS,
+    USEEIO_V02_TO_V03_SHEETS,
+    ceda_stepwise_target_mapping,
+    sheets_in_order,
+    useeio_stepwise_target_mapping,
+)
+
 
 @dataclass(frozen=True)
 class ComboSpec:
@@ -27,12 +35,16 @@ class ComboSpec:
 
     Attributes:
         drive_folder_id: Drive folder holding the per-run diagnostics Sheets.
-            Used to resolve ``names_in_order`` to Sheet IDs.
+            Used to resolve ``names_in_order`` to Sheet IDs when
+            ``sheets_in_order`` is empty.
         names_in_order: Ordered Sheet titles (one per diagnostics run). Order
             controls merge order in the output tabs.
         target_mapping: Per-``config_name`` target column for the net-diff
             tabs (subtract ``target`` from ``config``). Keys must match the
             ``config_name`` value stored in each run's ``config_summary`` tab.
+        sheets_in_order: Optional explicit ``(sheet_id, title)`` pairs. When
+            non-empty, inputs are taken directly and ``drive_folder_id`` /
+            ``names_in_order`` are ignored (for Sheets that span folders).
 
     The destination Sheet for merged output is always supplied on the
     command line via ``--output-sheet-id``; it is intentionally not part of
@@ -42,6 +54,7 @@ class ComboSpec:
     drive_folder_id: str
     names_in_order: list[str]
     target_mapping: dict[str, str]
+    sheets_in_order: tuple[tuple[str, str], ...] = ()
 
 
 # Historical destination Sheets (pass via --output-sheet-id when reproducing):
@@ -119,5 +132,21 @@ COMBINATIONS: dict[str, ComboSpec] = {
             '2025_usa_cornerstone_B_transformation_and_waste_disaggregation': '2025_usa_cornerstone_taxonomy_and_waste_disagg',
             '2025_usa_cornerstone_v0_2': 'v8_ceda_2025_usa',
         },
+    ),
+    # v0 baseline → FINAL v0.2 → v0.3 release steps. Net-diff chains stepwise;
+    # atomic v0.2-footing configs (inflation, A/price, MECS) diff vs full_model.
+    'v0.2_to_v0.3_ceda': ComboSpec(
+        drive_folder_id='',
+        names_in_order=[],
+        target_mapping=ceda_stepwise_target_mapping(CEDA_V02_TO_V03_SHEETS),
+        sheets_in_order=sheets_in_order(CEDA_V02_TO_V03_SHEETS),
+    ),
+    # FINAL v0.2 → v0.3 release steps. Net-diff chains stepwise; atomic
+    # v0.2-footing configs (inflation, A/price, MECS) diff vs full_model.
+    'v0.2_to_v0.3_useeio': ComboSpec(
+        drive_folder_id='',
+        names_in_order=[],
+        target_mapping=useeio_stepwise_target_mapping(USEEIO_V02_TO_V03_SHEETS),
+        sheets_in_order=sheets_in_order(USEEIO_V02_TO_V03_SHEETS),
     ),
 }

--- a/bedrock/utils/validation/analysis/combine_ef_diagnostics.py
+++ b/bedrock/utils/validation/analysis/combine_ef_diagnostics.py
@@ -89,9 +89,8 @@ from bedrock.utils.validation.analysis.fetch import load_tab, load_tabs_optional
 
 logger = logging.getLogger(__name__)
 
-# Default output xlsx lives next to diagnostics_plots' output under
-# analysis/output/<combo>/ef_diagnostics_merged.xlsx. Override with
-# --output-xlsx <path>; pass --output-xlsx "" to skip the local file.
+# Default output xlsx lives under analysis/output/<combo>/ef_diagnostics_merged.xlsx.
+# Override with --output-xlsx <path>; pass --output-xlsx "" to skip the local file.
 OUTPUT_ROOT = Path(__file__).resolve().parent / 'output'
 DEFAULT_OUTPUT_XLSX_NAME = 'ef_diagnostics_merged.xlsx'
 
@@ -803,6 +802,21 @@ def _resolve_combo(combo_name: str) -> ComboSpec:
     return COMBINATIONS[combo_name]
 
 
+def _resolve_combo_sheet_inputs(spec: ComboSpec) -> list[tuple[str, str]]:
+    """Return ordered ``(sheet_id, title)`` pairs for a combo."""
+    if spec.sheets_in_order:
+        return list(spec.sheets_in_order)
+    if not spec.drive_folder_id or not spec.names_in_order:
+        raise ValueError(
+            'Combo must set either sheets_in_order or both drive_folder_id '
+            'and names_in_order.'
+        )
+    return _resolve_sheets_from_folder(
+        folder_id=spec.drive_folder_id,
+        titles_in_order=spec.names_in_order,
+    )
+
+
 @click.command(
     help=(
         'Merge multiple EF diagnostics Google Sheets into one comparison '
@@ -850,10 +864,7 @@ def main(
     output_sheet_id: str | None,
 ) -> None:
     spec = _resolve_combo(combo_name)
-    sheet_inputs = _resolve_sheets_from_folder(
-        folder_id=spec.drive_folder_id,
-        titles_in_order=spec.names_in_order,
-    )
+    sheet_inputs = _resolve_combo_sheet_inputs(spec)
     if output_xlsx is None:
         effective_xlsx_path: str | None = str(_default_output_xlsx_path(combo_name))
     else:

--- a/bedrock/utils/validation/analysis/ef_hist_panels.py
+++ b/bedrock/utils/validation/analysis/ef_hist_panels.py
@@ -1,0 +1,135 @@
+"""Clipped per-sector % diff histogram panels for diagnostics sheets.
+
+Release-progression grids, single-sheet renders, and A-matrix bundle histograms
+share this panel style: ±100% clip, 60 bins, zero line, n/median/p95 stats box.
+Distinct from ``plotting.percent_histogram`` (wider xlim, median reference lines).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from matplotlib.axes import Axes
+from matplotlib.ticker import PercentFormatter
+
+from bedrock.utils.validation.analysis.diagnostics_plots import _parse_pct
+
+EF_KIND_LABEL: dict[str, str] = {"N": "total EF (N)", "D": "direct EF (D)"}
+
+# Panel font sizes (multiplied by ``font_scale`` per panel).
+PANEL_TITLE_FONTSIZE = 20
+PANEL_AXIS_LABEL_FONTSIZE = 11
+PANEL_STATS_FONTSIZE = 10
+PANEL_TICK_LABEL_FONTSIZE = 10
+PANEL_SUPTITLE_FONTSIZE = 14
+
+HIST_FONT_SCALE = 2.0
+HIST_STATS_EXTRA_SCALE = 2.0
+HIST_PCT_CLIP = 100.0
+HIST_BINS = 60
+
+_KIND_SPEC: dict[str, dict[str, object]] = {
+    "N": {
+        "pct_col": "N_perc_diff",
+        "new_col": "N_new",
+        "old_col": "N_old_inflated",
+        "numeric_cols": ("N_new", "N_old", "N_old_inflated", "N_perc_diff"),
+    },
+    "D": {
+        "pct_col": "D_perc_diff",
+        "new_col": "D_new",
+        "old_col": "D_old_inflated",
+        "numeric_cols": ("D_new", "D_old", "D_old_inflated", "D_perc_diff"),
+    },
+}
+
+
+def _coerce_kind_columns(df: pd.DataFrame, ef_kind: str) -> pd.DataFrame:
+    """Coerce diagnostics tab columns, including percent-formatted cells."""
+    spec = _KIND_SPEC[ef_kind]
+    numeric_cols = spec["numeric_cols"]
+    assert isinstance(numeric_cols, tuple)
+    out = df.copy()
+    for col in numeric_cols:
+        if col not in out.columns:
+            continue
+        if col.endswith("_perc_diff"):
+            out[col] = out[col].map(_parse_pct)
+        else:
+            s = out[col].astype(str).str.strip()
+            is_pct = s.str.endswith("%")
+            cleaned = s.str.rstrip("%").str.replace(",", "", regex=False)
+            numeric = pd.to_numeric(cleaned, errors="coerce")
+            out[col] = numeric.mask(is_pct, numeric / 100)
+    return out
+
+
+def pct_values(df: pd.DataFrame, ef_kind: str) -> np.ndarray:
+    """Return per-sector pct diff as a fraction array (not percent)."""
+    spec = _KIND_SPEC[ef_kind]
+    pct_col = str(spec["pct_col"])
+    new_col = str(spec["new_col"])
+    old_col = str(spec["old_col"])
+    df = _coerce_kind_columns(df.copy(), ef_kind)
+    if pct_col in df.columns:
+        series = pd.Series(pd.to_numeric(df[pct_col], errors="coerce")).dropna()
+    elif new_col in df.columns and old_col in df.columns:
+        new = pd.Series(pd.to_numeric(df[new_col], errors="coerce"))
+        old = pd.Series(pd.to_numeric(df[old_col], errors="coerce"))
+        series = ((new - old) / old.abs()).dropna()
+    else:
+        raise KeyError(
+            f"Tab has neither {pct_col!r} nor ({new_col!r}, {old_col!r}); "
+            f"got columns: {list(df.columns)}"
+        )
+    arr = series.to_numpy(dtype=float)
+    return arr[np.isfinite(arr)]
+
+
+def draw_per_sector_pct_hist_panel(
+    ax: Axes,
+    pct_fraction: np.ndarray,
+    *,
+    title: str,
+    color: str,
+    font_scale: float = 1.0,
+    ylabel: str = "sector count",
+) -> None:
+    """Draw one clipped per-sector % diff histogram on ``ax``.
+
+    ``pct_fraction`` values are unit fractions (0.15 = 15%).
+    """
+    pct_percent = np.asarray(pct_fraction, dtype=float) * 100.0
+    finite = pct_percent[np.isfinite(pct_percent)]
+    if finite.size == 0:
+        ax.text(0.5, 0.5, "no data", transform=ax.transAxes, ha="center", va="center")
+        ax.set_title(title, fontsize=PANEL_TITLE_FONTSIZE * font_scale, color="black")
+        return
+    clipped = np.clip(finite, -HIST_PCT_CLIP, HIST_PCT_CLIP)
+    ax.hist(clipped, bins=HIST_BINS, color=color, alpha=0.85)
+    ax.axvline(0, color="k", lw=1.0)
+    ax.set_xlim(-HIST_PCT_CLIP, HIST_PCT_CLIP)
+    ax.xaxis.set_major_formatter(PercentFormatter(decimals=0))
+    ax.grid(True, ls=":", alpha=0.3)
+    ax.text(
+        0.04,
+        0.96,
+        (
+            f"n={len(finite)}\n"
+            f"median={np.median(finite):.1f}%\n"
+            f"p95(|·|)={np.quantile(np.abs(finite), 0.95):.1f}%"
+        ),
+        transform=ax.transAxes,
+        fontsize=PANEL_STATS_FONTSIZE * font_scale * HIST_STATS_EXTRA_SCALE,
+        va="top",
+        ha="left",
+        bbox=dict(
+            boxstyle="round,pad=0.3", facecolor="white", alpha=0.4, edgecolor="0.7"
+        ),
+    )
+    ax.set_title(title, fontsize=PANEL_TITLE_FONTSIZE * font_scale, color="black")
+    ax.set_xlabel(
+        "Percentage Diff (%)", fontsize=PANEL_AXIS_LABEL_FONTSIZE * font_scale
+    )
+    ax.set_ylabel(ylabel, fontsize=PANEL_AXIS_LABEL_FONTSIZE * font_scale)
+    ax.tick_params(axis="both", labelsize=PANEL_TICK_LABEL_FONTSIZE * font_scale)

--- a/bedrock/utils/validation/analysis/ef_progression.py
+++ b/bedrock/utils/validation/analysis/ef_progression.py
@@ -7,11 +7,11 @@ import logging
 import numpy as np
 import pandas as pd
 
-from bedrock.analysis.a_matrix_time_series.plot_v0_3_n_pct_hist import _pct_values
 from bedrock.utils.validation.analysis.diagnostics_plots import (
     _drop_old_only,
     _normalize_schema,
 )
+from bedrock.utils.validation.analysis.ef_hist_panels import pct_values
 from bedrock.utils.validation.analysis.fetch import load_tab
 
 logger = logging.getLogger(__name__)
@@ -44,7 +44,7 @@ def _tab_frame(sheet_id: str, ef_kind: str) -> pd.DataFrame:
 
 def pct_fractions_vs_v0(sheet_id: str, ef_kind: str) -> np.ndarray:
     """In-sheet producer % diff vs CEDA v0 (``N_perc_diff`` / ``D_perc_diff``)."""
-    return _pct_values(_tab_frame(sheet_id, ef_kind), ef_kind)
+    return pct_values(_tab_frame(sheet_id, ef_kind), ef_kind)
 
 
 def pct_fractions_useeio_purchaser_vs_v0(sheet_id: str) -> np.ndarray:
@@ -132,9 +132,7 @@ def pct_fractions_vs_baseline_sheet(
         and not _skip_inflation(config_name)
         and ref_2023_sheet_id is not None
     ):
-        ratio = _inflation_ratio_2023_to_2024(
-            step_sheet_id, ref_2023_sheet_id, ef_kind
-        )
+        ratio = _inflation_ratio_2023_to_2024(step_sheet_id, ref_2023_sheet_id, ef_kind)
         merged = merged.set_index("sector")
         merged["_base"] = merged["_base"] * ratio.reindex(merged.index)
         merged = merged.reset_index()

--- a/bedrock/utils/validation/analysis/ef_progression.py
+++ b/bedrock/utils/validation/analysis/ef_progression.py
@@ -1,0 +1,145 @@
+"""Percent-diff loaders for release-progression EF histogram panels."""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import pandas as pd
+
+from bedrock.analysis.a_matrix_time_series.plot_v0_3_n_pct_hist import _pct_values
+from bedrock.utils.validation.analysis.diagnostics_plots import (
+    _drop_old_only,
+    _normalize_schema,
+)
+from bedrock.utils.validation.analysis.fetch import load_tab
+
+logger = logging.getLogger(__name__)
+
+KIND_TAB = {"N": "N_and_diffs", "D": "D_and_diffs"}
+
+# IO@2023 / GHG@2024 — cross-year inflation does not apply (plot-ef-diagnostics).
+_SKIP_INFLATION_CONFIG_SUBSTRINGS = ("umd_2024_ghgia",)
+
+
+def _config_name(sheet_id: str) -> str:
+    cs = load_tab(sheet_id, "config_summary")
+    mapping = dict(zip(cs["config_field"], cs["value"], strict=False))
+    return str(mapping.get("config_name", "")).strip()
+
+
+def _model_base_year(sheet_id: str) -> int:
+    cs = load_tab(sheet_id, "config_summary")
+    mapping = dict(zip(cs["config_field"], cs["value"], strict=False))
+    for key in ("model_base_year", "usa_io_data_year"):
+        raw = mapping.get(key)
+        if raw is not None and str(raw).strip():
+            return int(float(raw))
+    return 0
+
+
+def _tab_frame(sheet_id: str, ef_kind: str) -> pd.DataFrame:
+    return _drop_old_only(_normalize_schema(load_tab(sheet_id, KIND_TAB[ef_kind])))
+
+
+def pct_fractions_vs_v0(sheet_id: str, ef_kind: str) -> np.ndarray:
+    """In-sheet producer % diff vs CEDA v0 (``N_perc_diff`` / ``D_perc_diff``)."""
+    return _pct_values(_tab_frame(sheet_id, ef_kind), ef_kind)
+
+
+def pct_fractions_useeio_purchaser_vs_v0(sheet_id: str) -> np.ndarray:
+    """Purchaser-price N % diff vs pinned USEEIO on a USEEIO-baseline sheet."""
+    df = _tab_frame(sheet_id, "N")
+    num = pd.to_numeric(df["N_new_purchaser"], errors="coerce")
+    den = pd.to_numeric(df["N_old_purchaser"], errors="coerce")
+    return ((num - den) / den.abs()).dropna().to_numpy(dtype=float)
+
+
+def _inflation_ratio_2023_to_2024(
+    step_sheet_id: str,
+    ref_2023_sheet_id: str,
+    ef_kind: str,
+) -> pd.Series:
+    """Per-sector ``N_old_inflated`` ratio (2024 sheet / 2023 sheet)."""
+    old_col = f"{ef_kind}_old_inflated"
+    step = _tab_frame(step_sheet_id, ef_kind).set_index("sector")
+    ref = _tab_frame(ref_2023_sheet_id, ef_kind).set_index("sector")
+    step_old = pd.to_numeric(step[old_col], errors="coerce")
+    ref_old = pd.to_numeric(ref[old_col], errors="coerce")
+    return step_old / ref_old
+
+
+def _skip_inflation(config_name: str) -> bool:
+    return any(s in config_name for s in _SKIP_INFLATION_CONFIG_SUBSTRINGS)
+
+
+def _absolute_ef_column(
+    sheet_id: str,
+    ef_kind: str,
+    *,
+    prefer_purchaser: bool = False,
+) -> str:
+    """Return the absolute EF column to read from a diagnostics tab."""
+    if prefer_purchaser and ef_kind == "N":
+        df = _tab_frame(sheet_id, ef_kind)
+        if "N_new_purchaser" in df.columns and df["N_new_purchaser"].notna().any():
+            return "N_new_purchaser"
+        logger.warning(
+            "Sheet %s has no usable N_new_purchaser; falling back to N_new.",
+            sheet_id,
+        )
+    return f"{ef_kind}_new"
+
+
+def pct_fractions_vs_baseline_sheet(
+    step_sheet_id: str,
+    baseline_sheet_id: str,
+    ef_kind: str,
+    *,
+    value_col: str | None = None,
+    ref_2023_sheet_id: str | None,
+    baseline_year: int,
+    prefer_purchaser: bool = False,
+) -> tuple[np.ndarray, bool]:
+    """Cross-sheet % diff vs another run's absolute EF column.
+
+    Returns ``(fractions, inflation_applied)``. When the step is a 2024-model
+    run and the baseline is 2023, the baseline EF is inflated per-sector using
+    ``{kind}_old_inflated`` on the step sheet vs ``ref_2023_sheet_id``.
+    """
+    step_col = value_col or _absolute_ef_column(
+        step_sheet_id, ef_kind, prefer_purchaser=prefer_purchaser
+    )
+    base_col = value_col or _absolute_ef_column(
+        baseline_sheet_id, ef_kind, prefer_purchaser=prefer_purchaser
+    )
+    cfg = _tab_frame(step_sheet_id, ef_kind)
+    base = _tab_frame(baseline_sheet_id, ef_kind)
+    cfg_vals = cfg[["sector", "sector_name", step_col]].copy()
+    cfg_vals[step_col] = pd.to_numeric(cfg_vals[step_col], errors="coerce")
+    base_vals = base[["sector", base_col]].copy()
+    base_vals[base_col] = pd.to_numeric(base_vals[base_col], errors="coerce")
+    base_vals = base_vals.rename(columns={base_col: "_base"})
+
+    merged = cfg_vals.merge(base_vals, on="sector", how="inner")
+    config_name = _config_name(step_sheet_id)
+    inflation_applied = False
+    step_year = _model_base_year(step_sheet_id)
+
+    if (
+        step_year == 2024
+        and baseline_year == 2023
+        and not _skip_inflation(config_name)
+        and ref_2023_sheet_id is not None
+    ):
+        ratio = _inflation_ratio_2023_to_2024(
+            step_sheet_id, ref_2023_sheet_id, ef_kind
+        )
+        merged = merged.set_index("sector")
+        merged["_base"] = merged["_base"] * ratio.reindex(merged.index)
+        merged = merged.reset_index()
+        inflation_applied = True
+
+    pdiff = (merged[step_col] - merged["_base"]) / merged["_base"].abs()
+    arr = pdiff.dropna().to_numpy(dtype=float)
+    return arr[np.isfinite(arr)], inflation_applied

--- a/bedrock/utils/validation/analysis/release_v0_3_progression.py
+++ b/bedrock/utils/validation/analysis/release_v0_3_progression.py
@@ -1,0 +1,251 @@
+"""v0.3 release-deck diagnostics progression — shared sheet registry.
+
+Sheet IDs and ``config_name`` values for the v0.3 release-deck progression.
+Used by ``bedrock.analysis.v0_3.plot_ef_release_v0_3`` and the
+``v0.2_to_v0.3_*`` combine combos in ``combinations.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+PINNED_USEEIO_BASELINE = 'pinned_useeio_baseline'
+# ``config_summary`` on the v0.2 FINAL diagnostics sheets records this stem.
+# The yaml was renamed to ``2025_usa_cornerstone_v0_2`` after those runs;
+# keep this literal for merge keys and net-diff column lookup.
+V02_FULL_MODEL = '2025_usa_cornerstone_full_model'
+
+# One-flag sensitivities on the v0.2 full-model footing: net-diff vs v0.2 FINAL,
+# not the prior progression step.
+ATOMIC_V02_FOOTING_CONFIGS: frozenset[str] = frozenset(
+    {
+        '2025_usa_cornerstone_full_model_v0_3_update_inflation_factors',
+        '2025_usa_cornerstone_full_model_v0_3_A_ceda_fallback_approach',
+        '2025_usa_cornerstone_full_model_v0_3_ghgi_mecs',
+    }
+)
+
+
+@dataclass(frozen=True)
+class ProgressionSheet:
+    step_label: str
+    sheet_id: str
+    config_name: str
+    sheet_title: str
+
+
+V0_BASELINE_CEDA = ProgressionSheet(
+    step_label='v0 baseline',
+    sheet_id='1lCh_LsNbylyLSfwQMqiSh2_oh5qtihXF800om5T02Lc',
+    config_name='v8_ceda_2025_usa',
+    sheet_title='[2026-03-26 v0 baseline] EF diagnostics',
+)
+
+V02_FINAL_CEDA = ProgressionSheet(
+    step_label='FINAL v0.2',
+    sheet_id='1h_Ra-jPkcivuqiQahAIex4PoZXTaYijRFKFzpmKFiXU',
+    config_name='2025_usa_cornerstone_full_model',
+    sheet_title=(
+        '[2026-06-18, bedrock repo, 2023, CEDA based, v0.2 / FINAL v0.2] EFs diagnostics'
+    ),
+)
+
+V02_FINAL_USEEIO = ProgressionSheet(
+    step_label='FINAL v0.2',
+    sheet_id='153b904T8qq9qBt4qELvDLNE7K6T12kOyXchM9maABmE',
+    config_name='2025_usa_cornerstone_full_model',
+    sheet_title=(
+        '[2026-06-18, bedrock repo, 2023, USEEIO based, v0.2 / FINAL v0.2] EFs diagnostics'
+    ),
+)
+
+V03_CEDA_STEPS: tuple[ProgressionSheet, ...] = (
+    ProgressionSheet(
+        step_label='Update inflation factors',
+        sheet_id='1Wi6q8dr6u1sP0ZqaeuW1SYgfKgVsOlatJQDFxduQ6HU',
+        config_name='2025_usa_cornerstone_full_model_v0_3_update_inflation_factors',
+        sheet_title=(
+            '[2026-06-18, bedrock repo, 2023, CEDA based, '
+            'v0.3 / Update inflation factors] EFs diagnostics'
+        ),
+    ),
+    ProgressionSheet(
+        step_label='CEDA A approach w/ price adj',
+        sheet_id='1Ywx6eyMnCTvHPG92uCsmH159A6BZA50GYWaZzrJn6f8',
+        config_name='2025_usa_cornerstone_full_model_v0_3_A_ceda_fallback_approach',
+        sheet_title=(
+            '[2026-06-18, bedrock repo, 2023, CEDA based, '
+            'v0.3 / CEDA A approach w/ price adj] EFs diagnostics'
+        ),
+    ),
+    ProgressionSheet(
+        step_label='MECS adjustment',
+        sheet_id='1hbS5sVk3oHTkVDp-z5v2j-pFt81uRKFFzWEKONIBG5E',
+        config_name='2025_usa_cornerstone_full_model_v0_3_ghgi_mecs',
+        sheet_title=(
+            '[2026-06-29, bedrock, v0.3 MECS on v0.2 footing — CEDA based] '
+            'EFs diagnostics'
+        ),
+    ),
+    ProgressionSheet(
+        step_label='Switch to 2023 UMD data',
+        sheet_id='14OxuVk_BXKUesQ6snw_s3oiQANl-uNBS7dFQxzBXrLc',
+        config_name='2025_usa_cornerstone_full_model_v0_3_umd_2023_ghgia',
+        sheet_title=(
+            '[2026-06-23, bedrock repo, 2023, CEDA based, '
+            'v0.3 / Switch to 2023 UMD data] EFs diagnostics'
+        ),
+    ),
+    ProgressionSheet(
+        step_label='Switch to 2024 UMD data',
+        sheet_id='1BjOcH1Oo3oB7hfKL87VqM93_QEKaKSeOEoN0zj0XjXU',
+        config_name='2025_usa_cornerstone_full_model_v0_3_umd_2024_ghgia',
+        sheet_title=(
+            '[2026-06-24, bedrock repo, 2024, CEDA based, '
+            'v0.3 / Update to 2024 UMD data] EFs diagnostics'
+        ),
+    ),
+    ProgressionSheet(
+        step_label='2024 US IO+GHG data',
+        sheet_id='1pfneC_RzW4mmVkGyitVnDnahAV0rQ9mAhhIsBTQb1EE',
+        config_name='2025_usa_cornerstone_full_model_v0_3_2024_io_ghg',
+        sheet_title=(
+            '[2026-06-24, bedrock repo, 2024, CEDA based, '
+            'v0.3 / 2024 US IO+GHG data] EFs diagnostics'
+        ),
+    ),
+    ProgressionSheet(
+        step_label='FINAL v0.3',
+        sheet_id='1mibFzzRyZShMS8MgDqtdmMSqvoos9JT7yWNo-wH6PTo',
+        config_name='2025_usa_cornerstone_v0_3',
+        sheet_title=(
+            '[2026-06-24, bedrock repo, 2024, CEDA based, '
+            'v0.3 / FINAL v0.3] EFs diagnostics'
+        ),
+    ),
+)
+
+V03_USEEIO_STEPS: tuple[ProgressionSheet, ...] = (
+    ProgressionSheet(
+        step_label='Update inflation factors',
+        sheet_id='1VG5WsspWLpsbMEvoDY8-7qEi8MYQ-y1Xu7M4x9-abMw',
+        config_name='2025_usa_cornerstone_full_model_v0_3_update_inflation_factors',
+        sheet_title=(
+            '[2026-06-18, bedrock repo, 2023, USEEIO based, '
+            'v0.3 / Update inflation factors] EFs diagnostics'
+        ),
+    ),
+    ProgressionSheet(
+        step_label='CEDA A approach w/ price adj',
+        sheet_id='1QZBKKHqaZm84-Kn1Fz0gpEdRTNCqnw0YJ8TQAsDn87o',
+        config_name='2025_usa_cornerstone_full_model_v0_3_A_ceda_fallback_approach',
+        sheet_title=(
+            '[2026-06-18, bedrock repo, 2023, USEEIO based, '
+            'v0.3 / CEDA A approach w/ price adj] EFs diagnostics'
+        ),
+    ),
+    ProgressionSheet(
+        step_label='MECS adjustment',
+        sheet_id='1bzOlu1hmhPXa5D-uUvBe6fT8ompHIhtC9D-BcKQwmb4',
+        config_name='2025_usa_cornerstone_full_model_v0_3_ghgi_mecs',
+        sheet_title=(
+            '[2026-06-29, bedrock, v0.3 MECS on v0.2 footing — USEEIO based] '
+            'EFs diagnostics'
+        ),
+    ),
+    ProgressionSheet(
+        step_label='Switch to 2023 UMD data',
+        sheet_id='1rzJEZuDe-GK_C5juKtIlrkYyQpnU0S9KUCBzMl9FT4M',
+        config_name='2025_usa_cornerstone_full_model_v0_3_umd_2023_ghgia',
+        sheet_title=(
+            '[2026-06-23, bedrock repo, 2023, USEEIO based, '
+            'v0.3 / Switch to 2023 UMD data] EFs diagnostics'
+        ),
+    ),
+    ProgressionSheet(
+        step_label='Switch to 2024 UMD data',
+        sheet_id='1YcctdXvoDPQLBnYyNZqSdgxqvLL47fv5dDCTjLkE-JY',
+        config_name='2025_usa_cornerstone_full_model_v0_3_umd_2024_ghgia',
+        sheet_title=(
+            '[2026-06-24, bedrock repo, 2024, USEEIO based, '
+            'v0.3 / Update to 2024 UMD data] EFs diagnostics'
+        ),
+    ),
+    ProgressionSheet(
+        step_label='2024 US IO+GHG data',
+        sheet_id='1lqwoSVuDcMkSp56p1U8uQBkNuIVgDYJiy8Pog8IU-Zg',
+        config_name='2025_usa_cornerstone_full_model_v0_3_2024_io_ghg',
+        sheet_title=(
+            '[2026-06-24, bedrock repo, 2024, USEEIO based, '
+            'v0.3 / 2024 US IO+GHG data] EFs diagnostics'
+        ),
+    ),
+    ProgressionSheet(
+        step_label='FINAL v0.3',
+        sheet_id='1FJYZHmQVN9D0JcUq7_hkqrxBU_h_K_xUPFQGDvf7gII',
+        config_name='2025_usa_cornerstone_v0_3',
+        sheet_title=(
+            '[2026-06-24, bedrock repo, 2024, USEEIO based, '
+            'v0.3 / FINAL v0.3] EFs diagnostics'
+        ),
+    ),
+)
+
+CEDA_V02_TO_V03_SHEETS: tuple[ProgressionSheet, ...] = (
+    V0_BASELINE_CEDA,
+    V02_FINAL_CEDA,
+) + V03_CEDA_STEPS
+
+USEEIO_V02_TO_V03_SHEETS: tuple[ProgressionSheet, ...] = (
+    V02_FINAL_USEEIO,
+) + V03_USEEIO_STEPS
+
+
+def sheets_in_order(
+    sheets: tuple[ProgressionSheet, ...],
+) -> tuple[tuple[str, str], ...]:
+    """``(sheet_id, sheet_title)`` pairs for ``ComboSpec.sheets_in_order``."""
+    return tuple((s.sheet_id, s.sheet_title) for s in sheets)
+
+
+def _apply_atomic_v02_footing_overrides(mapping: dict[str, str]) -> dict[str, str]:
+    """Point atomic v0.2-footing configs at ``V02_FULL_MODEL`` for net-diff."""
+    out = dict(mapping)
+    for cfg in ATOMIC_V02_FOOTING_CONFIGS:
+        if cfg in out:
+            out[cfg] = V02_FULL_MODEL
+    return out
+
+
+def ceda_stepwise_target_mapping(
+    sheets: tuple[ProgressionSheet, ...],
+) -> dict[str, str]:
+    """Each step's net-diff subtracts the prior step (first step vs itself).
+
+    Atomic v0.2-footing configs in ``ATOMIC_V02_FOOTING_CONFIGS`` net-diff
+    against ``2025_usa_cornerstone_full_model`` instead.
+    """
+    config_names = [s.config_name for s in sheets]
+    if not config_names:
+        return {}
+    mapping = {config_names[0]: config_names[0]}
+    for idx in range(1, len(config_names)):
+        mapping[config_names[idx]] = config_names[idx - 1]
+    return _apply_atomic_v02_footing_overrides(mapping)
+
+
+def useeio_stepwise_target_mapping(
+    sheets: tuple[ProgressionSheet, ...],
+) -> dict[str, str]:
+    """Chain net-diffs; anchor v0.2 FINAL vs ``pinned_useeio_baseline``.
+
+    Atomic v0.2-footing configs in ``ATOMIC_V02_FOOTING_CONFIGS`` net-diff
+    against ``2025_usa_cornerstone_full_model`` instead of the prior step.
+    """
+    config_names = [s.config_name for s in sheets]
+    if not config_names:
+        return {}
+    mapping: dict[str, str] = {config_names[0]: PINNED_USEEIO_BASELINE}
+    for idx in range(1, len(config_names)):
+        mapping[config_names[idx]] = config_names[idx - 1]
+    return _apply_atomic_v02_footing_overrides(mapping)


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

Adds tooling to merge, plot, and dispatch the v0.3 release EF diagnostics progression (CEDA and USEEIO baselines), optional progression panels recomputed vs FINAL v0.2, and shared diagnostics-sheet histogram primitives under `utils/validation/analysis`.

**Outputs saved in Drive [here](https://drive.google.com/drive/folders/1u3J2bSBfUh2SEyHCFzVy0UJfAsHtBzPH).**

**Sheet registry** — `release_v0_3_progression.py` lists Drive sheet IDs, titles, and `config_name` values for v0.3 release steps and FINAL v0.2 anchors. v0.2 FINAL sheets record `2025_usa_cornerstone_full_model` in `config_summary`.

**Combine** — `combine_ef_diagnostics` accepts explicit `(sheet_id, title)` pairs via `ComboSpec.sheets_in_order`. Combos:

- `v0.2_to_v0.3_ceda` — v0 baseline → FINAL v0.2 → seven v0.3 steps
- `v0.2_to_v0.3_useeio` — FINAL v0.2 → seven v0.3 steps (no purchaser step)

Net-diff rules for `v0.2_to_v0.3_*`:

- Stepwise chain for UMD / IO / FINAL columns
- Atomic v0.2-footing sensitivities (inflation, A/price, MECS on `ghgi_mecs` sheets) subtract 2025_usa_cornerstone_full_model`, not the prior step
- USEEIO v0.2 FINAL anchors vs `pinned_useeio_baseline`

**Plot / dispatch** — `bedrock/analysis/v0_3/` holds release progression histograms, FINAL v0.2 vs v0.3 overlays, BLy charts, and dispatch for remaining release steps (MECS through FINAL).

`--compare-to v0` (default) uses each sheet's in-tab diff vs CEDA v0 / USEEIO. `--compare-to v0.2` recomputes each v0.3 step vs FINAL v0.2 with 2023→2024 inflation on 2024-model steps (`[+1yr infl]` panel suffix; skipped for `umd_2024_ghgia`). Loaders live in `ef_progression.py`. Registries stay in `utils/validation` so combine presets do not depend on `analysis/`.

**Shared histogram panels** — `ef_hist_panels.py` centralizes `pct_values` and `draw_per_sector_pct_hist_panel` (clipped ±100%, 60 bins, n/median/p95 stats box). Release progression grids, `plot_v0_3_n_pct_hist`, and A-matrix bundle histograms import from validation instead of crossing `utils` → `analysis`. Distinct from `plotting.percent_histogram` (wider xlim, median reference lines).

Docs: `bedrock/analysis/v0_3/README.md`, `bedrock/utils/validation/analysis/README.md`, and `.claude/skills/plot-ef-diagnostics/SKILL.md`.

## Testing

Combine (into `bedrock/analysis/v0_3/output/release_v0_3/`):

```powershell
uv run python -m bedrock.utils.validation.analysis.combine_ef_diagnostics `
    --combo v0.2_to_v0.3_ceda `
    --output-xlsx bedrock/analysis/v0_3/output/release_v0_3/ef_diagnostics_merged_v0_2_to_v0_3_ceda.xlsx

uv run python -m bedrock.utils.validation.analysis.combine_ef_diagnostics `
    --combo v0.2_to_v0.3_useeio `
    --output-xlsx bedrock/analysis/v0_3/output/release_v0_3/ef_diagnostics_merged_v0_2_to_v0_3_useeio.xlsx
```

Plot:

```powershell
uv run python -m bedrock.analysis.v0_3.plot_ef_release_v0_3
uv run python -m bedrock.analysis.v0_3.plot_ef_release_v0_3 --compare-to v0.2
```

Dispatch dry-run:

```powershell
uv run python -m bedrock.analysis.v0_3.dispatch_ef_release_v0_3 --dry-run
```

Manual checks:

- Merged `v0.2_to_v0.3_*` workbooks: CEDA nine config columns; USEEIO eight (purchaser omitted); atomic steps net-diff vs `2025_usa_cornerstone_full_model`
- Progression PNGs: `progression_v03_{ceda,useeio}_{N,D}.png` and `*_vs_v02.png` under `output/release_v0_3/`


