### PR TITLE
feat(validation): v03_waterfall USEEIO group diagnostics

### DIFF
--- a/bedrock/analysis/v0_3/README.md
+++ b/bedrock/analysis/v0_3/README.md
@@ -19,6 +19,7 @@ Plot outputs land in `output/release_v0_3/` or `output/release_v0_v03_groups/`
 | `plot_ef_release_v0_3.py` | Release progression histograms, FINAL v0.2 vs v0.3 overlays, and BLy charts from registered sheets. |
 | `plot_ef_v0_v03_useeio_groups.py` | Stacked G1→G2→G3 wholesale USEEIO progression (3 marginal panels + FINAL cumulative overlays). |
 | `dispatch_ef_release_v0_3.py` | Dispatch v0.3 release steps (MECS through FINAL) to the EF time-series Drive folder; appends to `output/release_v0_3/ef_run_index_release_v0_3.csv`. |
+| `dispatch_ef_v03_waterfall.py` | Dispatch four `v03_waterfall_*` group endpoints (USEEIO baseline only); appends to `output/release_v0_v03_groups/ef_run_index_v03_waterfall.csv`. |
 
 ## Plot
 
@@ -32,11 +33,15 @@ Pass `--skip-progression`, `--skip-overlay`, or `--skip-bly` to omit figure grou
 `--compare-to v0.2` recomputes each v0.3 step vs FINAL v0.2 (2024 steps get
 `[+1yr infl]` on the panel title where applicable).
 
-Wholesale v0→v0.3 USEEIO groups (stacked G1→G2→G3 marginals):
+Wholesale v0→v0.3 USEEIO groups (stacked G1→G2→G3 marginals, IO@2024 producer):
 
 ```powershell
 uv run python -m bedrock.analysis.v0_3.plot_ef_v0_v03_useeio_groups
 ```
+
+Dispatch group sheets with `dispatch_ef_v03_waterfall`, then paste sheet IDs from
+`ef_run_index_v03_waterfall.csv` into `release_v0_v03_useeio_groups.py` before
+combine/plot.
 
 ## Dispatch
 
@@ -44,6 +49,10 @@ uv run python -m bedrock.analysis.v0_3.plot_ef_v0_v03_useeio_groups
 uv run python -m bedrock.analysis.v0_3.dispatch_ef_release_v0_3 --dry-run
 uv run python -m bedrock.analysis.v0_3.dispatch_ef_release_v0_3 `
     --only-configs 2025_usa_cornerstone_full_model_v0_3_ghgi_mecs
+
+uv run python -m bedrock.analysis.v0_3.dispatch_ef_v03_waterfall --dry-run
+uv run python -m bedrock.analysis.v0_3.dispatch_ef_v03_waterfall `
+    --only-configs v03_waterfall_useeio_g1_schema_ghg
 ```
 
 ## Combine

--- a/bedrock/analysis/v0_3/README.md
+++ b/bedrock/analysis/v0_3/README.md
@@ -17,7 +17,7 @@ Plot outputs land in `output/release_v0_3/` or `output/release_v0_v03_groups/`
 | Script | Purpose |
 |--------|---------|
 | `plot_ef_release_v0_3.py` | Release progression histograms, FINAL v0.2 vs v0.3 overlays, and BLy charts from registered sheets. |
-| `plot_ef_v0_v03_useeio_groups.py` | Stacked G1→G2→G3 wholesale USEEIO progression (3 marginal panels + FINAL cumulative overlays). |
+| `plot_ef_v0_v03_useeio_groups.py` | Stacked G1→G2→G3 wholesale USEEIO progression (3 marginal panels + FINAL vs pinned USEEIO overlays, producer). |
 | `dispatch_ef_release_v0_3.py` | Dispatch v0.3 release steps (MECS through FINAL) to the EF time-series Drive folder; appends to `output/release_v0_3/ef_run_index_release_v0_3.csv`. |
 | `dispatch_ef_v03_waterfall.py` | Dispatch four `v03_waterfall_*` group endpoints (USEEIO baseline only) to the v03 waterfall Drive folder; appends to `output/release_v0_v03_groups/ef_run_index_v03_waterfall.csv`. |
 

--- a/bedrock/analysis/v0_3/README.md
+++ b/bedrock/analysis/v0_3/README.md
@@ -19,7 +19,7 @@ Plot outputs land in `output/release_v0_3/` or `output/release_v0_v03_groups/`
 | `plot_ef_release_v0_3.py` | Release progression histograms, FINAL v0.2 vs v0.3 overlays, and BLy charts from registered sheets. |
 | `plot_ef_v0_v03_useeio_groups.py` | Stacked G1→G2→G3 wholesale USEEIO progression (3 marginal panels + FINAL cumulative overlays). |
 | `dispatch_ef_release_v0_3.py` | Dispatch v0.3 release steps (MECS through FINAL) to the EF time-series Drive folder; appends to `output/release_v0_3/ef_run_index_release_v0_3.csv`. |
-| `dispatch_ef_v03_waterfall.py` | Dispatch four `v03_waterfall_*` group endpoints (USEEIO baseline only); appends to `output/release_v0_v03_groups/ef_run_index_v03_waterfall.csv`. |
+| `dispatch_ef_v03_waterfall.py` | Dispatch four `v03_waterfall_*` group endpoints (USEEIO baseline only) to the v03 waterfall Drive folder; appends to `output/release_v0_v03_groups/ef_run_index_v03_waterfall.csv`. |
 
 ## Plot
 

--- a/bedrock/analysis/v0_3/dispatch_ef_v03_waterfall.py
+++ b/bedrock/analysis/v0_3/dispatch_ef_v03_waterfall.py
@@ -58,7 +58,9 @@ class WaterfallCell:
 
 
 WATERFALL_STEPS: tuple[WaterfallCell, ...] = (
-    WaterfallCell("v03_waterfall_useeio_g1_schema_ghg", "waterfall USEEIO G1 schema/GHG", 2024),
+    WaterfallCell(
+        "v03_waterfall_useeio_g1_schema_ghg", "waterfall USEEIO G1 schema/GHG", 2024
+    ),
     WaterfallCell("v03_waterfall_g2_methods", "waterfall G2 methods", 2024),
     WaterfallCell("v03_waterfall_g3_data", "waterfall G3 data", 2024),
     WaterfallCell("v03_waterfall_final", "waterfall FINAL v0.3", 2024),
@@ -125,7 +127,9 @@ def dispatch_waterfall(
         only_set = set(only_configs)
         steps = tuple(c for c in WATERFALL_STEPS if c.config_name in only_set)
         if not steps:
-            raise ValueError(f"No WATERFALL_STEPS match --only-configs {only_configs!r}")
+            raise ValueError(
+                f"No WATERFALL_STEPS match --only-configs {only_configs!r}"
+            )
 
     for cell in steps:
         model_base_year, usa_ghg_data_year = _years_for_config(cell.config_name)

--- a/bedrock/analysis/v0_3/dispatch_ef_v03_waterfall.py
+++ b/bedrock/analysis/v0_3/dispatch_ef_v03_waterfall.py
@@ -1,7 +1,7 @@
 """Dispatch v03_waterfall USEEIO diagnostics (four cumulative group endpoints).
 
-Four ``v03_waterfall_*`` configs × USEEIO baseline → four Sheets in the EF
-time-series Drive folder. Persists to
+Four ``v03_waterfall_*`` configs × USEEIO baseline → four Sheets in the
+v03 waterfall Drive folder (default below). Persists to
 ``output/release_v0_v03_groups/ef_run_index_v03_waterfall.csv``.
 
 Usage:
@@ -20,7 +20,6 @@ from pathlib import Path
 import pandas as pd
 
 from bedrock.analysis.a_matrix_time_series.dispatch_ef_time_series import (
-    EF_TIME_SERIES_DRIVE_FOLDER_ID,
     _create_sheet,
     _throttle,
     _trigger_workflow,
@@ -31,6 +30,9 @@ from bedrock.utils.validation.analysis.release_v0_v03_useeio_groups import (
 )
 
 logger = logging.getLogger(__name__)
+
+# v0.3 wholesale waterfall diagnostics (separate from Step 7 EF time-series folder).
+V03_WATERFALL_DRIVE_FOLDER_ID = "107RNHx1OUGN6roYdRi3BbdCSrMNFhl6u"
 
 _OUTPUT_DIR = Path(__file__).resolve().parent / "output" / "release_v0_v03_groups"
 WATERFALL_INDEX_PATH = _OUTPUT_DIR / "ef_run_index_v03_waterfall.csv"
@@ -102,6 +104,7 @@ def _already_recorded(df: pd.DataFrame, sheet_title: str) -> bool:
 def dispatch_waterfall(
     *,
     git_ref: str = "main",
+    drive_folder_id: str = V03_WATERFALL_DRIVE_FOLDER_ID,
     dry_run: bool = False,
     throttle: str = "poll",
     only_configs: tuple[str, ...] | None = None,
@@ -138,9 +141,10 @@ def dispatch_waterfall(
 
         if dry_run:
             logger.info(
-                "DRY-RUN would create: %s | config=%s use_useeio=true "
+                "DRY-RUN would create: %s | folder=%s config=%s use_useeio=true "
                 "model_base_year=%d usa_ghg_data_year=%d",
                 title,
+                drive_folder_id,
                 cell.config_name,
                 model_base_year,
                 usa_ghg_data_year,
@@ -150,7 +154,7 @@ def dispatch_waterfall(
 
         _throttle(throttle)
 
-        sheet_id = _create_sheet(EF_TIME_SERIES_DRIVE_FOLDER_ID, title)
+        sheet_id = _create_sheet(drive_folder_id, title)
         logger.info("Created sheet %s: %s", sheet_id, title)
         _trigger_workflow(
             git_ref=git_ref,
@@ -192,6 +196,14 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--drive-folder-id",
+        default=V03_WATERFALL_DRIVE_FOLDER_ID,
+        help=(
+            "Google Drive folder ID for new diagnostics Sheets "
+            f"(default: v03 waterfall folder {V03_WATERFALL_DRIVE_FOLDER_ID})."
+        ),
+    )
+    parser.add_argument(
         "--title-date",
         default="",
         help="YYYY-MM-DD prefix for sheet titles (default: UTC today).",
@@ -201,6 +213,7 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(message)s")
     dispatch_waterfall(
         git_ref=args.git_ref,
+        drive_folder_id=args.drive_folder_id,
         dry_run=args.dry_run,
         throttle=args.throttle,
         only_configs=only,

--- a/bedrock/analysis/v0_3/dispatch_ef_v03_waterfall.py
+++ b/bedrock/analysis/v0_3/dispatch_ef_v03_waterfall.py
@@ -1,0 +1,212 @@
+"""Dispatch v03_waterfall USEEIO diagnostics (four cumulative group endpoints).
+
+Four ``v03_waterfall_*`` configs × USEEIO baseline → four Sheets in the EF
+time-series Drive folder. Persists to
+``output/release_v0_v03_groups/ef_run_index_v03_waterfall.csv``.
+
+Usage:
+    uv run python -m bedrock.analysis.v0_3.dispatch_ef_v03_waterfall --dry-run
+    uv run python -m bedrock.analysis.v0_3.dispatch_ef_v03_waterfall
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+import pandas as pd
+
+from bedrock.analysis.a_matrix_time_series.dispatch_ef_time_series import (
+    EF_TIME_SERIES_DRIVE_FOLDER_ID,
+    _create_sheet,
+    _throttle,
+    _trigger_workflow,
+)
+from bedrock.utils.config.usa_config import _load_usa_config_from_file_name
+from bedrock.utils.validation.analysis.release_v0_v03_useeio_groups import (
+    V03_WATERFALL_CONFIGS,
+)
+
+logger = logging.getLogger(__name__)
+
+_OUTPUT_DIR = Path(__file__).resolve().parent / "output" / "release_v0_v03_groups"
+WATERFALL_INDEX_PATH = _OUTPUT_DIR / "ef_run_index_v03_waterfall.csv"
+
+INDEX_COLUMNS = (
+    "config_name",
+    "baseline",
+    "sheet_id",
+    "sheet_title",
+    "useeio_box_ticked",
+    "model_base_year",
+    "usa_ghg_data_year",
+    "git_ref",
+    "triggered_at",
+)
+
+
+@dataclass(frozen=True)
+class WaterfallCell:
+    config_name: str
+    step_label: str
+    title_year: int
+
+
+WATERFALL_STEPS: tuple[WaterfallCell, ...] = (
+    WaterfallCell("v03_waterfall_useeio_g1_schema_ghg", "waterfall USEEIO G1 schema/GHG", 2024),
+    WaterfallCell("v03_waterfall_g2_methods", "waterfall G2 methods", 2024),
+    WaterfallCell("v03_waterfall_g3_data", "waterfall G3 data", 2024),
+    WaterfallCell("v03_waterfall_final", "waterfall FINAL v0.3", 2024),
+)
+
+
+def _sheet_title(*, today: str, title_year: int, step_label: str) -> str:
+    return (
+        f"[{today}, bedrock repo, {title_year}, USEEIO based, "
+        f"v0.3 / {step_label}] EFs diagnostics"
+    )
+
+
+def _years_for_config(config_name: str) -> tuple[int, int]:
+    cfg = _load_usa_config_from_file_name(f"{config_name}.yaml")
+    return cfg.model_base_year, cfg.usa_ghg_data_year
+
+
+def _load_index() -> pd.DataFrame:
+    if WATERFALL_INDEX_PATH.exists():
+        df = pd.read_csv(WATERFALL_INDEX_PATH)
+    else:
+        df = pd.DataFrame(columns=list(INDEX_COLUMNS))
+    for col in INDEX_COLUMNS:
+        if col not in df.columns:
+            df[col] = ""
+    return df
+
+
+def _append_index_row(row: dict[str, object]) -> None:
+    df = _load_index()
+    df = pd.concat([df, pd.DataFrame([row])], ignore_index=True)
+    WATERFALL_INDEX_PATH.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(WATERFALL_INDEX_PATH, index=False)
+
+
+def _already_recorded(df: pd.DataFrame, sheet_title: str) -> bool:
+    if df.empty:
+        return False
+    return bool((df["sheet_title"] == sheet_title).any())
+
+
+def dispatch_waterfall(
+    *,
+    git_ref: str = "main",
+    dry_run: bool = False,
+    throttle: str = "poll",
+    only_configs: tuple[str, ...] | None = None,
+    title_date: str | None = None,
+) -> None:
+    unknown = set(only_configs or ()) - set(V03_WATERFALL_CONFIGS)
+    if unknown:
+        raise ValueError(
+            f"Unknown config(s) {sorted(unknown)!r}; expected subset of "
+            f"{list(V03_WATERFALL_CONFIGS)!r}"
+        )
+
+    today = title_date or dt.datetime.utcnow().strftime("%Y-%m-%d")
+    n_dispatched = 0
+
+    steps = WATERFALL_STEPS
+    if only_configs:
+        only_set = set(only_configs)
+        steps = tuple(c for c in WATERFALL_STEPS if c.config_name in only_set)
+        if not steps:
+            raise ValueError(f"No WATERFALL_STEPS match --only-configs {only_configs!r}")
+
+    for cell in steps:
+        model_base_year, usa_ghg_data_year = _years_for_config(cell.config_name)
+        title = _sheet_title(
+            today=today,
+            title_year=cell.title_year,
+            step_label=cell.step_label,
+        )
+        index_df = _load_index()
+        if _already_recorded(index_df, title):
+            logger.info("Skip already-recorded: %s", title)
+            continue
+
+        if dry_run:
+            logger.info(
+                "DRY-RUN would create: %s | config=%s use_useeio=true "
+                "model_base_year=%d usa_ghg_data_year=%d",
+                title,
+                cell.config_name,
+                model_base_year,
+                usa_ghg_data_year,
+            )
+            n_dispatched += 1
+            continue
+
+        _throttle(throttle)
+
+        sheet_id = _create_sheet(EF_TIME_SERIES_DRIVE_FOLDER_ID, title)
+        logger.info("Created sheet %s: %s", sheet_id, title)
+        _trigger_workflow(
+            git_ref=git_ref,
+            config_name=cell.config_name,
+            sheet_id=sheet_id,
+            model_base_year=model_base_year,
+            use_useeio_baseline=True,
+            usa_ghg_data_year=usa_ghg_data_year,
+        )
+        _append_index_row(
+            {
+                "config_name": cell.config_name,
+                "baseline": "useeio",
+                "sheet_id": sheet_id,
+                "sheet_title": title,
+                "useeio_box_ticked": "true",
+                "model_base_year": model_base_year,
+                "usa_ghg_data_year": usa_ghg_data_year,
+                "git_ref": git_ref,
+                "triggered_at": dt.datetime.utcnow().isoformat() + "Z",
+            }
+        )
+        n_dispatched += 1
+
+    logger.info("Done. cells=%d", n_dispatched)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--git-ref", default="main")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--throttle", default="poll")
+    parser.add_argument(
+        "--only-configs",
+        default="",
+        help=(
+            "Comma-separated v03_waterfall config stems to dispatch "
+            f"(default: all {len(V03_WATERFALL_CONFIGS)})."
+        ),
+    )
+    parser.add_argument(
+        "--title-date",
+        default="",
+        help="YYYY-MM-DD prefix for sheet titles (default: UTC today).",
+    )
+    args = parser.parse_args()
+    only = tuple(s.strip() for s in args.only_configs.split(",") if s.strip()) or None
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    dispatch_waterfall(
+        git_ref=args.git_ref,
+        dry_run=args.dry_run,
+        throttle=args.throttle,
+        only_configs=only,
+        title_date=args.title_date or None,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/bedrock/analysis/v0_3/plot_ef_v0_v03_useeio_groups.py
+++ b/bedrock/analysis/v0_3/plot_ef_v0_v03_useeio_groups.py
@@ -25,6 +25,7 @@ from bedrock.utils.validation.analysis.ef_hist_panels import (
     draw_per_sector_pct_hist_panel,
 )
 from bedrock.utils.validation.analysis.ef_progression import (
+    pct_fractions_producer_vs_old,
     pct_fractions_stacked_group,
     pct_fractions_vs_v0,
 )
@@ -131,7 +132,7 @@ def _plot_group_grid(
 def _plot_final_useeio_overlay(out_dir: Path) -> None:
     series_by_label = {
         "FINAL v0.3": pd.Series(
-            pct_fractions_vs_v0(FINAL_V03_USEEIO.sheet_id, "N") * 100.0
+            pct_fractions_producer_vs_old(FINAL_V03_USEEIO.sheet_id, "N") * 100.0
         ),
     }
     fig, ax = plt.subplots(figsize=(11, 6.5))
@@ -152,10 +153,12 @@ def _plot_final_useeio_overlay(out_dir: Path) -> None:
 
 def _plot_final_ceda_overlay(out_dir: Path) -> None:
     for ef_kind in ("N", "D"):
+        if ef_kind == "N":
+            fractions = pct_fractions_producer_vs_old(FINAL_V03_USEEIO.sheet_id, "N")
+        else:
+            fractions = pct_fractions_vs_v0(FINAL_V03_USEEIO.sheet_id, ef_kind)
         series_by_label = {
-            "FINAL v0.3": pd.Series(
-                pct_fractions_vs_v0(FINAL_V03_USEEIO.sheet_id, ef_kind) * 100.0
-            ),
+            "FINAL v0.3": pd.Series(fractions * 100.0),
         }
         fig, ax = plt.subplots(figsize=(11, 6.5))
         kind_label = EF_KIND_LABEL[ef_kind]

--- a/bedrock/analysis/v0_3/plot_ef_v0_v03_useeio_groups.py
+++ b/bedrock/analysis/v0_3/plot_ef_v0_v03_useeio_groups.py
@@ -47,6 +47,13 @@ USEEIO_BAR = "#ff7f0e"
 CEDA_BAR = "#1f77b4"
 PANEL_FONT_SCALE = 0.9
 
+# Short panel headers — full step labels live in the registry for combine/docs.
+_STACK_PANEL_TITLES = (
+    "GHG reconciliation",
+    "IO year adjustments",
+    "US data update",
+)
+
 
 @dataclass(frozen=True)
 class PanelLoad:
@@ -108,7 +115,8 @@ def _plot_group_grid(
         ax = flat[i]
         loaded = panel_loader(i)
         title = _panel_title(
-            step.step_label, inflation_applied=loaded.inflation_applied
+            _STACK_PANEL_TITLES[i],
+            inflation_applied=loaded.inflation_applied,
         )
         draw_per_sector_pct_hist_panel(
             ax,
@@ -123,7 +131,7 @@ def _plot_group_grid(
     for ax in flat[n:]:
         ax.axis("off")
     fig.suptitle(group_title, fontsize=14, y=1.02)
-    fig.tight_layout()
+    fig.tight_layout(rect=(0, 0, 1, 0.94))
     save_and_close(fig, out_path)
     print(f"Wrote: {out_path}")
 
@@ -176,7 +184,7 @@ def main(out_dir: Path, skip_overlay: bool) -> None:
             steps,
             group_title=(
                 f"[v0→v0.3 USEEIO · stacked groups] per-sector {ef_kind} % diff "
-                "(producer; G1 vs pinned USEEIO, G2+ vs prior step)"
+                "(producer, sequential comparisons)"
             ),
             out_path=out_dir / f"progression_v0_v03_useeio_groups_{ef_kind}.png",
             bar_color=bar_color,

--- a/bedrock/analysis/v0_3/plot_ef_v0_v03_useeio_groups.py
+++ b/bedrock/analysis/v0_3/plot_ef_v0_v03_useeio_groups.py
@@ -27,7 +27,6 @@ from bedrock.utils.validation.analysis.ef_hist_panels import (
 from bedrock.utils.validation.analysis.ef_progression import (
     pct_fractions_producer_vs_old,
     pct_fractions_stacked_group,
-    pct_fractions_vs_v0,
 )
 from bedrock.utils.validation.analysis.plotting import (
     overlay_pct_diff_histogram,
@@ -129,47 +128,28 @@ def _plot_group_grid(
     print(f"Wrote: {out_path}")
 
 
-def _plot_final_useeio_overlay(out_dir: Path) -> None:
-    series_by_label = {
-        "FINAL v0.3": pd.Series(
-            pct_fractions_producer_vs_old(FINAL_V03_USEEIO.sheet_id, "N") * 100.0
-        ),
-    }
-    fig, ax = plt.subplots(figsize=(11, 6.5))
-    overlay_pct_diff_histogram(
-        ax,
-        series_by_label,
-        xlabel="EF change vs USEEIO baseline (producer, %)",
-        title=(
-            f"{EF_KIND_LABEL['N']} per-sector % diff vs pinned USEEIO — "
-            "shipped v0.3 (cumulative, producer)"
-        ),
-    )
-    fig.tight_layout()
-    out = out_dir / "overlay_final_useeio_N_cumulative.png"
-    save_and_close(fig, out)
-    print(f"Wrote: {out}")
-
-
-def _plot_final_ceda_overlay(out_dir: Path) -> None:
+def _plot_final_useeio_overlays(out_dir: Path) -> None:
+    """Cumulative FINAL vs pinned USEEIO (producer) on the USEEIO-baseline sheet."""
     for ef_kind in ("N", "D"):
-        if ef_kind == "N":
-            fractions = pct_fractions_producer_vs_old(FINAL_V03_USEEIO.sheet_id, "N")
-        else:
-            fractions = pct_fractions_vs_v0(FINAL_V03_USEEIO.sheet_id, ef_kind)
         series_by_label = {
-            "FINAL v0.3": pd.Series(fractions * 100.0),
+            "FINAL v0.3": pd.Series(
+                pct_fractions_producer_vs_old(FINAL_V03_USEEIO.sheet_id, ef_kind)
+                * 100.0
+            ),
         }
         fig, ax = plt.subplots(figsize=(11, 6.5))
         kind_label = EF_KIND_LABEL[ef_kind]
         overlay_pct_diff_histogram(
             ax,
             series_by_label,
-            xlabel="EF change vs CEDA v0 baseline (%)",
-            title=f"{kind_label} per-sector % diff vs CEDA v0 — shipped v0.3 (cumulative)",
+            xlabel="EF change vs pinned USEEIO baseline (producer, %)",
+            title=(
+                f"{kind_label} per-sector % diff vs pinned USEEIO — "
+                "shipped v0.3 (cumulative, producer)"
+            ),
         )
         fig.tight_layout()
-        out = out_dir / f"overlay_final_ceda_{ef_kind}_cumulative.png"
+        out = out_dir / f"overlay_final_useeio_{ef_kind}_cumulative.png"
         save_and_close(fig, out)
         print(f"Wrote: {out}")
 
@@ -192,12 +172,11 @@ def main(out_dir: Path, skip_overlay: bool) -> None:
 
     for ef_kind in ("N", "D"):
         bar_color = USEEIO_BAR if ef_kind == "N" else CEDA_BAR
-        baseline_label = "pinned USEEIO" if ef_kind == "N" else "CEDA v0"
         _plot_group_grid(
             steps,
             group_title=(
                 f"[v0→v0.3 USEEIO · stacked groups] per-sector {ef_kind} % diff "
-                f"(producer / {baseline_label})"
+                "(producer; G1 vs pinned USEEIO, G2+ vs prior step)"
             ),
             out_path=out_dir / f"progression_v0_v03_useeio_groups_{ef_kind}.png",
             bar_color=bar_color,
@@ -210,8 +189,7 @@ def main(out_dir: Path, skip_overlay: bool) -> None:
         )
 
     if not skip_overlay:
-        _plot_final_useeio_overlay(out_dir)
-        _plot_final_ceda_overlay(out_dir)
+        _plot_final_useeio_overlays(out_dir)
 
 
 if __name__ == "__main__":

--- a/bedrock/analysis/v0_3/plot_ef_v0_v03_useeio_groups.py
+++ b/bedrock/analysis/v0_3/plot_ef_v0_v03_useeio_groups.py
@@ -26,7 +26,6 @@ from bedrock.utils.validation.analysis.ef_hist_panels import (
 )
 from bedrock.utils.validation.analysis.ef_progression import (
     pct_fractions_stacked_group,
-    pct_fractions_useeio_purchaser_vs_v0,
     pct_fractions_vs_v0,
 )
 from bedrock.utils.validation.analysis.plotting import (
@@ -37,7 +36,6 @@ from bedrock.utils.validation.analysis.plotting import (
 from bedrock.utils.validation.analysis.release_v0_3_progression import ProgressionSheet
 from bedrock.utils.validation.analysis.release_v0_v03_useeio_groups import (
     FINAL_V03_USEEIO,
-    REF_2023_FOR_INFLATION,
     V0_V03_USEEIO_STACK_SHEETS,
 )
 
@@ -133,17 +131,17 @@ def _plot_group_grid(
 def _plot_final_useeio_overlay(out_dir: Path) -> None:
     series_by_label = {
         "FINAL v0.3": pd.Series(
-            pct_fractions_useeio_purchaser_vs_v0(FINAL_V03_USEEIO.sheet_id) * 100.0
+            pct_fractions_vs_v0(FINAL_V03_USEEIO.sheet_id, "N") * 100.0
         ),
     }
     fig, ax = plt.subplots(figsize=(11, 6.5))
     overlay_pct_diff_histogram(
         ax,
         series_by_label,
-        xlabel="EF change vs USEEIO baseline (purchaser, %)",
+        xlabel="EF change vs USEEIO baseline (producer, %)",
         title=(
             f"{EF_KIND_LABEL['N']} per-sector % diff vs pinned USEEIO — "
-            "shipped v0.3 (cumulative)"
+            "shipped v0.3 (cumulative, producer)"
         ),
     )
     fig.tight_layout()
@@ -185,37 +183,26 @@ def main(out_dir: Path, skip_overlay: bool) -> None:
     setup_mpl(font_size=13)
     out_dir.mkdir(parents=True, exist_ok=True)
     steps = V0_V03_USEEIO_STACK_SHEETS
-
-    _plot_group_grid(
-        steps,
-        group_title=(
-            "[v0→v0.3 USEEIO · stacked groups] per-sector N % diff "
-            "(purchaser / pinned USEEIO)"
-        ),
-        out_path=out_dir / "progression_v0_v03_useeio_groups_N.png",
-        bar_color=USEEIO_BAR,
-        panel_loader=_loader_stacked(
-            steps,
-            "N",
-            prefer_purchaser=True,
-            ref_2023_sheet_id=REF_2023_FOR_INFLATION,
-        ),
-    )
+    # All group endpoints target IO@2024 producer footing; no 2023→2024 inflation.
+    ref_2023_sheet_id: str | None = None
+    prefer_purchaser = False
 
     for ef_kind in ("N", "D"):
+        bar_color = USEEIO_BAR if ef_kind == "N" else CEDA_BAR
+        baseline_label = "pinned USEEIO" if ef_kind == "N" else "CEDA v0"
         _plot_group_grid(
             steps,
             group_title=(
                 f"[v0→v0.3 USEEIO · stacked groups] per-sector {ef_kind} % diff "
-                "(producer / CEDA v0)"
+                f"(producer / {baseline_label})"
             ),
             out_path=out_dir / f"progression_v0_v03_useeio_groups_{ef_kind}.png",
-            bar_color=CEDA_BAR,
+            bar_color=bar_color,
             panel_loader=_loader_stacked(
                 steps,
                 ef_kind,
-                prefer_purchaser=False,
-                ref_2023_sheet_id=REF_2023_FOR_INFLATION,
+                prefer_purchaser=prefer_purchaser,
+                ref_2023_sheet_id=ref_2023_sheet_id,
             ),
         )
 

--- a/bedrock/utils/config/configs/v03_waterfall_final.yaml
+++ b/bedrock/utils/config/configs/v03_waterfall_final.yaml
@@ -1,0 +1,19 @@
+# v03_waterfall FINAL: shipped v0.3 feature mix @ IO@2024 producer (diagnostics endpoint).
+# Same methodology flags as release ``2025_usa_cornerstone_v0_3``; separate config for waterfall dispatch.
+
+model_base_year: 2024
+price_type: producer
+
+usa_ghg_data_year: 2024
+
+use_cornerstone_2026_model_schema: true
+load_E_from_flowsa: true
+
+v0_3_umd_2024_ghgia: true
+
+scale_a_matrix_with_ceda_method_as_fallback: true
+adjust_summary_A_and_q_dollar_year: true
+update_inflation_factors: true
+
+use_E_data_year_for_x_in_B: true
+implement_waste_disaggregation: true

--- a/bedrock/utils/config/configs/v03_waterfall_g2_methods.yaml
+++ b/bedrock/utils/config/configs/v03_waterfall_g2_methods.yaml
@@ -1,0 +1,20 @@
+# v03_waterfall G2: bedrock methods on IO@2024 producer footing.
+# Cumulative on G1: CEDA A/price, cornerstone margins, inflation; drops USEEIO A/margins.
+
+model_base_year: 2024
+price_type: producer
+
+usa_ghg_data_year: 2023
+
+use_cornerstone_2026_model_schema: true
+load_E_from_flowsa: true
+new_ghg_method: true
+use_E_data_year_for_x_in_B: true
+implement_waste_disaggregation: true
+
+scale_a_matrix_with_useeio_method: false
+useeio_margins: false
+cornerstone_industry_avg_margins: true
+scale_a_matrix_with_ceda_method_as_fallback: true
+adjust_summary_A_and_q_dollar_year: true
+update_inflation_factors: true

--- a/bedrock/utils/config/configs/v03_waterfall_g3_data.yaml
+++ b/bedrock/utils/config/configs/v03_waterfall_g3_data.yaml
@@ -1,0 +1,18 @@
+# v03_waterfall G3: G2 methods + 2024 UMD GHG / IO data @ IO@2024 producer.
+# Retains CEDA A/price and inflation from G2; adds v0_3_umd_2024_ghgia (MECS in parquet).
+
+model_base_year: 2024
+price_type: producer
+
+usa_ghg_data_year: 2024
+
+use_cornerstone_2026_model_schema: true
+load_E_from_flowsa: true
+v0_3_umd_2024_ghgia: true
+use_E_data_year_for_x_in_B: true
+implement_waste_disaggregation: true
+
+scale_a_matrix_with_ceda_method_as_fallback: true
+adjust_summary_A_and_q_dollar_year: true
+update_inflation_factors: true
+cornerstone_industry_avg_margins: true

--- a/bedrock/utils/config/configs/v03_waterfall_useeio_g1_schema_ghg.yaml
+++ b/bedrock/utils/config/configs/v03_waterfall_useeio_g1_schema_ghg.yaml
@@ -1,0 +1,23 @@
+# v03_waterfall USEEIO G1: USEEIO-like A/margins + Cornerstone schema/GHG @ IO@2024 producer.
+# Cumulative wholesale USEEIO group anchor (pinned → Cornerstone GHG + schema).
+
+model_base_year: 2024
+price_type: producer
+iot_before_or_after_redefinition: before
+
+usa_ghg_data_year: 2023
+
+use_cornerstone_2026_model_schema: true
+load_E_from_flowsa: true
+use_E_data_year_for_x_in_B: true
+implement_waste_disaggregation: true
+
+scale_a_matrix_with_useeio_method: true
+use_useeio_schema: false
+deflate_x_to_detail_io_year_for_B: true
+use_ghg_national_2023_m2: false
+skip_scrap_adjustment_in_vnorm: true
+new_ghg_method: true
+
+useeio_margins: true
+cornerstone_industry_avg_margins: false

--- a/bedrock/utils/validation/analysis/README.md
+++ b/bedrock/utils/validation/analysis/README.md
@@ -83,8 +83,12 @@ back, caches them locally as parquet, and renders analysis figures.
   `2025_usa_cornerstone_v0_2` in configs after dispatch). Atomic v0.3 steps
   (inflation, A/price, MECS) net-diff against that column, not stepwise.
 - `release_v0_v03_useeio_groups.py` — wholesale v0→v0.3 USEEIO group
-  endpoints (G1 schema/GHG, G2 methods, G3 data, FINAL). Consumed by combo
-  `v0_to_v03_useeio_groups` and `bedrock.analysis.v0_3.plot_ef_v0_v03_useeio_groups`.
+  endpoints (G1 USEEIO-like schema/GHG, G2 methods, G3 data, FINAL). Configs:
+  `v03_waterfall_useeio_g1_schema_ghg`, `v03_waterfall_g2_methods`,
+  `v03_waterfall_g3_data`, `v03_waterfall_final` (IO@2024 producer footing).
+  Dispatch via `bedrock.analysis.v0_3.dispatch_ef_v03_waterfall`. Consumed by
+  combo `v0_to_v03_useeio_groups` and
+  `bedrock.analysis.v0_3.plot_ef_v0_v03_useeio_groups`.
 
 ## Running
 

--- a/bedrock/utils/validation/analysis/combinations.py
+++ b/bedrock/utils/validation/analysis/combinations.py
@@ -49,6 +49,9 @@ class ComboSpec:
         sheets_in_order: Optional explicit ``(sheet_id, title)`` pairs. When
             non-empty, inputs are taken directly and ``drive_folder_id`` /
             ``names_in_order`` are ignored (for Sheets that span folders).
+        n_price_type: Which N columns to merge for absolute-EF tabs:
+            ``purchaser`` (default; USEEIO release-deck convention) or
+            ``producer`` (``N_new`` / ``N_old_inflated`` footing).
 
     The destination Sheet for merged output is always supplied on the
     command line via ``--output-sheet-id``; it is intentionally not part of
@@ -59,6 +62,7 @@ class ComboSpec:
     names_in_order: list[str]
     target_mapping: dict[str, str]
     sheets_in_order: tuple[tuple[str, str], ...] = ()
+    n_price_type: str = "purchaser"
 
 
 # Historical destination Sheets (pass via --output-sheet-id when reproducing):
@@ -159,5 +163,6 @@ COMBINATIONS: dict[str, ComboSpec] = {
         names_in_order=[],
         target_mapping=useeio_group_stack_target_mapping(V0_V03_USEEIO_GROUP_SHEETS),
         sheets_in_order=sheets_in_order(V0_V03_USEEIO_GROUP_SHEETS),
+        n_price_type='producer',
     ),
 }

--- a/bedrock/utils/validation/analysis/combine_ef_diagnostics.py
+++ b/bedrock/utils/validation/analysis/combine_ef_diagnostics.py
@@ -432,6 +432,7 @@ def merge_sheets(
     output_xlsx_path: str | None,
     output_sheet_id: str | None = None,
     refresh: bool = False,
+    n_price_type: str = "purchaser",
 ) -> dict[str, pd.DataFrame]:
     """Merge multiple diagnostics Sheets into the 7 comparison tabs.
 
@@ -452,6 +453,27 @@ def merge_sheets(
     """
     if not sheet_inputs_in_order:
         raise ValueError('Need at least one input Sheet.')
+    if n_price_type not in ("purchaser", "producer"):
+        raise ValueError(
+            f"n_price_type must be 'purchaser' or 'producer', got {n_price_type!r}"
+        )
+
+    n_new_preferred = (
+        "N_new_purchaser"
+        if n_price_type == "purchaser"
+        else "N_new_inflated"
+    )
+    n_new_fallback: tuple[str, ...] = (
+        ("N_new_inflated", "N_new")
+        if n_price_type == "purchaser"
+        else ("N_new",)
+    )
+    pinned_n_preferred = (
+        "N_old_purchaser" if n_price_type == "purchaser" else "N_old_inflated"
+    )
+    pinned_n_fallback: tuple[str, ...] = (
+        ("N_old_inflated",) if n_price_type == "purchaser" else ()
+    )
 
     # Read each run's config_summary upfront and classify it. This is the
     # source of truth for two behaviors that both depend on whether a run
@@ -519,8 +541,8 @@ def merge_sheets(
             sheet_id=first_sheet_id,
             label=first_label,
             tab='N_and_diffs',
-            preferred_metric_col='N_old_purchaser',
-            fallback_metric_cols=('N_old_inflated',),
+            preferred_metric_col=pinned_n_preferred,
+            fallback_metric_cols=pinned_n_fallback,
             refresh=refresh,
         )
 
@@ -537,8 +559,8 @@ def merge_sheets(
             sheet_id=sheet_id,
             label=label,
             tab='N_and_diffs',
-            preferred_metric_col='N_new_purchaser',
-            fallback_metric_cols=('N_new_inflated', 'N_new'),
+            preferred_metric_col=n_new_preferred,
+            fallback_metric_cols=n_new_fallback,
             refresh=refresh,
         )
 
@@ -896,6 +918,7 @@ def main(
         output_xlsx_path=effective_xlsx_path,
         output_sheet_id=output_sheet_id or None,
         refresh=refresh,
+        n_price_type=spec.n_price_type,
     )
 
 

--- a/bedrock/utils/validation/analysis/combine_ef_diagnostics.py
+++ b/bedrock/utils/validation/analysis/combine_ef_diagnostics.py
@@ -459,14 +459,10 @@ def merge_sheets(
         )
 
     n_new_preferred = (
-        "N_new_purchaser"
-        if n_price_type == "purchaser"
-        else "N_new_inflated"
+        "N_new_purchaser" if n_price_type == "purchaser" else "N_new_inflated"
     )
     n_new_fallback: tuple[str, ...] = (
-        ("N_new_inflated", "N_new")
-        if n_price_type == "purchaser"
-        else ("N_new",)
+        ("N_new_inflated", "N_new") if n_price_type == "purchaser" else ("N_new",)
     )
     pinned_n_preferred = (
         "N_old_purchaser" if n_price_type == "purchaser" else "N_old_inflated"

--- a/bedrock/utils/validation/analysis/ef_progression.py
+++ b/bedrock/utils/validation/analysis/ef_progression.py
@@ -43,8 +43,33 @@ def _tab_frame(sheet_id: str, ef_kind: str) -> pd.DataFrame:
 
 
 def pct_fractions_vs_v0(sheet_id: str, ef_kind: str) -> np.ndarray:
-    """In-sheet producer % diff vs CEDA v0 (``N_perc_diff`` / ``D_perc_diff``)."""
+    """In-sheet % diff from ``{kind}_perc_diff`` (or absolute columns as fallback).
+
+    On USEEIO-baseline sheets with purchaser columns, ``N_perc_diff`` compares
+    purchaser price, not producer. Use :func:`pct_fractions_producer_vs_old`
+    when the run targets producer footing.
+    """
     return pct_values(_tab_frame(sheet_id, ef_kind), ef_kind)
+
+
+def pct_fractions_producer_vs_old(sheet_id: str, ef_kind: str) -> np.ndarray:
+    """In-sheet producer % diff: ``{kind}_new[_inflated]`` vs ``{kind}_old_inflated``.
+
+    Ignores ``{kind}_perc_diff``, which on USEEIO-baseline sheets may reflect
+    purchaser price when ``N_new_purchaser`` is emitted.
+    """
+    df = _tab_frame(sheet_id, ef_kind)
+    inflated_col = f"{ef_kind}_new_inflated"
+    new_col = f"{ef_kind}_new"
+    old_col = f"{ef_kind}_old_inflated"
+    if inflated_col in df.columns and pd.to_numeric(df[inflated_col], errors="coerce").notna().any():
+        new = pd.to_numeric(df[inflated_col], errors="coerce")
+    else:
+        new = pd.to_numeric(df[new_col], errors="coerce")
+    old = pd.to_numeric(df[old_col], errors="coerce")
+    pdiff = (new - old) / old.abs()
+    arr = pdiff.dropna().to_numpy(dtype=float)
+    return arr[np.isfinite(arr)]
 
 
 def pct_fractions_useeio_purchaser_vs_v0(sheet_id: str) -> np.ndarray:
@@ -166,7 +191,7 @@ def pct_fractions_stacked_group(
     if prior_sheet_id is None:
         if prefer_purchaser and ef_kind == "N":
             return pct_fractions_useeio_purchaser_vs_v0(step_sheet_id), False
-        return pct_fractions_vs_v0(step_sheet_id, ef_kind), False
+        return pct_fractions_producer_vs_old(step_sheet_id, ef_kind), False
     baseline_year = _model_base_year(prior_sheet_id)
     return pct_fractions_vs_baseline_sheet(
         step_sheet_id,

--- a/bedrock/utils/validation/analysis/ef_progression.py
+++ b/bedrock/utils/validation/analysis/ef_progression.py
@@ -62,7 +62,10 @@ def pct_fractions_producer_vs_old(sheet_id: str, ef_kind: str) -> np.ndarray:
     inflated_col = f"{ef_kind}_new_inflated"
     new_col = f"{ef_kind}_new"
     old_col = f"{ef_kind}_old_inflated"
-    if inflated_col in df.columns and pd.to_numeric(df[inflated_col], errors="coerce").notna().any():
+    if (
+        inflated_col in df.columns
+        and pd.to_numeric(df[inflated_col], errors="coerce").notna().any()
+    ):
         new = pd.to_numeric(df[inflated_col], errors="coerce")
     else:
         new = pd.to_numeric(df[new_col], errors="coerce")

--- a/bedrock/utils/validation/analysis/release_v0_v03_useeio_groups.py
+++ b/bedrock/utils/validation/analysis/release_v0_v03_useeio_groups.py
@@ -22,33 +22,44 @@ from bedrock.utils.validation.analysis.release_v0_3_progression import (
     sheets_in_order,
 )
 
-# TODO: replace sheet_id / sheet_title after dispatch_ef_v03_waterfall run.
 G1_SCHEMA_GHG = ProgressionSheet(
     step_label="G1: USEEIO-like A/margins + Cornerstone schema/GHG",
-    sheet_id="",
+    sheet_id="18Nz4dfrv0kvSFo3G1dGrOgM_1HLC9843o4-yrO6m-uM",
     config_name="v03_waterfall_useeio_g1_schema_ghg",
-    sheet_title="(pending v03_waterfall dispatch)",
+    sheet_title=(
+        "[2026-07-09, bedrock repo, 2024, USEEIO based, "
+        "v0.3 / waterfall USEEIO G1 schema/GHG] EFs diagnostics"
+    ),
 )
 
 G2_METHODS = ProgressionSheet(
     step_label="G2: Bedrock methods (CEDA A/price, margins, inflation)",
-    sheet_id="",
+    sheet_id="1RPd44RBxUTtThz33EGH2ILt8o0WGWsLtJU4763run8U",
     config_name="v03_waterfall_g2_methods",
-    sheet_title="(pending v03_waterfall dispatch)",
+    sheet_title=(
+        "[2026-07-09, bedrock repo, 2024, USEEIO based, "
+        "v0.3 / waterfall G2 methods] EFs diagnostics"
+    ),
 )
 
 G3_DATA = ProgressionSheet(
     step_label="G3: Data update (MECS, UMD, 2024 IO/GHG)",
-    sheet_id="",
+    sheet_id="1uFL4hfOofBUeV05fQOFIophabRFrVizo_N5wSqd_2wA",
     config_name="v03_waterfall_g3_data",
-    sheet_title="(pending v03_waterfall dispatch)",
+    sheet_title=(
+        "[2026-07-09, bedrock repo, 2024, USEEIO based, "
+        "v0.3 / waterfall G3 data] EFs diagnostics"
+    ),
 )
 
 FINAL_V03_USEEIO = ProgressionSheet(
     step_label="FINAL v0.3 (waterfall)",
-    sheet_id="",
+    sheet_id="1SHSf6IINj6a79qjmhwJGHZR0Oo8XOaxCpv0dggsfkSU",
     config_name="v03_waterfall_final",
-    sheet_title="(pending v03_waterfall dispatch)",
+    sheet_title=(
+        "[2026-07-09, bedrock repo, 2024, USEEIO based, "
+        "v0.3 / waterfall FINAL v0.3] EFs diagnostics"
+    ),
 )
 
 V0_V03_USEEIO_GROUP_SHEETS: tuple[ProgressionSheet, ...] = (

--- a/bedrock/utils/validation/analysis/release_v0_v03_useeio_groups.py
+++ b/bedrock/utils/validation/analysis/release_v0_v03_useeio_groups.py
@@ -75,7 +75,9 @@ V0_V03_USEEIO_STACK_SHEETS: tuple[ProgressionSheet, ...] = (
     G3_DATA,
 )
 
-V03_WATERFALL_CONFIGS: tuple[str, ...] = tuple(s.config_name for s in V0_V03_USEEIO_GROUP_SHEETS)
+V03_WATERFALL_CONFIGS: tuple[str, ...] = tuple(
+    s.config_name for s in V0_V03_USEEIO_GROUP_SHEETS
+)
 
 # Default local merge workbook for combo ``v0_to_v03_useeio_groups`` (USEEIO baseline).
 V0_TO_V03_USEEIO_GROUPS_MERGED_XLSX = (

--- a/bedrock/utils/validation/analysis/release_v0_v03_useeio_groups.py
+++ b/bedrock/utils/validation/analysis/release_v0_v03_useeio_groups.py
@@ -1,14 +1,17 @@
-"""Wholesale v0→v0.3 USEEIO diagnostics — three stacked group endpoints + FINAL.
+"""Wholesale v0→v0.3 USEEIO diagnostics — v03_waterfall cumulative group endpoints.
 
-Each group endpoint is a dispatched diagnostics Sheet. Combine net-diffs chain
-G1 → G2 → G3 (marginal strips); FINAL is the shipped release (verification
-column, not a fourth deck marginal).
+Four ``v03_waterfall_*`` configs at IO@2024 producer footing. Combine net-diffs
+chain G1 → G2 → G3 (marginal strips); FINAL verifies the shipped feature mix.
 
-Group definitions:
-  G1 — Cornerstone 2023 GHG + 2026 schema (Phoebe restore schema+GHG)
-  G2 — Methods: Phoebe B/A/IoT bridge + inflation + CEDA A/price (A_ceda endpoint)
-  G3 — Data: MECS + UMD + 2024 IO/GHG (2024_io_ghg endpoint)
-  FINAL — ``2025_usa_cornerstone_v0_3``
+Group definitions (cumulative):
+  G1 — ``v03_waterfall_useeio_g1_schema_ghg`` — USEEIO-like A/margins + Cornerstone schema/GHG
+  G2 — ``v03_waterfall_g2_methods`` — G1 + CEDA A/price, cornerstone margins, inflation
+  G3 — ``v03_waterfall_g3_data`` — G2 + 2024 UMD GHG / IO data
+  FINAL — ``v03_waterfall_final`` — full v0.3 methodology (verification column)
+
+Dispatch: ``bedrock.analysis.v0_3.dispatch_ef_v03_waterfall``. After dispatch,
+paste sheet IDs from ``output/release_v0_v03_groups/ef_run_index_v03_waterfall.csv``
+into the ``ProgressionSheet`` entries below.
 """
 
 from __future__ import annotations
@@ -19,45 +22,34 @@ from bedrock.utils.validation.analysis.release_v0_3_progression import (
     sheets_in_order,
 )
 
+# TODO: replace sheet_id / sheet_title after dispatch_ef_v03_waterfall run.
 G1_SCHEMA_GHG = ProgressionSheet(
-    step_label="G1: Cornerstone 2023 GHG + schema",
-    sheet_id="1l6Yzys1yNNvmZX2Fno30ftWjuMBCtRPFTESTbinYKz0",
-    config_name="useeio_phoebe_23_restore_schema_and_ghg",
-    sheet_title="[05-06-2026] USEEIO - restore GHG model and schema",
+    step_label="G1: USEEIO-like A/margins + Cornerstone schema/GHG",
+    sheet_id="",
+    config_name="v03_waterfall_useeio_g1_schema_ghg",
+    sheet_title="(pending v03_waterfall dispatch)",
 )
 
 G2_METHODS = ProgressionSheet(
-    step_label="G2: Methods (A/B, IoT, inflation, CEDA A/price)",
-    sheet_id="1QZBKKHqaZm84-Kn1Fz0gpEdRTNCqnw0YJ8TQAsDn87o",
-    config_name="2025_usa_cornerstone_full_model_v0_3_A_ceda_fallback_approach",
-    sheet_title=(
-        "[2026-06-18, bedrock repo, 2023, USEEIO based, "
-        "v0.3 / CEDA A approach w/ price adj] EFs diagnostics"
-    ),
+    step_label="G2: Bedrock methods (CEDA A/price, margins, inflation)",
+    sheet_id="",
+    config_name="v03_waterfall_g2_methods",
+    sheet_title="(pending v03_waterfall dispatch)",
 )
 
 G3_DATA = ProgressionSheet(
     step_label="G3: Data update (MECS, UMD, 2024 IO/GHG)",
-    sheet_id="1lqwoSVuDcMkSp56p1U8uQBkNuIVgDYJiy8Pog8IU-Zg",
-    config_name="2025_usa_cornerstone_full_model_v0_3_2024_io_ghg",
-    sheet_title=(
-        "[2026-06-24, bedrock repo, 2024, USEEIO based, "
-        "v0.3 / 2024 US IO+GHG data] EFs diagnostics"
-    ),
+    sheet_id="",
+    config_name="v03_waterfall_g3_data",
+    sheet_title="(pending v03_waterfall dispatch)",
 )
 
 FINAL_V03_USEEIO = ProgressionSheet(
-    step_label="FINAL v0.3 (shipped)",
-    sheet_id="1FJYZHmQVN9D0JcUq7_hkqrxBU_h_K_xUPFQGDvf7gII",
-    config_name="2025_usa_cornerstone_v0_3",
-    sheet_title=(
-        "[2026-06-24, bedrock repo, 2024, USEEIO based, "
-        "v0.3 / FINAL v0.3] EFs diagnostics"
-    ),
+    step_label="FINAL v0.3 (waterfall)",
+    sheet_id="",
+    config_name="v03_waterfall_final",
+    sheet_title="(pending v03_waterfall dispatch)",
 )
-
-# IO@2023 reference for 2023→2024 inflation on the G3 marginal (G3 vs G2).
-REF_2023_FOR_INFLATION = "1rzJEZuDe-GK_C5juKtIlrkYyQpnU0S9KUCBzMl9FT4M"
 
 V0_V03_USEEIO_GROUP_SHEETS: tuple[ProgressionSheet, ...] = (
     G1_SCHEMA_GHG,
@@ -71,6 +63,8 @@ V0_V03_USEEIO_STACK_SHEETS: tuple[ProgressionSheet, ...] = (
     G2_METHODS,
     G3_DATA,
 )
+
+V03_WATERFALL_CONFIGS: tuple[str, ...] = tuple(s.config_name for s in V0_V03_USEEIO_GROUP_SHEETS)
 
 # Default local merge workbook for combo ``v0_to_v03_useeio_groups`` (USEEIO baseline).
 V0_TO_V03_USEEIO_GROUPS_MERGED_XLSX = (
@@ -96,7 +90,7 @@ __all__ = [
     "G1_SCHEMA_GHG",
     "G2_METHODS",
     "G3_DATA",
-    "REF_2023_FOR_INFLATION",
+    "V03_WATERFALL_CONFIGS",
     "V0_TO_V03_USEEIO_GROUPS_MERGED_XLSX",
     "V0_V03_USEEIO_GROUP_SHEETS",
     "V0_V03_USEEIO_STACK_SHEETS",


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

Adds a dedicated **v03_waterfall** config family and USEEIO-baseline dispatch for the wholesale v0→v0.3 narrative: three stacked marginal groups (schema/GHG → methods → data) plus a FINAL verification endpoint, all at **IO@2024 producer** footing. Existing release configs (`2025_usa_cornerstone_v0_3`, stepwise `2025_usa_cornerstone_full_model_*`) are unchanged.

**Configs** (`bedrock/utils/config/configs/`):

| Config | Role |
|--------|------|
| `v03_waterfall_useeio_g1_schema_ghg` | USEEIO-like A/margins + Cornerstone schema/GHG |
| `v03_waterfall_g2_methods` | CEDA A/price, cornerstone margins, inflation |
| `v03_waterfall_g3_data` | G2 + 2024 UMD GHG / IO data |
| `v03_waterfall_final` | Shipped v0.3 feature mix (diagnostics endpoint) |

G2/G3/FINAL are baseline-neutral yaml; only G1 encodes the USEEIO anchor (`v03_waterfall_useeio_*`) so a future CEDA waterfall can reuse the shared steps.

**Dispatch** — `bedrock.analysis.v0_3.dispatch_ef_v03_waterfall` triggers four USEEIO-baseline runs via `generate_diagnostics`, writes sheets to the v03 waterfall Drive folder (`107RNHx1OUGN6roYdRi3BbdCSrMNFhl6u`), and appends `output/release_v0_v03_groups/ef_run_index_v03_waterfall.csv`.

**Registry** — `release_v0_v03_useeio_groups.py` records dispatched sheet IDs/titles and `config_name` stems for combo `v0_to_v03_useeio_groups`.

**Combine** — `ComboSpec.n_price_type` selects N columns for merge/net-diff tabs. The waterfall combo sets `producer` (`N_new` / `N_old_inflated`) because USEEIO-baseline sheets overwrite `N_perc_diff` to purchaser price when margin columns exist. G1 net-diff targets `pinned_useeio_baseline`; G2→G3→FINAL chain stepwise.

**Plot** — `plot_ef_v0_v03_useeio_groups.py` renders three stacked marginal histograms (producer, sequential comparisons) with short panel titles (GHG reconciliation / IO year adjustments / US data update) and FINAL N/D cumulative overlays vs pinned USEEIO. Mislabeled “vs CEDA v0” overlays are removed until CEDA-baseline waterfall dispatch exists.

**Loaders** — `pct_fractions_producer_vs_old()` in `ef_progression.py` computes in-sheet producer % diffs from absolute N/D columns, bypassing purchaser-overwritten `N_perc_diff`.

Docs: `bedrock/analysis/v0_3/README.md`, `bedrock/utils/validation/analysis/README.md`.

## Testing

Dispatch (already run on `by_waterfall_configs`; re-run after registry/config edits):

```powershell
uv run python -m bedrock.analysis.v0_3.dispatch_ef_v03_waterfall --dry-run
uv run python -m bedrock.analysis.v0_3.dispatch_ef_v03_waterfall --git-ref by_waterfall_configs
```

Combine:

```powershell
uv run python -m bedrock.utils.validation.analysis.combine_ef_diagnostics `
    --combo v0_to_v03_useeio_groups `
    --output-xlsx bedrock/analysis/v0_3/output/release_v0_v03_groups/ef_diagnostics_merged_v0_to_v03_useeio_groups_useeio.xlsx
```

Plot:

```powershell
uv run python -m bedrock.analysis.v0_3.plot_ef_v0_v03_useeio_groups
```

Manual checks on 2026-07-09 USEEIO waterfall sheets:

- Merge workbook N tabs use producer columns (`N_new` / `N_new_inflated`, not `N_new_purchaser`).
- Stacked G2 marginal N shows large negative producer shift vs G1 (not purchaser artifact).
- `totals_net_diff` chains four configs; G1 row vs `pinned_useeio_baseline`.
- PNGs under `bedrock/analysis/v0_3/output/release_v0_v03_groups/`.
