### PR TITLE
fix(eeio): sum many-to-one BEA parents when expanding industry x

### DIFF
--- a/bedrock/analysis/time_series_B_matrix/derive_B_time_series.py
+++ b/bedrock/analysis/time_series_B_matrix/derive_B_time_series.py
@@ -156,9 +156,7 @@ def derive_x_time_series() -> dict[int, pd.Series]:
     than nominal inflation.
     """
     from bedrock.transform.eeio.cornerstone_expansion import (  # noqa: PLC0415
-        CS_INDUSTRY_LIST,
-        cs_industry_to_bea_map,
-        expand_vector,
+        expand_industry_output_vector,
     )
     from bedrock.transform.eeio.derived_cornerstone import (  # noqa: PLC0415
         _distribute_waste_parent_x_using_v_row_shares,
@@ -177,7 +175,7 @@ def derive_x_time_series() -> dict[int, pd.Series]:
         x_bea = derive_gross_output_after_redefinition(
             target_year=cast("USA_GROSS_INDUSTRY_OUTPUT_YEARS", year),
         )
-        x_cs = expand_vector(x_bea, CS_INDUSTRY_LIST, cs_industry_to_bea_map())
+        x_cs = expand_industry_output_vector(x_bea)
         x_cs.index.name = "sector"
         x_cs = _distribute_waste_parent_x_using_v_row_shares(x_cs)
 

--- a/bedrock/publish/cache_reset.py
+++ b/bedrock/publish/cache_reset.py
@@ -33,6 +33,7 @@ from bedrock.transform.eeio.derived_cornerstone import (
     derive_cornerstone_VA,
     derive_cornerstone_Vnorm_scrap_corrected,
     derive_cornerstone_x,
+    derive_cornerstone_x_after_redefinition,
     derive_cornerstone_y_nab,
     derive_cornerstone_Ytot_matrix_set,
 )
@@ -59,6 +60,7 @@ UPSTREAM_CACHED_DERIVES: list[Callable[..., object]] = [
     derive_disagg_Ytot_with_trade,
     derive_cornerstone_V,
     derive_cornerstone_x,
+    derive_cornerstone_x_after_redefinition,
     derive_cornerstone_q,
     derive_cornerstone_Vnorm_scrap_corrected,
     derive_cornerstone_U_with_negatives,

--- a/bedrock/transform/eeio/__tests__/test_expand_industry_output_vector.py
+++ b/bedrock/transform/eeio/__tests__/test_expand_industry_output_vector.py
@@ -1,0 +1,70 @@
+"""Tests for industry gross-output expand (many-to-one sum vs reverse-map)."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from bedrock.transform.eeio.cornerstone_expansion import (
+    CS_INDUSTRY_LIST,
+    cs_industry_to_bea_map,
+    expand_industry_output_vector,
+    expand_vector,
+    industry_corresp_raw,
+)
+
+
+def _synthetic_bea_x() -> pd.Series[float]:
+    """Distinct positive values on every BEA industry column in the correspondence."""
+    corresp = industry_corresp_raw()
+    values = {bea: float(i + 1) * 1_000.0 for i, bea in enumerate(corresp.columns)}
+    return pd.Series(values, dtype=float)
+
+
+def _multi_parent_industry_rows() -> list[str]:
+    corresp = industry_corresp_raw()
+    return [c for c in corresp.index if (corresp.loc[c] > 0).sum() > 1]
+
+
+def _first_parent_industry_expand(x_bea: pd.Series[float]) -> pd.Series[float]:
+    """Historical reverse-map expand: each CS row gets only its first BEA parent."""
+    corresp = industry_corresp_raw()
+    out = pd.Series(0.0, index=CS_INDUSTRY_LIST, dtype=float)
+    for cs in CS_INDUSTRY_LIST:
+        parents = corresp.columns[corresp.loc[cs] > 0].tolist()
+        if parents and parents[0] in x_bea.index:
+            out[cs] = float(x_bea[parents[0]])
+    return out
+
+
+def test_expand_industry_output_sums_all_multi_parent_rows() -> None:
+    """Property: every many-to-one CS industry gets the sum of its BEA parents."""
+    corresp = industry_corresp_raw()
+    x_bea = _synthetic_bea_x()
+    x_cs = expand_industry_output_vector(x_bea)
+    multi = _multi_parent_industry_rows()
+    assert multi, "expected at least one industry many-to-one row"
+    for cs in multi:
+        parents = corresp.columns[corresp.loc[cs] > 0].tolist()
+        assert x_cs[cs] == sum(float(x_bea[p]) for p in parents)
+
+
+def test_expand_industry_output_vs_first_parent_only_multi_parent_rows_differ() -> None:
+    """Blast radius: vs first-parent expand, only multi-parent CS rows change."""
+    corresp = industry_corresp_raw()
+    x_bea = _synthetic_bea_x()
+    x_new = expand_industry_output_vector(x_bea)
+    x_old = _first_parent_industry_expand(x_bea)
+    multi = set(_multi_parent_industry_rows())
+
+    delta = x_new - x_old
+    assert set(delta.index[delta.abs() > 1e-9]) == multi
+    for cs in multi:
+        parents = corresp.columns[corresp.loc[cs] > 0].tolist()
+        assert delta[cs] == sum(float(x_bea[p]) for p in parents[1:])
+
+
+def test_expand_vector_rejects_industry_reverse_map() -> None:
+    """Hard guard: industry GO must not use expand_vector + cs_industry_to_bea_map."""
+    with pytest.raises(ValueError, match="expand_industry_output_vector"):
+        expand_vector(_synthetic_bea_x(), CS_INDUSTRY_LIST, cs_industry_to_bea_map())

--- a/bedrock/transform/eeio/__tests__/test_expand_industry_output_vector.py
+++ b/bedrock/transform/eeio/__tests__/test_expand_industry_output_vector.py
@@ -21,9 +21,18 @@ def _synthetic_bea_x() -> pd.Series[float]:
     return pd.Series(values, dtype=float)
 
 
+def _bea_parents(corresp: pd.DataFrame, cs: str) -> list[str]:
+    """BEA industry columns with a positive weight on the Cornerstone row ``cs``."""
+    return [
+        str(col)
+        for col in corresp.columns
+        if float(pd.to_numeric(corresp.at[cs, col], errors="coerce") or 0.0) > 0
+    ]
+
+
 def _multi_parent_industry_rows() -> list[str]:
     corresp = industry_corresp_raw()
-    return [c for c in corresp.index if (corresp.loc[c] > 0).sum() > 1]
+    return [str(c) for c in corresp.index if len(_bea_parents(corresp, str(c))) > 1]
 
 
 def _first_parent_industry_expand(x_bea: pd.Series[float]) -> pd.Series[float]:
@@ -31,7 +40,7 @@ def _first_parent_industry_expand(x_bea: pd.Series[float]) -> pd.Series[float]:
     corresp = industry_corresp_raw()
     out = pd.Series(0.0, index=CS_INDUSTRY_LIST, dtype=float)
     for cs in CS_INDUSTRY_LIST:
-        parents = corresp.columns[corresp.loc[cs] > 0].tolist()
+        parents = _bea_parents(corresp, cs)
         if parents and parents[0] in x_bea.index:
             out[cs] = float(x_bea[parents[0]])
     return out
@@ -45,7 +54,7 @@ def test_expand_industry_output_sums_all_multi_parent_rows() -> None:
     multi = _multi_parent_industry_rows()
     assert multi, "expected at least one industry many-to-one row"
     for cs in multi:
-        parents = corresp.columns[corresp.loc[cs] > 0].tolist()
+        parents = _bea_parents(corresp, cs)
         assert x_cs[cs] == sum(float(x_bea[p]) for p in parents)
 
 
@@ -60,7 +69,7 @@ def test_expand_industry_output_vs_first_parent_only_multi_parent_rows_differ() 
     delta = x_new - x_old
     assert set(delta.index[delta.abs() > 1e-9]) == multi
     for cs in multi:
-        parents = corresp.columns[corresp.loc[cs] > 0].tolist()
+        parents = _bea_parents(corresp, cs)
         assert delta[cs] == sum(float(x_bea[p]) for p in parents[1:])
 
 

--- a/bedrock/transform/eeio/cornerstone_expansion.py
+++ b/bedrock/transform/eeio/cornerstone_expansion.py
@@ -4,10 +4,18 @@ Loads and caches binary correspondence matrices between BEA 2017 (or CEDA v7)
 and Cornerstone 2026 taxonomies, and provides functions to *expand*
 BEA-space or CEDA-space matrices/vectors to the 405-sector Cornerstone space.
 
-Expansion strategy: rows/columns for disaggregated sectors (waste, aluminum)
-are **duplicated** from the BEA parent — this preserves per-unit intensities
-for A and B.  Waste subsectors receive special intragroup treatment to prevent
-Leontief-inverse inflation.
+Expansion covers both taxonomy directions:
+
+- **One-to-many disaggregation** (e.g. waste ``562000`` → seven children):
+  ``expand_vector`` / ``expand_square_matrix`` **duplicate** the BEA parent onto
+  each Cornerstone child so per-unit intensities are preserved. Waste
+  subsectors then get special intragroup treatment (and, for industry gross
+  output, a V-share redistribute) to prevent Leontief-inverse inflation.
+- **Many-to-one aggregation** (e.g. government electric utilities into
+  ``221100``): ``expand_industry_output_vector`` **sums** all BEA parents via
+  the raw industry correspondence. Reverse-map helpers keep a single parent
+  for intensity-preserving matrix expand and must not be used for industry
+  gross-output vectors.
 """
 
 from __future__ import annotations
@@ -206,12 +214,53 @@ def expand_vector(
     target_codes: list[str],
     code_map: dict[str, str],
 ) -> pd.Series[float]:
-    """Expand a BEA vector to Cornerstone by duplicating entries."""
+    """Expand a BEA vector to Cornerstone by duplicating entries.
+
+    Uses a single-parent reverse map: one-to-many children each receive the
+    full parent value; many-to-one Cornerstone rows keep only the first BEA
+    parent.
+
+    Raises ``ValueError`` if *code_map* is the cached industry reverse map
+    from :func:`cs_industry_to_bea_map`. That map silently drops secondary
+    parents on aggregates (government enterprises into ``221100`` /
+    ``485000``). Industry gross output must use
+    :func:`expand_industry_output_vector` instead. Commodity expand and
+    matrix helpers that need first-parent duplication are unaffected
+    (they do not pass the industry reverse map into this function).
+    """
+    if code_map is cs_industry_to_bea_map():
+        raise ValueError(
+            "expand_vector with cs_industry_to_bea_map() drops many-to-one BEA "
+            "parents (e.g. S00101/S00202 into 221100). Use "
+            "expand_industry_output_vector for industry gross output."
+        )
     cs_valid, bea_valid = _valid_pairs(target_codes, code_map, v.index)
 
     expanded = v.loc[bea_valid].copy()
     expanded.index = cs_valid
     return expanded.reindex(target_codes, fill_value=0.0)
+
+
+def expand_industry_output_vector(x_bea: pd.Series[float]) -> pd.Series[float]:
+    """Expand BEA industry gross output to Cornerstone industries.
+
+    Multiplies by the raw binary industry correspondence
+    (Cornerstone × BEA) so:
+
+    - many-to-one rows (``221100`` ← private + gov utilities; ``485000`` ←
+      private + gov transit) **sum** parent gross output;
+    - one-to-many rows (waste children ← ``562000``) **duplicate** the parent
+      scalar onto each child (same intermediate as :func:`expand_vector`).
+
+    The waste duplication is **not** final industry output: callers must run
+    ``_distribute_waste_parent_x_using_v_row_shares`` (or equivalent) so the
+    waste children share a single copy of parent gross output rather than
+    counting it seven times. Without that step, ``sum(x)`` overstates waste.
+    """
+    corresp = industry_corresp_raw()
+    x_aligned = x_bea.reindex(corresp.columns, fill_value=0.0)
+    expanded = corresp @ x_aligned
+    return expanded.reindex(CS_INDUSTRY_LIST, fill_value=0.0)
 
 
 def expand_ghg_matrix_from_bea_to_cornerstone(

--- a/bedrock/transform/eeio/derived_cornerstone.py
+++ b/bedrock/transform/eeio/derived_cornerstone.py
@@ -52,10 +52,9 @@ from bedrock.transform.eeio.cornerstone_disagg_pipeline import (
 )
 from bedrock.transform.eeio.cornerstone_expansion import (
     CS_COMMODITY_LIST,
-    CS_INDUSTRY_LIST,
     commodity_corresp,
     cs_commodity_to_bea_map,
-    cs_industry_to_bea_map,
+    expand_industry_output_vector,
     expand_square_matrix,
     expand_vector,
     industry_corresp,
@@ -203,9 +202,9 @@ def _distribute_waste_parent_x_using_v_row_shares(
 ) -> pd.Series[float]:
     """Split duplicated BEA parent gross output across waste children using ``V`` row-sum shares.
 
-    After ``expand_vector``, one-to-many BEA→Cornerstone splits (e.g. 562000)
-    assign the **full** parent total to **each** child. When waste
-    disaggregation is enabled, replace those rows with
+    After industry-output expand, one-to-many BEA→Cornerstone splits
+    (e.g. 562000) assign the **full** parent total to **each** child. When
+    waste disaggregation is enabled, replace those rows with
     ``parent_go * (x_v[i] / sum_j x_v[j])`` where ``x_v`` is row sums of
     uninflated disaggregated ``V`` (2017-detail Make structure as mapped to
     Cornerstone) and ``parent_go`` is the duplicated scalar (GHG-year \$ scale).
@@ -223,7 +222,10 @@ def derive_cornerstone_x_after_redefinition(year: int = 0) -> pd.Series[float]:
     source from config, then expands it to Cornerstone industries via the
     BEA→Cornerstone industry correspondence.
 
-    For one-to-many splits (e.g. waste 562000), ``expand_vector`` first
+    Industry gross output is expanded with
+    ``expand_industry_output_vector`` so many-to-one aggregates (government
+    electric / transit enterprises into ``221100`` / ``485000``) sum BEA
+    parents. For one-to-many splits (e.g. waste 562000), that expand first
     duplicates the parent scalar to each child. When waste disaggregation is
     on, those waste rows are then replaced so each child gets a share of the
     parent total consistent with row sums of disaggregated ``V`` (same nominal
@@ -243,7 +245,7 @@ def derive_cornerstone_x_after_redefinition(year: int = 0) -> pd.Series[float]:
         target_year=effective_year,
         iot_before_or_after_redefinition=cfg.iot_before_or_after_redefinition,
     )
-    x_cs = expand_vector(x_bea, CS_INDUSTRY_LIST, cs_industry_to_bea_map())
+    x_cs = expand_industry_output_vector(x_bea)
     x_cs.index.name = 'sector'
     return _distribute_waste_parent_x_using_v_row_shares(x_cs)
 

--- a/bedrock/utils/economic/inflation_helpers_cornerstone.py
+++ b/bedrock/utils/economic/inflation_helpers_cornerstone.py
@@ -528,9 +528,7 @@ def derive_cornerstone_q_and_vnorm_for_year(
     # Local import: derived_cornerstone imports from this module, mirroring the
     # existing pattern at the top of `get_vnorm_adjusted_commodity_price_ratio`.
     from bedrock.transform.eeio.cornerstone_expansion import (  # noqa: PLC0415
-        CS_INDUSTRY_LIST,
-        cs_industry_to_bea_map,
-        expand_vector,
+        expand_industry_output_vector,
     )
     from bedrock.transform.eeio.derived_cornerstone import (  # noqa: PLC0415
         _distribute_waste_parent_x_using_v_row_shares,
@@ -552,11 +550,11 @@ def derive_cornerstone_q_and_vnorm_for_year(
         target_year=ta.cast(USA_GROSS_INDUSTRY_OUTPUT_YEARS, year),
         iot_before_or_after_redefinition=cfg.iot_before_or_after_redefinition,
     )
-    x_y = expand_vector(x_bea_y, CS_INDUSTRY_LIST, cs_industry_to_bea_map())
-    # When waste disagg is on, expand_vector duplicates the 562000 parent GO
-    # across waste children; redistribute via 2017 V row shares so the
-    # disaggregated industries get the right share. No-op when waste disagg
-    # is off (the helper short-circuits on missing weights).
+    x_y = expand_industry_output_vector(x_bea_y)
+    # When waste disagg is on, industry-output expand duplicates the 562000
+    # parent GO across waste children; redistribute via 2017 V row shares so
+    # the disaggregated industries get the right share. No-op when waste
+    # disagg is off (the helper short-circuits on missing weights).
     x_y = _distribute_waste_parent_x_using_v_row_shares(x_y)
     x_y = x_y.reindex(x_2017.index, fill_value=0.0)
 


### PR DESCRIPTION
cc:
Closes: #512 

**This fixes the incorrect handling of industry output for electricity `211` and transit `485` which was resulting in inflated D matrix values.**

## What changed? Why?

Cornerstone industry gross output for government-enterprise aggregates (`221100` ← private + `S00101` + `S00202`; `485000` ← private + `S00201`) was built with `expand_vector` + reverse-map **first parent only**, so government utility/transit dollars never entered `x`. Where Cornerstone `E` still carries those tons, `D = E/x` (and downstream `N` / `BLy`) were biased high—especially electric power.

`expand_industry_output_vector` now forms industry `x` as `industry_corresp_raw() @ x_bea` (sum over BEA parents). Wired at `derive_cornerstone_x_after_redefinition`, inflation year-`x` helpers, and B time-series expand. One-to-many waste duplication + V-share redistribute is unchanged. A hard guard rejects the industry reverse map on the generic `expand_vector` path. `derive_cornerstone_x_after_redefinition` is listed in `UPSTREAM_CACHED_DERIVES`.

### Measured effect on shipped `2025_usa_cornerstone_v0_3` (post-fix vs pre-fix USEEIO FINAL sheet)

**Direct factors (D)** — localized. Among ~400 overlapping sectors, only three move by more than 0.5%:

| Sector | ΔD (post / pre − 1) |
|--------|---------------------|
| `221100` Electric power | **−17.3%** |
| `221200` Natural gas distribution | **−9.5%** (side effect via Make / `Vnorm`, not a second reverse-map hole) |
| `485000` Transit | **−7.5%** |

Median ΔD ≈ 0; 99%+ of sectors stay within 0.1%. Electricity D vs USEEIO goes from roughly **+25%** (pre-fix sheet) to about **+3.4%** (post-fix local). Waterfall G1 electricity D lands on the USEEIO pin (~**+0.1%**).

**Total factors (N)** — broad. Lower electricity (and transit) intensities feed through `L`, so many sectors’ N fall even when their own D is flat:

| Statistic | Value |
|-----------|--------|
| Median ΔN | **−4.7%** |
| p95(\|ΔN\|) | **9.1%** |
| Share with \|ΔN\| > 5% | **44%** |
| `221100` ΔN | **−16.3%** |
| `485000` ΔN | **−6.0%** |

Electricity N vs USEEIO (producer): pre-fix FINAL ≈ **+32%**; post-fix local ≈ **+11%**. Residual after the denominator fix is methods/data years (G2/v0.3), not thin `x`.

## Testing

- Unit: `uv run pytest bedrock/transform/eeio/__tests__/test_expand_industry_output_vector.py -v` (multi-parent sum property, blast radius vs first-parent, reverse-map guard).
- Local EF/BLy review on `2025_usa_cornerstone_v0_3`, waterfall G1/G2, and `useeio_phoebe_23` smoke (`x[221100]` = sum of BEA parents).
- Redispatch of Drive diagnostics sheets deferred to stacked waterfall/plot PRs after this lands on `main`.

