### PR TITLE
feat(validation): add wholesale v0-v0.3 USEEIO group diagnostics

### DIFF
--- a/bedrock/analysis/v0_3/README.md
+++ b/bedrock/analysis/v0_3/README.md
@@ -5,10 +5,11 @@ progression. They read or dispatch Google Sheets produced by
 `bedrock.utils.validation.generate_diagnostics` and reuse shared loaders in
 `bedrock.utils.validation.analysis` (`fetch`, `plotting`, `bly_plots`, etc.).
 
-The sheet registry (`release_v0_3_progression.py`) lives in
-`bedrock.utils.validation.analysis` so combine combos stay self-contained.
+The sheet registries (`release_v0_3_progression.py`,
+`release_v0_v03_useeio_groups.py`) live in `bedrock.utils.validation.analysis`
+so combine combos stay self-contained.
 
-Plot, dispatch, and merged workbooks all land in `output/release_v0_3/`
+Plot outputs land in `output/release_v0_3/` or `output/release_v0_v03_groups/`
 (gitignored).
 
 ## Scripts
@@ -16,6 +17,7 @@ Plot, dispatch, and merged workbooks all land in `output/release_v0_3/`
 | Script | Purpose |
 |--------|---------|
 | `plot_ef_release_v0_3.py` | Release progression histograms, FINAL v0.2 vs v0.3 overlays, and BLy charts from registered sheets. |
+| `plot_ef_v0_v03_useeio_groups.py` | Stacked G1→G2→G3 wholesale USEEIO progression (3 marginal panels + FINAL cumulative overlays). |
 | `dispatch_ef_release_v0_3.py` | Dispatch v0.3 release steps (MECS through FINAL) to the EF time-series Drive folder; appends to `output/release_v0_3/ef_run_index_release_v0_3.csv`. |
 
 ## Plot
@@ -30,6 +32,12 @@ Pass `--skip-progression`, `--skip-overlay`, or `--skip-bly` to omit figure grou
 `--compare-to v0.2` recomputes each v0.3 step vs FINAL v0.2 (2024 steps get
 `[+1yr infl]` on the panel title where applicable).
 
+Wholesale v0→v0.3 USEEIO groups (stacked G1→G2→G3 marginals):
+
+```powershell
+uv run python -m bedrock.analysis.v0_3.plot_ef_v0_v03_useeio_groups
+```
+
 ## Dispatch
 
 ```powershell
@@ -41,8 +49,9 @@ uv run python -m bedrock.analysis.v0_3.dispatch_ef_release_v0_3 `
 ## Combine
 
 Merged workbooks use combos in `bedrock.utils.validation.analysis.combinations`
-(`v0.2_to_v0.3_ceda`, `v0.2_to_v0.3_useeio`), which read sheet IDs from
-`release_v0_3_progression.py` in that package:
+(`v0.2_to_v0.3_ceda`, `v0.2_to_v0.3_useeio`, `v0_to_v03_useeio_groups`). Example
+filenames end with the baseline tag (`_ceda`, `_useeio`) so both v0.2→v0.3
+workbooks can sit in one folder:
 
 ```powershell
 uv run python -m bedrock.utils.validation.analysis.combine_ef_diagnostics `
@@ -52,6 +61,10 @@ uv run python -m bedrock.utils.validation.analysis.combine_ef_diagnostics `
 uv run python -m bedrock.utils.validation.analysis.combine_ef_diagnostics `
     --combo v0.2_to_v0.3_useeio `
     --output-xlsx bedrock/analysis/v0_3/output/release_v0_3/ef_diagnostics_merged_v0_2_to_v0_3_useeio.xlsx
+
+uv run python -m bedrock.utils.validation.analysis.combine_ef_diagnostics `
+    --combo v0_to_v03_useeio_groups `
+    --output-xlsx bedrock/analysis/v0_3/output/release_v0_v03_groups/ef_diagnostics_merged_v0_to_v03_useeio_groups_useeio.xlsx
 ```
 
 Re-run with `--refresh` after sheet tab content changes.

--- a/bedrock/analysis/v0_3/plot_ef_v0_v03_useeio_groups.py
+++ b/bedrock/analysis/v0_3/plot_ef_v0_v03_useeio_groups.py
@@ -1,0 +1,229 @@
+"""Stacked G1→G2→G3 EF histograms for wholesale v0→v0.3 USEEIO progression.
+
+Three marginal panels (each vs the prior group endpoint) plus an optional
+FINAL vs pinned USEEIO overlay. Uses existing diagnostics Sheets only.
+
+Usage:
+    uv run python -m bedrock.analysis.v0_3.plot_ef_v0_v03_useeio_groups
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+import click
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from bedrock.utils.validation.analysis.ef_hist_panels import (
+    EF_KIND_LABEL,
+    draw_per_sector_pct_hist_panel,
+)
+from bedrock.utils.validation.analysis.ef_progression import (
+    pct_fractions_stacked_group,
+    pct_fractions_useeio_purchaser_vs_v0,
+    pct_fractions_vs_v0,
+)
+from bedrock.utils.validation.analysis.plotting import (
+    overlay_pct_diff_histogram,
+    save_and_close,
+    setup_mpl,
+)
+from bedrock.utils.validation.analysis.release_v0_3_progression import ProgressionSheet
+from bedrock.utils.validation.analysis.release_v0_v03_useeio_groups import (
+    FINAL_V03_USEEIO,
+    REF_2023_FOR_INFLATION,
+    V0_V03_USEEIO_STACK_SHEETS,
+)
+
+logger = logging.getLogger(__name__)
+
+OUT_DIR = Path(__file__).resolve().parent / "output" / "release_v0_v03_groups"
+
+USEEIO_BAR = "#ff7f0e"
+CEDA_BAR = "#1f77b4"
+PANEL_FONT_SCALE = 0.9
+
+
+@dataclass(frozen=True)
+class PanelLoad:
+    fractions: np.ndarray
+    inflation_applied: bool = False
+
+
+def _panel_title(step_label: str, *, inflation_applied: bool) -> str:
+    if inflation_applied:
+        return f"{step_label} [+1yr infl]"
+    return step_label
+
+
+def _prior_sheet_id(steps: Sequence[ProgressionSheet], index: int) -> str | None:
+    if index == 0:
+        return None
+    return steps[index - 1].sheet_id
+
+
+def _loader_stacked(
+    steps: Sequence[ProgressionSheet],
+    ef_kind: str,
+    *,
+    prefer_purchaser: bool,
+    ref_2023_sheet_id: str | None,
+) -> Callable[[int], PanelLoad]:
+    def load(index: int) -> PanelLoad:
+        step = steps[index]
+        prior = _prior_sheet_id(steps, index)
+        fractions, inflation_applied = pct_fractions_stacked_group(
+            step.sheet_id,
+            prior,
+            ef_kind,
+            ref_2023_sheet_id=ref_2023_sheet_id,
+            prefer_purchaser=prefer_purchaser,
+        )
+        return PanelLoad(fractions, inflation_applied=inflation_applied)
+
+    return load
+
+
+def _plot_group_grid(
+    steps: Sequence[ProgressionSheet],
+    *,
+    group_title: str,
+    out_path: Path,
+    bar_color: str,
+    panel_loader: Callable[[int], PanelLoad],
+) -> None:
+    n = len(steps)
+    cols = min(3, n)
+    rows = math.ceil(n / cols)
+    fig, axes = plt.subplots(
+        rows, cols, figsize=(5.5 * cols, 4.8 * rows), squeeze=False
+    )
+    flat = list(axes.flat)
+    ymax = 0.0
+    for i, step in enumerate(steps):
+        ax = flat[i]
+        loaded = panel_loader(i)
+        title = _panel_title(
+            step.step_label, inflation_applied=loaded.inflation_applied
+        )
+        draw_per_sector_pct_hist_panel(
+            ax,
+            loaded.fractions,
+            title=title,
+            color=bar_color,
+            font_scale=PANEL_FONT_SCALE,
+        )
+        ymax = max(ymax, ax.get_ylim()[1])
+    for i in range(n):
+        flat[i].set_ylim(0, ymax)
+    for ax in flat[n:]:
+        ax.axis("off")
+    fig.suptitle(group_title, fontsize=14, y=1.02)
+    fig.tight_layout()
+    save_and_close(fig, out_path)
+    print(f"Wrote: {out_path}")
+
+
+def _plot_final_useeio_overlay(out_dir: Path) -> None:
+    series_by_label = {
+        "FINAL v0.3": pd.Series(
+            pct_fractions_useeio_purchaser_vs_v0(FINAL_V03_USEEIO.sheet_id) * 100.0
+        ),
+    }
+    fig, ax = plt.subplots(figsize=(11, 6.5))
+    overlay_pct_diff_histogram(
+        ax,
+        series_by_label,
+        xlabel="EF change vs USEEIO baseline (purchaser, %)",
+        title=(
+            f"{EF_KIND_LABEL['N']} per-sector % diff vs pinned USEEIO — "
+            "shipped v0.3 (cumulative)"
+        ),
+    )
+    fig.tight_layout()
+    out = out_dir / "overlay_final_useeio_N_cumulative.png"
+    save_and_close(fig, out)
+    print(f"Wrote: {out}")
+
+
+def _plot_final_ceda_overlay(out_dir: Path) -> None:
+    for ef_kind in ("N", "D"):
+        series_by_label = {
+            "FINAL v0.3": pd.Series(
+                pct_fractions_vs_v0(FINAL_V03_USEEIO.sheet_id, ef_kind) * 100.0
+            ),
+        }
+        fig, ax = plt.subplots(figsize=(11, 6.5))
+        kind_label = EF_KIND_LABEL[ef_kind]
+        overlay_pct_diff_histogram(
+            ax,
+            series_by_label,
+            xlabel="EF change vs CEDA v0 baseline (%)",
+            title=f"{kind_label} per-sector % diff vs CEDA v0 — shipped v0.3 (cumulative)",
+        )
+        fig.tight_layout()
+        out = out_dir / f"overlay_final_ceda_{ef_kind}_cumulative.png"
+        save_and_close(fig, out)
+        print(f"Wrote: {out}")
+
+
+@click.command()
+@click.option(
+    "--out-dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=OUT_DIR,
+    show_default=True,
+)
+@click.option("--skip-overlay", is_flag=True)
+def main(out_dir: Path, skip_overlay: bool) -> None:
+    setup_mpl(font_size=13)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    steps = V0_V03_USEEIO_STACK_SHEETS
+
+    _plot_group_grid(
+        steps,
+        group_title=(
+            "[v0→v0.3 USEEIO · stacked groups] per-sector N % diff "
+            "(purchaser / pinned USEEIO)"
+        ),
+        out_path=out_dir / "progression_v0_v03_useeio_groups_N.png",
+        bar_color=USEEIO_BAR,
+        panel_loader=_loader_stacked(
+            steps,
+            "N",
+            prefer_purchaser=True,
+            ref_2023_sheet_id=REF_2023_FOR_INFLATION,
+        ),
+    )
+
+    for ef_kind in ("N", "D"):
+        _plot_group_grid(
+            steps,
+            group_title=(
+                f"[v0→v0.3 USEEIO · stacked groups] per-sector {ef_kind} % diff "
+                "(producer / CEDA v0)"
+            ),
+            out_path=out_dir / f"progression_v0_v03_useeio_groups_{ef_kind}.png",
+            bar_color=CEDA_BAR,
+            panel_loader=_loader_stacked(
+                steps,
+                ef_kind,
+                prefer_purchaser=False,
+                ref_2023_sheet_id=REF_2023_FOR_INFLATION,
+            ),
+        )
+
+    if not skip_overlay:
+        _plot_final_useeio_overlay(out_dir)
+        _plot_final_ceda_overlay(out_dir)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    main()

--- a/bedrock/utils/validation/analysis/README.md
+++ b/bedrock/utils/validation/analysis/README.md
@@ -66,9 +66,11 @@ back, caches them locally as parquet, and renders analysis figures.
   `N_old_inflated`) and pin metadata. Per-config N columns prefer
   `N_new_purchaser`, then `N_new_inflated`, then `N_new`. This lets a
   USEEIO-rebuild combo's net-diff show `run.D_new − pinned_baseline`
-  instead of the default self vs self. Combos that don't opt in (e.g.
-  the v0.2 release-vs-release setup) keep their original output schema
-  unchanged.
+  instead of the default self vs self. For `totals_net_diff`, targets of
+  `pinned_useeio_baseline` use that config's `BLy_new - BLy_old (MtCO2e)`
+  from the `totals` tab (`BLy_old` is the pinned Excel baseline). Combos
+  that don't opt in (e.g. the v0.2 release-vs-release setup) keep their
+  original output schema unchanged.
 - `combinations.py` — registered diagnostics combinations (one `ComboSpec`
   per named multi-run comparison). Holds the Drive folder ID, ordered input
   Sheet titles, and per-`config_name` target mapping. The destination Sheet
@@ -80,6 +82,9 @@ back, caches them locally as parquet, and renders analysis figures.
   `config_name` `2025_usa_cornerstone_full_model` (renamed to
   `2025_usa_cornerstone_v0_2` in configs after dispatch). Atomic v0.3 steps
   (inflation, A/price, MECS) net-diff against that column, not stepwise.
+- `release_v0_v03_useeio_groups.py` — wholesale v0→v0.3 USEEIO group
+  endpoints (G1 schema/GHG, G2 methods, G3 data, FINAL). Consumed by combo
+  `v0_to_v03_useeio_groups` and `bedrock.analysis.v0_3.plot_ef_v0_v03_useeio_groups`.
 
 ## Running
 
@@ -149,6 +154,10 @@ uv run python -m bedrock.utils.validation.analysis.combine_ef_diagnostics \
 uv run python -m bedrock.utils.validation.analysis.combine_ef_diagnostics \
     --combo v0.2_to_v0.3_useeio \
     --output-xlsx bedrock/analysis/v0_3/output/release_v0_3/ef_diagnostics_merged_v0_2_to_v0_3_useeio.xlsx
+
+uv run python -m bedrock.utils.validation.analysis.combine_ef_diagnostics \
+    --combo v0_to_v03_useeio_groups \
+    --output-xlsx bedrock/analysis/v0_3/output/release_v0_v03_groups/ef_diagnostics_merged_v0_to_v03_useeio_groups_useeio.xlsx
 ```
 
 Re-run with `--refresh` after sheet tabs change.

--- a/bedrock/utils/validation/analysis/combinations.py
+++ b/bedrock/utils/validation/analysis/combinations.py
@@ -27,6 +27,10 @@ from bedrock.utils.validation.analysis.release_v0_3_progression import (
     sheets_in_order,
     useeio_stepwise_target_mapping,
 )
+from bedrock.utils.validation.analysis.release_v0_v03_useeio_groups import (
+    V0_V03_USEEIO_GROUP_SHEETS,
+    useeio_group_stack_target_mapping,
+)
 
 
 @dataclass(frozen=True)
@@ -148,5 +152,12 @@ COMBINATIONS: dict[str, ComboSpec] = {
         names_in_order=[],
         target_mapping=useeio_stepwise_target_mapping(USEEIO_V02_TO_V03_SHEETS),
         sheets_in_order=sheets_in_order(USEEIO_V02_TO_V03_SHEETS),
+    ),
+    # Wholesale v0→v0.3 USEEIO: three stacked group endpoints + FINAL.
+    'v0_to_v03_useeio_groups': ComboSpec(
+        drive_folder_id='',
+        names_in_order=[],
+        target_mapping=useeio_group_stack_target_mapping(V0_V03_USEEIO_GROUP_SHEETS),
+        sheets_in_order=sheets_in_order(V0_V03_USEEIO_GROUP_SHEETS),
     ),
 }

--- a/bedrock/utils/validation/analysis/combine_ef_diagnostics.py
+++ b/bedrock/utils/validation/analysis/combine_ef_diagnostics.py
@@ -49,7 +49,9 @@ Output tabs (identical schema to the legacy xlsx flow):
   5) ``totals_net_diff`` -- net differences against the target mapping,
      on the BLy column appropriate to the source tab
      (``BLy (MtCO2e)`` for release-vs-snapshot, ``BLy_new (MtCO2e)``
-     for USEEIO mode).
+     for USEEIO mode). When the target is ``pinned_useeio_baseline``, the
+     row uses ``BLy_new - BLy_old (MtCO2e)`` from that config's totals row
+     (``BLy_old`` is the pinned USEEIO baseline in USEEIO mode).
   6) ``config_summary_merged`` -- all config fields across runs, with a
      first row labelled ``filename`` holding each input Sheet's title.
      When the combo opts into ``pinned_useeio_baseline`` (USEEIO mode),
@@ -705,19 +707,38 @@ def merge_sheets(
                 )
 
             target_cfg = target_mapping[cfg_name]
-            # ``pinned_useeio_baseline`` is allowed in target_mapping for D/N
-            # tabs but isn't a config column in the totals data. For USEEIO
-            # combos this is fine: the same diff is already visible directly
-            # in the totals row's ``BLy_new - BLy_old (MtCO2e)`` column
-            # (since BLy_old IS the pinned baseline in USEEIO mode).
             if target_cfg == PINNED_USEEIO_BASELINE_COLUMN:
-                logger.info(
-                    'Skipping totals_net_diff for %r (targets %r); see the '
-                    'BLy_new - BLy_old (MtCO2e) column of the totals row for '
-                    'the same comparison.',
-                    cfg_name,
-                    target_cfg,
+                if not any_useeio:
+                    logger.info(
+                        'Skipping totals_net_diff for %r (targets %r); '
+                        'pinned USEEIO baseline totals apply only in USEEIO mode.',
+                        cfg_name,
+                        target_cfg,
+                    )
+                    continue
+                src = totals_merged[totals_merged['config_name'] == cfg_name].copy()
+                if src.empty:
+                    raise KeyError(
+                        f'Config {cfg_name!r} was not found in totals_merged '
+                        'config_name values.'
+                    )
+                bly_diff_col = 'BLy_new - BLy_old (MtCO2e)'
+                if bly_diff_col not in src.columns:
+                    raise KeyError(
+                        f'Expected column {bly_diff_col!r} in totals data for '
+                        f'{cfg_name!r} (vs {target_cfg!r}). Got: {list(src.columns)}'
+                    )
+                out = pd.DataFrame(
+                    {
+                        'config_name': cfg_name,
+                        'target_config_name': target_cfg,
+                        'row_order': src['row_order'],
+                        totals_value_col: pd.to_numeric(
+                            src[bly_diff_col], errors='coerce'
+                        ),
+                    }
                 )
+                totals_net_frames.append(out)
                 continue
 
             src = totals_merged[totals_merged['config_name'] == cfg_name].copy()

--- a/bedrock/utils/validation/analysis/ef_progression.py
+++ b/bedrock/utils/validation/analysis/ef_progression.py
@@ -50,9 +50,15 @@ def pct_fractions_vs_v0(sheet_id: str, ef_kind: str) -> np.ndarray:
 def pct_fractions_useeio_purchaser_vs_v0(sheet_id: str) -> np.ndarray:
     """Purchaser-price N % diff vs pinned USEEIO on a USEEIO-baseline sheet."""
     df = _tab_frame(sheet_id, "N")
-    num = pd.to_numeric(df["N_new_purchaser"], errors="coerce")
-    den = pd.to_numeric(df["N_old_purchaser"], errors="coerce")
-    return ((num - den) / den.abs()).dropna().to_numpy(dtype=float)
+    if "N_new_purchaser" in df.columns and df["N_new_purchaser"].notna().any():
+        num = pd.to_numeric(df["N_new_purchaser"], errors="coerce")
+        den = pd.to_numeric(df["N_old_purchaser"], errors="coerce")
+        return ((num - den) / den.abs()).dropna().to_numpy(dtype=float)
+    logger.warning(
+        "Sheet %s has no usable N_new_purchaser; falling back to producer N vs v0.",
+        sheet_id,
+    )
+    return pct_fractions_vs_v0(sheet_id, "N")
 
 
 def _inflation_ratio_2023_to_2024(
@@ -141,3 +147,32 @@ def pct_fractions_vs_baseline_sheet(
     pdiff = (merged[step_col] - merged["_base"]) / merged["_base"].abs()
     arr = pdiff.dropna().to_numpy(dtype=float)
     return arr[np.isfinite(arr)], inflation_applied
+
+
+def pct_fractions_stacked_group(
+    step_sheet_id: str,
+    prior_sheet_id: str | None,
+    ef_kind: str,
+    *,
+    ref_2023_sheet_id: str | None,
+    prefer_purchaser: bool = False,
+) -> tuple[np.ndarray, bool]:
+    """Marginal % diff for one stacked group vs its prior endpoint.
+
+    When ``prior_sheet_id`` is ``None`` (G1), returns in-sheet diff vs CEDA v0
+    or USEEIO purchaser baseline. Otherwise cross-sheet diff vs the prior
+    group absolute EF column, with 2023→2024 inflation when applicable.
+    """
+    if prior_sheet_id is None:
+        if prefer_purchaser and ef_kind == "N":
+            return pct_fractions_useeio_purchaser_vs_v0(step_sheet_id), False
+        return pct_fractions_vs_v0(step_sheet_id, ef_kind), False
+    baseline_year = _model_base_year(prior_sheet_id)
+    return pct_fractions_vs_baseline_sheet(
+        step_sheet_id,
+        prior_sheet_id,
+        ef_kind,
+        ref_2023_sheet_id=ref_2023_sheet_id,
+        baseline_year=baseline_year,
+        prefer_purchaser=prefer_purchaser,
+    )

--- a/bedrock/utils/validation/analysis/release_v0_v03_useeio_groups.py
+++ b/bedrock/utils/validation/analysis/release_v0_v03_useeio_groups.py
@@ -1,0 +1,105 @@
+"""Wholesale v0→v0.3 USEEIO diagnostics — three stacked group endpoints + FINAL.
+
+Each group endpoint is a dispatched diagnostics Sheet. Combine net-diffs chain
+G1 → G2 → G3 (marginal strips); FINAL is the shipped release (verification
+column, not a fourth deck marginal).
+
+Group definitions:
+  G1 — Cornerstone 2023 GHG + 2026 schema (Phoebe restore schema+GHG)
+  G2 — Methods: Phoebe B/A/IoT bridge + inflation + CEDA A/price (A_ceda endpoint)
+  G3 — Data: MECS + UMD + 2024 IO/GHG (2024_io_ghg endpoint)
+  FINAL — ``2025_usa_cornerstone_v0_3``
+"""
+
+from __future__ import annotations
+
+from bedrock.utils.validation.analysis.release_v0_3_progression import (
+    PINNED_USEEIO_BASELINE,
+    ProgressionSheet,
+    sheets_in_order,
+)
+
+G1_SCHEMA_GHG = ProgressionSheet(
+    step_label="G1: Cornerstone 2023 GHG + schema",
+    sheet_id="1l6Yzys1yNNvmZX2Fno30ftWjuMBCtRPFTESTbinYKz0",
+    config_name="useeio_phoebe_23_restore_schema_and_ghg",
+    sheet_title="[05-06-2026] USEEIO - restore GHG model and schema",
+)
+
+G2_METHODS = ProgressionSheet(
+    step_label="G2: Methods (A/B, IoT, inflation, CEDA A/price)",
+    sheet_id="1QZBKKHqaZm84-Kn1Fz0gpEdRTNCqnw0YJ8TQAsDn87o",
+    config_name="2025_usa_cornerstone_full_model_v0_3_A_ceda_fallback_approach",
+    sheet_title=(
+        "[2026-06-18, bedrock repo, 2023, USEEIO based, "
+        "v0.3 / CEDA A approach w/ price adj] EFs diagnostics"
+    ),
+)
+
+G3_DATA = ProgressionSheet(
+    step_label="G3: Data update (MECS, UMD, 2024 IO/GHG)",
+    sheet_id="1lqwoSVuDcMkSp56p1U8uQBkNuIVgDYJiy8Pog8IU-Zg",
+    config_name="2025_usa_cornerstone_full_model_v0_3_2024_io_ghg",
+    sheet_title=(
+        "[2026-06-24, bedrock repo, 2024, USEEIO based, "
+        "v0.3 / 2024 US IO+GHG data] EFs diagnostics"
+    ),
+)
+
+FINAL_V03_USEEIO = ProgressionSheet(
+    step_label="FINAL v0.3 (shipped)",
+    sheet_id="1FJYZHmQVN9D0JcUq7_hkqrxBU_h_K_xUPFQGDvf7gII",
+    config_name="2025_usa_cornerstone_v0_3",
+    sheet_title=(
+        "[2026-06-24, bedrock repo, 2024, USEEIO based, "
+        "v0.3 / FINAL v0.3] EFs diagnostics"
+    ),
+)
+
+# IO@2023 reference for 2023→2024 inflation on the G3 marginal (G3 vs G2).
+REF_2023_FOR_INFLATION = "1rzJEZuDe-GK_C5juKtIlrkYyQpnU0S9KUCBzMl9FT4M"
+
+V0_V03_USEEIO_GROUP_SHEETS: tuple[ProgressionSheet, ...] = (
+    G1_SCHEMA_GHG,
+    G2_METHODS,
+    G3_DATA,
+    FINAL_V03_USEEIO,
+)
+
+V0_V03_USEEIO_STACK_SHEETS: tuple[ProgressionSheet, ...] = (
+    G1_SCHEMA_GHG,
+    G2_METHODS,
+    G3_DATA,
+)
+
+# Default local merge workbook for combo ``v0_to_v03_useeio_groups`` (USEEIO baseline).
+V0_TO_V03_USEEIO_GROUPS_MERGED_XLSX = (
+    "ef_diagnostics_merged_v0_to_v03_useeio_groups_useeio.xlsx"
+)
+
+
+def useeio_group_stack_target_mapping(
+    sheets: tuple[ProgressionSheet, ...],
+) -> dict[str, str]:
+    """Stacked net-diff targets: G1 vs pinned USEEIO, then each step vs prior."""
+    config_names = [s.config_name for s in sheets]
+    if not config_names:
+        return {}
+    mapping: dict[str, str] = {config_names[0]: PINNED_USEEIO_BASELINE}
+    for idx in range(1, len(config_names)):
+        mapping[config_names[idx]] = config_names[idx - 1]
+    return mapping
+
+
+__all__ = [
+    "FINAL_V03_USEEIO",
+    "G1_SCHEMA_GHG",
+    "G2_METHODS",
+    "G3_DATA",
+    "REF_2023_FOR_INFLATION",
+    "V0_TO_V03_USEEIO_GROUPS_MERGED_XLSX",
+    "V0_V03_USEEIO_GROUP_SHEETS",
+    "V0_V03_USEEIO_STACK_SHEETS",
+    "sheets_in_order",
+    "useeio_group_stack_target_mapping",
+]


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

Adds tooling for the wholesale USEEIO narrative: three stacked group endpoints (schema/GHG, methods, data) plus shipped `2025_usa_cornerstone_v0_3`, with marginal net-diffs between groups and cumulative FINAL overlays.

**Figures and combined diagnostics added to Drive [here](https://drive.google.com/drive/folders/1O4T_X67XTmJCk0sMV-StwDgOv-F4ORju).**

**Sheet registry** — `release_v0_v03_useeio_groups.py` holds Drive sheet IDs, titles, and `config_name` values for G1 (`useeio_phoebe_23_restore_schema_and_ghg`), G2 (`2025_usa_cornerstone_full_model_v0_3_A_ceda_fallback_approach`), G3 (`2025_usa_cornerstone_full_model_v0_3_2024_io_ghg`), and FINAL (`2025_usa_cornerstone_v0_3`). G3 marginal plots apply 2023→2024 inflation using the IO@2023 reference sheet.

**Combine** — Combo `v0_to_v03_useeio_groups` chains net-diffs G1 → G2 → G3 → FINAL (G1 vs `pinned_useeio_baseline`). `totals_net_diff` emits a row for configs targeting `pinned_useeio_baseline` by reading `BLy_new - BLy_old (MtCO2e)` from that config's `totals` tab.

**Plot** — `plot_ef_v0_v03_useeio_groups.py` renders three stacked marginal histogram panels (G1→G2→G3) for N (purchaser / pinned USEEIO) and N/D (producer / CEDA v0), plus optional FINAL cumulative overlays vs pinned USEEIO and CEDA v0.

**Loaders** — `pct_fractions_stacked_group()` in `ef_progression.py` drives marginal panels; `pct_fractions_useeio_purchaser_vs_v0()` falls back to producer N when a sheet lacks purchaser columns (G1 Phoebe sheet).

Docs: `bedrock/analysis/v0_3/README.md`, `bedrock/utils/validation/analysis/README.md`.

## Testing

Combine:

```powershell
uv run python -m bedrock.utils.validation.analysis.combine_ef_diagnostics `
    --combo v0_to_v03_useeio_groups `
    --output-xlsx bedrock/analysis/v0_3/output/release_v0_v03_groups/ef_diagnostics_merged_v0_to_v03_useeio_groups_useeio.xlsx
```

Plot:

```powershell
uv run python -m bedrock.analysis.v0_3.plot_ef_v0_v03_useeio_groups
```

Manual checks:

- `totals_net_diff` has four rows; G1 vs `pinned_useeio_baseline` ≈ 289 MtCO2e BLy net
- Marginal strips: G2−G1 ≈ 137, G3−G2 ≈ −16, FINAL−G3 ≈ −48 MtCO2e
- PNGs under `bedrock/analysis/v0_3/output/release_v0_v03_groups/`
