### PR TITLE
Additional diagnostic plot updates

### DIFF
--- a/bedrock/analysis/v0_3/README.md
+++ b/bedrock/analysis/v0_3/README.md
@@ -17,8 +17,8 @@ Plot outputs land in `output/release_v0_3/` or `output/release_v0_v03_groups/`
 | Script | Purpose |
 |--------|---------|
 | `plot_ef_release_v0_3.py` | Release progression histograms, FINAL v0.2 vs v0.3 overlays, and BLy charts from registered sheets. |
-| `plot_ef_v0_v03_useeio_groups.py` | Stacked G1→G2→G3 wholesale USEEIO progression (sequential + cumulative-vs-pin panels, FINAL overlays, producer). |
-| `plot_ef_v0_v03_ceda_groups.py` | Stacked G1a→G1b→G2→G3 wholesale CEDA progression (sequential + cumulative-vs-v0 panels, FINAL overlays, producer). |
+| `plot_ef_v0_v03_useeio_groups.py` | Stacked G1→G2→G3 wholesale USEEIO progression (sequential + cumulative-vs-pin panels, FINAL overlays, producer). FINAL N overlay flags pinned key sectors. |
+| `plot_ef_v0_v03_ceda_groups.py` | Stacked G1a→G1b→G2→G3 wholesale CEDA progression (sequential + cumulative-vs-v0 panels, FINAL overlays, producer). FINAL N overlay flags pinned key sectors. |
 | `dispatch_ef_release_v0_3.py` | Dispatch v0.3 release steps (MECS through FINAL) to the EF time-series Drive folder; appends to `output/release_v0_3/ef_run_index_release_v0_3.csv`. |
 | `dispatch_ef_v03_waterfall.py` | Dispatch `v03_waterfall_*` group endpoints (USEEIO or CEDA baseline) to the v03 waterfall Drive folder; appends to a baseline-specific run index CSV. |
 

--- a/bedrock/analysis/v0_3/README.md
+++ b/bedrock/analysis/v0_3/README.md
@@ -17,8 +17,8 @@ Plot outputs land in `output/release_v0_3/` or `output/release_v0_v03_groups/`
 | Script | Purpose |
 |--------|---------|
 | `plot_ef_release_v0_3.py` | Release progression histograms, FINAL v0.2 vs v0.3 overlays, and BLy charts from registered sheets. |
-| `plot_ef_v0_v03_useeio_groups.py` | Stacked G1→G2→G3 wholesale USEEIO progression (3 marginal panels + FINAL vs pinned USEEIO overlays, producer). |
-| `plot_ef_v0_v03_ceda_groups.py` | Stacked G1a→G1b→G2→G3 wholesale CEDA progression (4 marginal panels + FINAL vs CEDA v0 overlays, producer). |
+| `plot_ef_v0_v03_useeio_groups.py` | Stacked G1→G2→G3 wholesale USEEIO progression (sequential + cumulative-vs-pin panels, FINAL overlays, producer). |
+| `plot_ef_v0_v03_ceda_groups.py` | Stacked G1a→G1b→G2→G3 wholesale CEDA progression (sequential + cumulative-vs-v0 panels, FINAL overlays, producer). |
 | `dispatch_ef_release_v0_3.py` | Dispatch v0.3 release steps (MECS through FINAL) to the EF time-series Drive folder; appends to `output/release_v0_3/ef_run_index_release_v0_3.csv`. |
 | `dispatch_ef_v03_waterfall.py` | Dispatch `v03_waterfall_*` group endpoints (USEEIO or CEDA baseline) to the v03 waterfall Drive folder; appends to a baseline-specific run index CSV. |
 

--- a/bedrock/analysis/v0_3/plot_ef_v0_v03_ceda_groups.py
+++ b/bedrock/analysis/v0_3/plot_ef_v0_v03_ceda_groups.py
@@ -183,6 +183,7 @@ def _plot_final_ceda_overlays(
             legend_loc="upper left" if use_keys else "upper right",
         )
         if use_keys:
+            assert key_sectors is not None
             annotate_key_sectors(ax, key_sectors, series * 100.0, font_scale=1.0)
         fig.tight_layout()
         out = out_dir / f"overlay_final_ceda_{ef_kind}_cumulative.png"

--- a/bedrock/analysis/v0_3/plot_ef_v0_v03_ceda_groups.py
+++ b/bedrock/analysis/v0_3/plot_ef_v0_v03_ceda_groups.py
@@ -4,8 +4,9 @@ Writes sequential panels (each vs the prior group endpoint) and cumulative
 panels (each vs CEDA v0), plus an optional FINAL vs CEDA v0 overlay. Uses
 existing diagnostics Sheets only.
 
-The FINAL N overlay optionally flags pinned key sectors (rugs + callout) —
-same shortlist as ceda ``usa_mrio_final``. Progression multi-panel grids omit
+The FINAL N overlay optionally flags pinned key sectors (rugs + callout)
+from ``KEY_USA_SECTORS`` (BLy-ranked; waste and government excluded).
+Progression multi-panel grids omit
 the overlay (too small).
 
 Usage:

--- a/bedrock/analysis/v0_3/plot_ef_v0_v03_ceda_groups.py
+++ b/bedrock/analysis/v0_3/plot_ef_v0_v03_ceda_groups.py
@@ -1,7 +1,8 @@
 """Stacked G1a→G1b→G2→G3 EF histograms for wholesale v0→v0.3 CEDA progression.
 
-Four marginal panels (each vs the prior group endpoint) plus an optional
-FINAL vs CEDA v0 overlay. Uses existing diagnostics Sheets only.
+Writes sequential panels (each vs the prior group endpoint) and cumulative
+panels (each vs CEDA v0), plus an optional FINAL vs CEDA v0 overlay. Uses
+existing diagnostics Sheets only.
 
 Usage:
     uv run python -m bedrock.analysis.v0_3.plot_ef_v0_v03_ceda_groups
@@ -91,6 +92,19 @@ def _loader_stacked(
             prefer_purchaser=prefer_purchaser,
         )
         return PanelLoad(fractions, inflation_applied=inflation_applied)
+
+    return load
+
+
+def _loader_cumulative_vs_baseline(
+    steps: Sequence[ProgressionSheet],
+    ef_kind: str,
+) -> Callable[[int], PanelLoad]:
+    """Each panel: in-sheet % diff vs CEDA v0 on that step's sheet."""
+
+    def load(index: int) -> PanelLoad:
+        step = steps[index]
+        return PanelLoad(pct_fractions_producer_vs_old(step.sheet_id, ef_kind))
 
     return load
 
@@ -192,6 +206,18 @@ def main(out_dir: Path, skip_overlay: bool) -> None:
                 prefer_purchaser=prefer_purchaser,
                 ref_2023_sheet_id=ref_2023_sheet_id,
             ),
+        )
+        _plot_group_grid(
+            steps,
+            group_title=(
+                f"[v0→v0.3 CEDA · stacked groups] per-sector {ef_kind} % diff "
+                "(producer, cumulative vs CEDA v0)"
+            ),
+            out_path=(
+                out_dir / f"progression_v0_v03_ceda_groups_{ef_kind}_cumulative.png"
+            ),
+            bar_color=bar_color,
+            panel_loader=_loader_cumulative_vs_baseline(steps, ef_kind),
         )
 
     if not skip_overlay:

--- a/bedrock/analysis/v0_3/plot_ef_v0_v03_ceda_groups.py
+++ b/bedrock/analysis/v0_3/plot_ef_v0_v03_ceda_groups.py
@@ -4,6 +4,10 @@ Writes sequential panels (each vs the prior group endpoint) and cumulative
 panels (each vs CEDA v0), plus an optional FINAL vs CEDA v0 overlay. Uses
 existing diagnostics Sheets only.
 
+The FINAL N overlay optionally flags pinned key sectors (rugs + callout) —
+same shortlist as ceda ``usa_mrio_final``. Progression multi-panel grids omit
+the overlay (too small).
+
 Usage:
     uv run python -m bedrock.analysis.v0_3.plot_ef_v0_v03_ceda_groups
 """
@@ -23,11 +27,14 @@ import pandas as pd
 
 from bedrock.utils.validation.analysis.ef_hist_panels import (
     EF_KIND_LABEL,
+    annotate_key_sectors,
     draw_per_sector_pct_hist_panel,
+    key_sectors_frame,
 )
 from bedrock.utils.validation.analysis.ef_progression import (
-    pct_fractions_producer_vs_old,
-    pct_fractions_stacked_group,
+    pct_series_producer_vs_old,
+    pct_series_stacked_group,
+    sector_names_from_sheet,
 )
 from bedrock.utils.validation.analysis.plotting import (
     overlay_pct_diff_histogram,
@@ -84,14 +91,16 @@ def _loader_stacked(
     def load(index: int) -> PanelLoad:
         step = steps[index]
         prior = _prior_sheet_id(steps, index)
-        fractions, inflation_applied = pct_fractions_stacked_group(
+        series, inflation_applied = pct_series_stacked_group(
             step.sheet_id,
             prior,
             ef_kind,
             ref_2023_sheet_id=ref_2023_sheet_id,
             prefer_purchaser=prefer_purchaser,
         )
-        return PanelLoad(fractions, inflation_applied=inflation_applied)
+        return PanelLoad(
+            series.to_numpy(dtype=float), inflation_applied=inflation_applied
+        )
 
     return load
 
@@ -104,7 +113,8 @@ def _loader_cumulative_vs_baseline(
 
     def load(index: int) -> PanelLoad:
         step = steps[index]
-        return PanelLoad(pct_fractions_producer_vs_old(step.sheet_id, ef_kind))
+        series = pct_series_producer_vs_old(step.sheet_id, ef_kind)
+        return PanelLoad(series.to_numpy(dtype=float))
 
     return load
 
@@ -125,7 +135,7 @@ def _plot_group_grid(
     )
     flat = list(axes.flat)
     ymax = 0.0
-    for i, step in enumerate(steps):
+    for i, _step in enumerate(steps):
         ax = flat[i]
         loaded = panel_loader(i)
         title = _panel_title(
@@ -150,16 +160,18 @@ def _plot_group_grid(
     print(f"Wrote: {out_path}")
 
 
-def _plot_final_ceda_overlays(out_dir: Path) -> None:
+def _plot_final_ceda_overlays(
+    out_dir: Path,
+    *,
+    key_sectors: pd.DataFrame | None,
+) -> None:
     """Cumulative FINAL vs CEDA v0 (producer) on the CEDA-baseline FINAL sheet."""
     for ef_kind in ("N", "D"):
-        series_by_label = {
-            "FINAL v0.3": pd.Series(
-                pct_fractions_producer_vs_old(FINAL_V03_CEDA.sheet_id, ef_kind) * 100.0
-            ),
-        }
+        series = pct_series_producer_vs_old(FINAL_V03_CEDA.sheet_id, ef_kind)
+        series_by_label = {"FINAL v0.3": series * 100.0}
         fig, ax = plt.subplots(figsize=(11, 6.5))
         kind_label = EF_KIND_LABEL[ef_kind]
+        use_keys = key_sectors is not None and ef_kind == "N"
         overlay_pct_diff_histogram(
             ax,
             series_by_label,
@@ -168,7 +180,10 @@ def _plot_final_ceda_overlays(out_dir: Path) -> None:
                 f"{kind_label} per-sector % diff vs CEDA v0 — "
                 "shipped v0.3 (cumulative, producer)"
             ),
+            legend_loc="upper left" if use_keys else "upper right",
         )
+        if use_keys:
+            annotate_key_sectors(ax, key_sectors, series * 100.0, font_scale=1.0)
         fig.tight_layout()
         out = out_dir / f"overlay_final_ceda_{ef_kind}_cumulative.png"
         save_and_close(fig, out)
@@ -183,12 +198,19 @@ def _plot_final_ceda_overlays(out_dir: Path) -> None:
     show_default=True,
 )
 @click.option("--skip-overlay", is_flag=True)
-def main(out_dir: Path, skip_overlay: bool) -> None:
+@click.option(
+    "--no-key-sectors",
+    is_flag=True,
+    help="Omit pinned key-sector rugs/callouts on the FINAL N overlay.",
+)
+def main(out_dir: Path, skip_overlay: bool, no_key_sectors: bool) -> None:
     setup_mpl(font_size=13)
     out_dir.mkdir(parents=True, exist_ok=True)
     steps = V0_V03_CEDA_STACK_SHEETS
     ref_2023_sheet_id: str | None = None
     prefer_purchaser = False
+    names = sector_names_from_sheet(FINAL_V03_CEDA.sheet_id, "N")
+    key_frame = None if no_key_sectors else key_sectors_frame(names)
 
     for ef_kind in ("N", "D"):
         bar_color = CEDA_BAR if ef_kind == "N" else USEEIO_BAR
@@ -221,7 +243,7 @@ def main(out_dir: Path, skip_overlay: bool) -> None:
         )
 
     if not skip_overlay:
-        _plot_final_ceda_overlays(out_dir)
+        _plot_final_ceda_overlays(out_dir, key_sectors=key_frame)
 
 
 if __name__ == "__main__":

--- a/bedrock/analysis/v0_3/plot_ef_v0_v03_useeio_groups.py
+++ b/bedrock/analysis/v0_3/plot_ef_v0_v03_useeio_groups.py
@@ -4,6 +4,10 @@ Writes sequential panels (each vs the prior group endpoint) and cumulative
 panels (each vs pinned USEEIO), plus an optional FINAL vs pinned USEEIO
 overlay. Uses existing diagnostics Sheets only.
 
+The FINAL N overlay optionally flags pinned key sectors (rugs + callout) —
+same shortlist as ceda ``usa_mrio_final``. Progression multi-panel grids omit
+the overlay (too small).
+
 Usage:
     uv run python -m bedrock.analysis.v0_3.plot_ef_v0_v03_useeio_groups
 """
@@ -23,11 +27,14 @@ import pandas as pd
 
 from bedrock.utils.validation.analysis.ef_hist_panels import (
     EF_KIND_LABEL,
+    annotate_key_sectors,
     draw_per_sector_pct_hist_panel,
+    key_sectors_frame,
 )
 from bedrock.utils.validation.analysis.ef_progression import (
-    pct_fractions_producer_vs_old,
-    pct_fractions_stacked_group,
+    pct_series_producer_vs_old,
+    pct_series_stacked_group,
+    sector_names_from_sheet,
 )
 from bedrock.utils.validation.analysis.plotting import (
     overlay_pct_diff_histogram,
@@ -48,7 +55,6 @@ USEEIO_BAR = "#ff7f0e"
 CEDA_BAR = "#1f77b4"
 PANEL_FONT_SCALE = 0.9
 
-# Short panel headers — full step labels live in the registry for combine/docs.
 _STACK_PANEL_TITLES = (
     "GHG reconciliation",
     "IO year adjustments",
@@ -84,14 +90,16 @@ def _loader_stacked(
     def load(index: int) -> PanelLoad:
         step = steps[index]
         prior = _prior_sheet_id(steps, index)
-        fractions, inflation_applied = pct_fractions_stacked_group(
+        series, inflation_applied = pct_series_stacked_group(
             step.sheet_id,
             prior,
             ef_kind,
             ref_2023_sheet_id=ref_2023_sheet_id,
             prefer_purchaser=prefer_purchaser,
         )
-        return PanelLoad(fractions, inflation_applied=inflation_applied)
+        return PanelLoad(
+            series.to_numpy(dtype=float), inflation_applied=inflation_applied
+        )
 
     return load
 
@@ -104,7 +112,8 @@ def _loader_cumulative_vs_baseline(
 
     def load(index: int) -> PanelLoad:
         step = steps[index]
-        return PanelLoad(pct_fractions_producer_vs_old(step.sheet_id, ef_kind))
+        series = pct_series_producer_vs_old(step.sheet_id, ef_kind)
+        return PanelLoad(series.to_numpy(dtype=float))
 
     return load
 
@@ -125,7 +134,7 @@ def _plot_group_grid(
     )
     flat = list(axes.flat)
     ymax = 0.0
-    for i, step in enumerate(steps):
+    for i, _step in enumerate(steps):
         ax = flat[i]
         loaded = panel_loader(i)
         title = _panel_title(
@@ -150,17 +159,18 @@ def _plot_group_grid(
     print(f"Wrote: {out_path}")
 
 
-def _plot_final_useeio_overlays(out_dir: Path) -> None:
+def _plot_final_useeio_overlays(
+    out_dir: Path,
+    *,
+    key_sectors: pd.DataFrame | None,
+) -> None:
     """Cumulative FINAL vs pinned USEEIO (producer) on the USEEIO-baseline sheet."""
     for ef_kind in ("N", "D"):
-        series_by_label = {
-            "FINAL v0.3": pd.Series(
-                pct_fractions_producer_vs_old(FINAL_V03_USEEIO.sheet_id, ef_kind)
-                * 100.0
-            ),
-        }
+        series = pct_series_producer_vs_old(FINAL_V03_USEEIO.sheet_id, ef_kind)
+        series_by_label = {"FINAL v0.3": series * 100.0}
         fig, ax = plt.subplots(figsize=(11, 6.5))
         kind_label = EF_KIND_LABEL[ef_kind]
+        use_keys = key_sectors is not None and ef_kind == "N"
         overlay_pct_diff_histogram(
             ax,
             series_by_label,
@@ -169,7 +179,10 @@ def _plot_final_useeio_overlays(out_dir: Path) -> None:
                 f"{kind_label} per-sector % diff vs pinned USEEIO — "
                 "shipped v0.3 (cumulative, producer)"
             ),
+            legend_loc="upper left" if use_keys else "upper right",
         )
+        if use_keys:
+            annotate_key_sectors(ax, key_sectors, series * 100.0, font_scale=1.0)
         fig.tight_layout()
         out = out_dir / f"overlay_final_useeio_{ef_kind}_cumulative.png"
         save_and_close(fig, out)
@@ -184,13 +197,19 @@ def _plot_final_useeio_overlays(out_dir: Path) -> None:
     show_default=True,
 )
 @click.option("--skip-overlay", is_flag=True)
-def main(out_dir: Path, skip_overlay: bool) -> None:
+@click.option(
+    "--no-key-sectors",
+    is_flag=True,
+    help="Omit pinned key-sector rugs/callouts on the FINAL N overlay.",
+)
+def main(out_dir: Path, skip_overlay: bool, no_key_sectors: bool) -> None:
     setup_mpl(font_size=13)
     out_dir.mkdir(parents=True, exist_ok=True)
     steps = V0_V03_USEEIO_STACK_SHEETS
-    # All group endpoints target IO@2024 producer footing; no 2023→2024 inflation.
     ref_2023_sheet_id: str | None = None
     prefer_purchaser = False
+    names = sector_names_from_sheet(FINAL_V03_USEEIO.sheet_id, "N")
+    key_frame = None if no_key_sectors else key_sectors_frame(names)
 
     for ef_kind in ("N", "D"):
         bar_color = USEEIO_BAR if ef_kind == "N" else CEDA_BAR
@@ -223,7 +242,7 @@ def main(out_dir: Path, skip_overlay: bool) -> None:
         )
 
     if not skip_overlay:
-        _plot_final_useeio_overlays(out_dir)
+        _plot_final_useeio_overlays(out_dir, key_sectors=key_frame)
 
 
 if __name__ == "__main__":

--- a/bedrock/analysis/v0_3/plot_ef_v0_v03_useeio_groups.py
+++ b/bedrock/analysis/v0_3/plot_ef_v0_v03_useeio_groups.py
@@ -182,6 +182,7 @@ def _plot_final_useeio_overlays(
             legend_loc="upper left" if use_keys else "upper right",
         )
         if use_keys:
+            assert key_sectors is not None
             annotate_key_sectors(ax, key_sectors, series * 100.0, font_scale=1.0)
         fig.tight_layout()
         out = out_dir / f"overlay_final_useeio_{ef_kind}_cumulative.png"

--- a/bedrock/analysis/v0_3/plot_ef_v0_v03_useeio_groups.py
+++ b/bedrock/analysis/v0_3/plot_ef_v0_v03_useeio_groups.py
@@ -4,8 +4,9 @@ Writes sequential panels (each vs the prior group endpoint) and cumulative
 panels (each vs pinned USEEIO), plus an optional FINAL vs pinned USEEIO
 overlay. Uses existing diagnostics Sheets only.
 
-The FINAL N overlay optionally flags pinned key sectors (rugs + callout) —
-same shortlist as ceda ``usa_mrio_final``. Progression multi-panel grids omit
+The FINAL N overlay optionally flags pinned key sectors (rugs + callout)
+from ``KEY_USA_SECTORS`` (BLy-ranked; waste and government excluded).
+Progression multi-panel grids omit
 the overlay (too small).
 
 Usage:

--- a/bedrock/analysis/v0_3/plot_ef_v0_v03_useeio_groups.py
+++ b/bedrock/analysis/v0_3/plot_ef_v0_v03_useeio_groups.py
@@ -1,7 +1,8 @@
 """Stacked G1→G2→G3 EF histograms for wholesale v0→v0.3 USEEIO progression.
 
-Three marginal panels (each vs the prior group endpoint) plus an optional
-FINAL vs pinned USEEIO overlay. Uses existing diagnostics Sheets only.
+Writes sequential panels (each vs the prior group endpoint) and cumulative
+panels (each vs pinned USEEIO), plus an optional FINAL vs pinned USEEIO
+overlay. Uses existing diagnostics Sheets only.
 
 Usage:
     uv run python -m bedrock.analysis.v0_3.plot_ef_v0_v03_useeio_groups
@@ -91,6 +92,19 @@ def _loader_stacked(
             prefer_purchaser=prefer_purchaser,
         )
         return PanelLoad(fractions, inflation_applied=inflation_applied)
+
+    return load
+
+
+def _loader_cumulative_vs_baseline(
+    steps: Sequence[ProgressionSheet],
+    ef_kind: str,
+) -> Callable[[int], PanelLoad]:
+    """Each panel: in-sheet % diff vs pinned USEEIO on that step's sheet."""
+
+    def load(index: int) -> PanelLoad:
+        step = steps[index]
+        return PanelLoad(pct_fractions_producer_vs_old(step.sheet_id, ef_kind))
 
     return load
 
@@ -194,6 +208,18 @@ def main(out_dir: Path, skip_overlay: bool) -> None:
                 prefer_purchaser=prefer_purchaser,
                 ref_2023_sheet_id=ref_2023_sheet_id,
             ),
+        )
+        _plot_group_grid(
+            steps,
+            group_title=(
+                f"[v0→v0.3 USEEIO · stacked groups] per-sector {ef_kind} % diff "
+                "(producer, cumulative vs pinned USEEIO)"
+            ),
+            out_path=(
+                out_dir / f"progression_v0_v03_useeio_groups_{ef_kind}_cumulative.png"
+            ),
+            bar_color=bar_color,
+            panel_loader=_loader_cumulative_vs_baseline(steps, ef_kind),
         )
 
     if not skip_overlay:

--- a/bedrock/utils/validation/analysis/ef_hist_panels.py
+++ b/bedrock/utils/validation/analysis/ef_hist_panels.py
@@ -144,8 +144,14 @@ def annotate_key_sectors(
     for r in sectors.itertuples(index=False):
         sec = str(r.sector).strip()
         pct_val = pct_lookup.get(sec)
-        has_pct = pct_val is not None and np.isfinite(float(pct_val))
-        pct = float(pct_val) if has_pct else float("nan")
+        if pct_val is None:
+            has_pct = False
+            pct = float("nan")
+        else:
+            pct = float(pct_val)
+            has_pct = bool(np.isfinite(pct))
+            if not has_pct:
+                pct = float("nan")
 
         if has_pct:
             marks.append((sec, float(np.clip(pct, lo, hi)), pct))

--- a/bedrock/utils/validation/analysis/ef_hist_panels.py
+++ b/bedrock/utils/validation/analysis/ef_hist_panels.py
@@ -3,6 +3,10 @@
 Release-progression grids, single-sheet renders, and A-matrix bundle histograms
 share this panel style: ±100% clip, 60 bins, zero line, n/median/p95 stats box.
 Distinct from ``plotting.percent_histogram`` (wider xlim, median reference lines).
+
+Optional key-sector overlays (rugs + callout) mirror the ceda
+``usa_mrio_final`` N histograms: annotation-only; the %-diff distribution is
+unchanged.
 """
 
 from __future__ import annotations
@@ -27,6 +31,20 @@ HIST_FONT_SCALE = 2.0
 HIST_STATS_EXTRA_SCALE = 2.0
 HIST_PCT_CLIP = 100.0
 HIST_BINS = 60
+
+# Pinned callout sectors for N histograms (same shortlist as ceda usa_mrio_final).
+# Top |BLy| emitters after dropping waste (562*) and |N%| > 100 outliers.
+KEY_USA_SECTORS: tuple[str, ...] = (
+    "221100",  # Electric power generation, transmission, and distribution
+    "211000",  # Oil and gas extraction
+    "1121A0",  # Beef cattle ranching and farming (incl. feedlots)
+    "GSLGO",  # State and local government (other services)
+    "481000",  # Air transportation
+    "1111B0",  # Grain farming
+    "324110",  # Petroleum refineries
+    "484000",  # Truck transportation
+)
+_COLOR_KEY_SECTOR = "#4a5568"  # neutral; no up/down encoding
 
 _KIND_SPEC: dict[str, dict[str, object]] = {
     "N": {
@@ -86,6 +104,114 @@ def pct_values(df: pd.DataFrame, ef_kind: str) -> np.ndarray:
     return arr[np.isfinite(arr)]
 
 
+def key_sectors_frame(sector_names: pd.Series | None = None) -> pd.DataFrame:
+    """Pinned ``KEY_USA_SECTORS`` with optional live ``sector_name`` labels.
+
+    ``sector_names`` is indexed by sector code. Missing names fall back to "".
+    """
+    names = (
+        sector_names.astype(str) if sector_names is not None else pd.Series(dtype=str)
+    )
+    return pd.DataFrame(
+        {
+            "sector": list(KEY_USA_SECTORS),
+            "sector_name": names.reindex(list(KEY_USA_SECTORS)).fillna("").to_numpy(),
+        }
+    )
+
+
+def annotate_key_sectors(
+    ax: Axes,
+    sectors: pd.DataFrame,
+    pct_by_sector: pd.Series,
+    *,
+    font_scale: float = 1.0,
+) -> None:
+    """Neutral rug ticks (sector-ID labels) + name/N% callout (hist unchanged).
+
+    ``pct_by_sector`` is in **percent** units (same as the panel x-axis), indexed
+    by stripped sector code. Values outside ``±HIST_PCT_CLIP`` are clipped for
+    rug placement only.
+    """
+    lo, hi = -HIST_PCT_CLIP, HIST_PCT_CLIP
+    y0, y1 = ax.get_ylim()
+    rug_h = (y1 - y0) * 0.07
+    pct_lookup = pct_by_sector.copy()
+    pct_lookup.index = pct_lookup.index.astype(str).str.strip()
+
+    marks: list[tuple[str, float, float]] = []
+    rows: list[str] = []
+    for r in sectors.itertuples(index=False):
+        sec = str(r.sector).strip()
+        pct_val = pct_lookup.get(sec)
+        has_pct = pct_val is not None and np.isfinite(float(pct_val))
+        pct = float(pct_val) if has_pct else float("nan")
+
+        if has_pct:
+            marks.append((sec, float(np.clip(pct, lo, hi)), pct))
+
+        name = str(r.sector_name).strip() or sec
+        if len(name) > 28:
+            name = name[:27] + "…"
+        pct_str = f"{pct:+5.1f}%" if has_pct else "  n/a"
+        rows.append(f"{sec:<6} {name:<28} {pct_str}")
+
+    marks.sort(key=lambda t: t[1])
+    heights: list[int] = []
+    last_x_at_level: dict[int, float] = {}
+    min_sep = (hi - lo) * 0.04
+    for _, x, _ in marks:
+        level = 0
+        while level in last_x_at_level and abs(x - last_x_at_level[level]) < min_sep:
+            level += 1
+        heights.append(level)
+        last_x_at_level[level] = x
+
+    label_fs = 7.5 * font_scale
+    for (sec, x, _), level in zip(marks, heights, strict=True):
+        ax.vlines(
+            x,
+            y0,
+            y0 + rug_h,
+            colors=_COLOR_KEY_SECTOR,
+            linewidths=2.0,
+            zorder=5,
+        )
+        ax.plot(x, y0 + rug_h, "^", color=_COLOR_KEY_SECTOR, markersize=6, zorder=6)
+        ax.text(
+            x,
+            y0 + rug_h * (1.15 + 0.85 * level),
+            sec,
+            ha="center",
+            va="bottom",
+            fontsize=label_fs,
+            color=_COLOR_KEY_SECTOR,
+            fontweight="bold",
+            zorder=7,
+        )
+
+    if not rows:
+        return
+
+    header = f"{'code':<6} {'name':<28} {'N%':>6}"
+    box = "Key sectors (by BLy)\n" + header + "\n" + "\n".join(rows)
+    ax.text(
+        0.98,
+        0.97,
+        box,
+        transform=ax.transAxes,
+        fontsize=max(6.5, 8.5 * font_scale),
+        va="top",
+        ha="right",
+        fontfamily="monospace",
+        linespacing=1.25,
+        bbox=dict(
+            boxstyle="round,pad=0.35", facecolor="white", edgecolor="0.6", alpha=0.92
+        ),
+        zorder=7,
+    )
+
+
 def draw_per_sector_pct_hist_panel(
     ax: Axes,
     pct_fraction: np.ndarray,
@@ -94,10 +220,15 @@ def draw_per_sector_pct_hist_panel(
     color: str,
     font_scale: float = 1.0,
     ylabel: str = "sector count",
+    pct_by_sector: pd.Series | None = None,
+    key_sectors: pd.DataFrame | None = None,
 ) -> None:
     """Draw one clipped per-sector % diff histogram on ``ax``.
 
     ``pct_fraction`` values are unit fractions (0.15 = 15%).
+    When ``key_sectors`` and ``pct_by_sector`` are provided, draws the key-sector
+    overlay. ``pct_by_sector`` may be fractions or percent; values with typical
+    |median| <= 2 are treated as fractions and scaled to percent.
     """
     pct_percent = np.asarray(pct_fraction, dtype=float) * 100.0
     finite = pct_percent[np.isfinite(pct_percent)]
@@ -133,3 +264,13 @@ def draw_per_sector_pct_hist_panel(
     )
     ax.set_ylabel(ylabel, fontsize=PANEL_AXIS_LABEL_FONTSIZE * font_scale)
     ax.tick_params(axis="both", labelsize=PANEL_TICK_LABEL_FONTSIZE * font_scale)
+
+    if key_sectors is not None and pct_by_sector is not None and not key_sectors.empty:
+        overlay = pd.to_numeric(pct_by_sector, errors="coerce")
+        finite_overlay = overlay[np.isfinite(overlay.to_numpy(dtype=float))]
+        if (
+            finite_overlay.size
+            and float(np.nanmedian(np.abs(finite_overlay.to_numpy(dtype=float)))) <= 2.0
+        ):
+            overlay = overlay * 100.0
+        annotate_key_sectors(ax, key_sectors, overlay, font_scale=font_scale)

--- a/bedrock/utils/validation/analysis/ef_hist_panels.py
+++ b/bedrock/utils/validation/analysis/ef_hist_panels.py
@@ -32,13 +32,13 @@ HIST_STATS_EXTRA_SCALE = 2.0
 HIST_PCT_CLIP = 100.0
 HIST_BINS = 60
 
-# Pinned callout sectors for N histograms (same shortlist as ceda usa_mrio_final).
-# Top |BLy| emitters after dropping waste (562*) and |N%| > 100 outliers.
+# Pinned callout sectors for N histograms. Top |BLy| emitters after dropping
+# waste (562*), government (G*/S00*), and |N%| > 100 outliers.
 KEY_USA_SECTORS: tuple[str, ...] = (
     "221100",  # Electric power generation, transmission, and distribution
     "211000",  # Oil and gas extraction
     "1121A0",  # Beef cattle ranching and farming (incl. feedlots)
-    "GSLGO",  # State and local government (other services)
+    "212100",  # Coal mining
     "481000",  # Air transportation
     "1111B0",  # Grain farming
     "324110",  # Petroleum refineries

--- a/bedrock/utils/validation/analysis/ef_progression.py
+++ b/bedrock/utils/validation/analysis/ef_progression.py
@@ -134,15 +134,26 @@ def _absolute_ef_column(
     *,
     prefer_purchaser: bool = False,
 ) -> str:
-    """Return the absolute EF column to read from a diagnostics tab."""
+    """Return the absolute EF column to read from a diagnostics tab.
+
+    Prefers dollar-year–aligned ``{kind}_new_inflated`` when present (e.g. USEEIO
+    G1 with ``deflate_x_to_detail_io_year_for_B``), so cross-sheet sequential
+    compares match ``model_base_year`` footing. Falls back to ``{kind}_new``.
+    """
+    df = _tab_frame(sheet_id, ef_kind)
     if prefer_purchaser and ef_kind == "N":
-        df = _tab_frame(sheet_id, ef_kind)
         if "N_new_purchaser" in df.columns and df["N_new_purchaser"].notna().any():
             return "N_new_purchaser"
         logger.warning(
-            "Sheet %s has no usable N_new_purchaser; falling back to N_new.",
+            "Sheet %s has no usable N_new_purchaser; falling back to producer N.",
             sheet_id,
         )
+    inflated_col = f"{ef_kind}_new_inflated"
+    if (
+        inflated_col in df.columns
+        and pd.to_numeric(df[inflated_col], errors="coerce").notna().any()
+    ):
+        return inflated_col
     return f"{ef_kind}_new"
 
 

--- a/bedrock/utils/validation/analysis/ef_progression.py
+++ b/bedrock/utils/validation/analysis/ef_progression.py
@@ -58,6 +58,12 @@ def pct_fractions_producer_vs_old(sheet_id: str, ef_kind: str) -> np.ndarray:
     Ignores ``{kind}_perc_diff``, which on USEEIO-baseline sheets may reflect
     purchaser price when ``N_new_purchaser`` is emitted.
     """
+    s = pct_series_producer_vs_old(sheet_id, ef_kind)
+    return s.to_numpy(dtype=float)
+
+
+def pct_series_producer_vs_old(sheet_id: str, ef_kind: str) -> pd.Series:
+    """Same as :func:`pct_fractions_producer_vs_old`, indexed by sector code."""
     df = _tab_frame(sheet_id, ef_kind)
     inflated_col = f"{ef_kind}_new_inflated"
     new_col = f"{ef_kind}_new"
@@ -71,8 +77,23 @@ def pct_fractions_producer_vs_old(sheet_id: str, ef_kind: str) -> np.ndarray:
         new = pd.to_numeric(df[new_col], errors="coerce")
     old = pd.to_numeric(df[old_col], errors="coerce")
     pdiff = (new - old) / old.abs()
-    arr = pdiff.dropna().to_numpy(dtype=float)
-    return arr[np.isfinite(arr)]
+    out = pd.Series(
+        pdiff.to_numpy(dtype=float), index=df["sector"].astype(str).str.strip()
+    )
+    return out.replace([np.inf, -np.inf], np.nan).dropna()
+
+
+def sector_names_from_sheet(sheet_id: str, ef_kind: str = "N") -> pd.Series:
+    """``sector -> sector_name`` from a diagnostics EF tab."""
+    df = _tab_frame(sheet_id, ef_kind)
+    if "sector_name" not in df.columns:
+        return pd.Series(dtype=str)
+    return (
+        df.drop_duplicates("sector")
+        .assign(sector=lambda d: d["sector"].astype(str).str.strip())
+        .set_index("sector")["sector_name"]
+        .astype(str)
+    )
 
 
 def pct_fractions_useeio_purchaser_vs_v0(sheet_id: str) -> np.ndarray:
@@ -141,6 +162,29 @@ def pct_fractions_vs_baseline_sheet(
     run and the baseline is 2023, the baseline EF is inflated per-sector using
     ``{kind}_old_inflated`` on the step sheet vs ``ref_2023_sheet_id``.
     """
+    series, inflation_applied = pct_series_vs_baseline_sheet(
+        step_sheet_id,
+        baseline_sheet_id,
+        ef_kind,
+        value_col=value_col,
+        ref_2023_sheet_id=ref_2023_sheet_id,
+        baseline_year=baseline_year,
+        prefer_purchaser=prefer_purchaser,
+    )
+    return series.to_numpy(dtype=float), inflation_applied
+
+
+def pct_series_vs_baseline_sheet(
+    step_sheet_id: str,
+    baseline_sheet_id: str,
+    ef_kind: str,
+    *,
+    value_col: str | None = None,
+    ref_2023_sheet_id: str | None,
+    baseline_year: int,
+    prefer_purchaser: bool = False,
+) -> tuple[pd.Series, bool]:
+    """Same as :func:`pct_fractions_vs_baseline_sheet`, indexed by sector."""
     step_col = value_col or _absolute_ef_column(
         step_sheet_id, ef_kind, prefer_purchaser=prefer_purchaser
     )
@@ -173,8 +217,12 @@ def pct_fractions_vs_baseline_sheet(
         inflation_applied = True
 
     pdiff = (merged[step_col] - merged["_base"]) / merged["_base"].abs()
-    arr = pdiff.dropna().to_numpy(dtype=float)
-    return arr[np.isfinite(arr)], inflation_applied
+    series = pd.Series(
+        pdiff.to_numpy(dtype=float),
+        index=merged["sector"].astype(str).str.strip(),
+    )
+    series = series.replace([np.inf, -np.inf], np.nan).dropna()
+    return series[np.isfinite(series.to_numpy(dtype=float))], inflation_applied
 
 
 def pct_fractions_stacked_group(
@@ -191,12 +239,41 @@ def pct_fractions_stacked_group(
     or USEEIO purchaser baseline. Otherwise cross-sheet diff vs the prior
     group absolute EF column, with 2023→2024 inflation when applicable.
     """
+    series, inflation_applied = pct_series_stacked_group(
+        step_sheet_id,
+        prior_sheet_id,
+        ef_kind,
+        ref_2023_sheet_id=ref_2023_sheet_id,
+        prefer_purchaser=prefer_purchaser,
+    )
+    return series.to_numpy(dtype=float), inflation_applied
+
+
+def pct_series_stacked_group(
+    step_sheet_id: str,
+    prior_sheet_id: str | None,
+    ef_kind: str,
+    *,
+    ref_2023_sheet_id: str | None,
+    prefer_purchaser: bool = False,
+) -> tuple[pd.Series, bool]:
+    """Same as :func:`pct_fractions_stacked_group`, indexed by sector."""
     if prior_sheet_id is None:
         if prefer_purchaser and ef_kind == "N":
-            return pct_fractions_useeio_purchaser_vs_v0(step_sheet_id), False
-        return pct_fractions_producer_vs_old(step_sheet_id, ef_kind), False
+            df = _tab_frame(step_sheet_id, "N")
+            if "N_new_purchaser" in df.columns and df["N_new_purchaser"].notna().any():
+                num = pd.to_numeric(df["N_new_purchaser"], errors="coerce")
+                den = pd.to_numeric(df["N_old_purchaser"], errors="coerce")
+                s = pd.Series(
+                    ((num - den) / den.abs()).to_numpy(dtype=float),
+                    index=df["sector"].astype(str).str.strip(),
+                )
+                s = s.replace([np.inf, -np.inf], np.nan).dropna()
+                return s[np.isfinite(s.to_numpy(dtype=float))], False
+            return pct_series_producer_vs_old(step_sheet_id, ef_kind), False
+        return pct_series_producer_vs_old(step_sheet_id, ef_kind), False
     baseline_year = _model_base_year(prior_sheet_id)
-    return pct_fractions_vs_baseline_sheet(
+    return pct_series_vs_baseline_sheet(
         step_sheet_id,
         prior_sheet_id,
         ef_kind,

--- a/bedrock/utils/validation/analysis/release_v0_v03_useeio_groups.py
+++ b/bedrock/utils/validation/analysis/release_v0_v03_useeio_groups.py
@@ -34,30 +34,30 @@ G1_SCHEMA_GHG = ProgressionSheet(
 
 G2_METHODS = ProgressionSheet(
     step_label="G2: Bedrock methods (CEDA A/price, margins, inflation)",
-    sheet_id="1RPd44RBxUTtThz33EGH2ILt8o0WGWsLtJU4763run8U",
+    sheet_id="1SogCbcLbRAE96R8ymij7B8uueIPYCk8MZIeSI5Km-5E",
     config_name="v03_waterfall_g2_methods",
     sheet_title=(
-        "[2026-07-09, bedrock repo, 2024, USEEIO based, "
+        "[2026-07-11, bedrock repo, 2024, USEEIO based, "
         "v0.3 / waterfall G2 methods] EFs diagnostics"
     ),
 )
 
 G3_DATA = ProgressionSheet(
     step_label="G3: Data update (MECS, UMD, 2024 IO/GHG)",
-    sheet_id="1uFL4hfOofBUeV05fQOFIophabRFrVizo_N5wSqd_2wA",
+    sheet_id="1F_v_m5y6o0OYJc1uTeFUn0qPys18s-N9TZmlqu-8SzY",
     config_name="v03_waterfall_g3_data",
     sheet_title=(
-        "[2026-07-09, bedrock repo, 2024, USEEIO based, "
+        "[2026-07-11, bedrock repo, 2024, USEEIO based, "
         "v0.3 / waterfall G3 data] EFs diagnostics"
     ),
 )
 
 FINAL_V03_USEEIO = ProgressionSheet(
     step_label="FINAL v0.3 (waterfall)",
-    sheet_id="1SHSf6IINj6a79qjmhwJGHZR0Oo8XOaxCpv0dggsfkSU",
+    sheet_id="1rWmekEraXOgXx5eEgf3zW86gDzgxh4uqe3Izsq6m_zo",
     config_name="v03_waterfall_final",
     sheet_title=(
-        "[2026-07-09, bedrock repo, 2024, USEEIO based, "
+        "[2026-07-11, bedrock repo, 2024, USEEIO based, "
         "v0.3 / waterfall FINAL v0.3] EFs diagnostics"
     ),
 )

--- a/bedrock/utils/validation/calculate_national_accounting_balance_diagnostics.py
+++ b/bedrock/utils/validation/calculate_national_accounting_balance_diagnostics.py
@@ -7,7 +7,7 @@ import typing as ta
 import numpy as np
 import pandas as pd
 
-from bedrock.utils.config.usa_config import get_usa_config
+from bedrock.utils.config.usa_config import USAConfig, get_usa_config
 from bedrock.utils.io.gcp import update_sheet_tab
 from bedrock.utils.snapshots.loader import (
     load_configured_snapshot,
@@ -46,6 +46,45 @@ def _compute_bly_series(
     if raw.shape[0] == 1:
         return raw.iloc[0, :].astype(float)
     raise TypeError(f"unexpected BLy shape {raw.shape}")
+
+
+def _cornerstone_y_nab_dollar_year(cfg: USAConfig) -> int:
+    """Dollar year of ``derive_cornerstone_y_nab()`` under the active A/q path.
+
+    ``y_nab`` is backcomputed from ``derive_cornerstone_Aq_scaled()``. When
+    ``scale_a_matrix_with_useeio_method`` is on, that path returns the 2017
+    detail base unchanged, so ``y`` stays in ``usa_detail_original_year``
+    dollars even if ``model_base_year`` is later. Other scale/inflate paths
+    put ``q`` (and thus ``y``) in ``model_base_year`` dollars.
+    """
+    if cfg.scale_a_matrix_with_useeio_method:
+        return int(cfg.usa_detail_original_year)
+    return int(cfg.model_base_year)
+
+
+def _rebase_b_intensity_dollar_year(
+    B: pd.DataFrame,
+    *,
+    from_year: int,
+    to_year: int,
+) -> pd.DataFrame:
+    """Rebase ``B`` intensity denominators from ``from_year`` $ to ``to_year`` $.
+
+    No-op when the years match. Uses the same sector price-index ratio as
+    ``inflation_adjust_ef_denom_to_new_base_year`` (EF ``D_old_inflated`` path).
+    """
+    if from_year == to_year:
+        return B
+    from bedrock.utils.validation.diagnostics_helpers import (
+        inflation_adjust_ef_denom_to_new_base_year,
+    )
+
+    scale = inflation_adjust_ef_denom_to_new_base_year(
+        pd.Series(1.0, index=B.columns, dtype=float),
+        new_base_year=to_year,
+        old_base_year=from_year,
+    )
+    return B * scale.to_numpy(dtype=float)
 
 
 def _percent_diff_vs_denominator(
@@ -89,11 +128,14 @@ def calculate_national_accounting_balance_diagnostics(
       ``E_old`` for the Excel baseline path).
     - ``BLy_new_vs_BLy_old``: per-sector live BLy vs BLy recomputed from the
       baseline (parquet ``B_USA_non_finetuned`` / ``Adom_USA`` / ``y_nab_USA`` at
-      the configured snapshot key, or USEEIO Excel synthetic ``B`` / ``A_d`` /
-      ``2017_US_Production_Complete`` when in Excel baseline mode). For USEEIO,
-      ``y_old`` is taken from Cornerstone ``derive_cornerstone_y_nab()`` and
-      reindexed to the USEEIO baseline sector axis. USEEIO-only sectors not in
-      Cornerstone (e.g., ``S00300``, ``S00401``, ``S00900``) are explicitly zeroed.
+      the configured snapshot key, or USEEIO Excel synthetic ``B`` / ``A_d``
+      when in Excel baseline mode). For USEEIO, ``y_old`` is Cornerstone
+      ``derive_cornerstone_y_nab()`` reindexed to the USEEIO sector axis
+      (USEEIO-only sectors such as ``S00300`` / ``S00401`` / ``S00900`` zeroed).
+      Workbook ``B`` intensities are rebased from workbook ``dollar_year`` to
+      the dollar year of that ``y_old`` (see ``_cornerstone_y_nab_dollar_year``),
+      not blindly to ``model_base_year``. Snapshot baselines leave ``B_old``
+      unchanged: snapshot ``B`` and ``y_nab`` already share one dollar year.
     """
     # Late-binding imports - depend on global config
     from bedrock.transform.eeio.derived import (
@@ -151,7 +193,12 @@ def calculate_national_accounting_balance_diagnostics(
         )
 
         ub = load_useeio_baseline_bundle(cfg)
-        B_old = ub.b_old_synthetic
+        y_dollar_year = _cornerstone_y_nab_dollar_year(cfg)
+        B_old = _rebase_b_intensity_dollar_year(
+            ub.b_old_synthetic,
+            from_year=ub.dollar_year,
+            to_year=y_dollar_year,
+        )
         Adom_old = ub.adom_old
         y_cornerstone = derive_cornerstone_y_nab()
         baseline_axis = Adom_old.index
@@ -175,9 +222,13 @@ def calculate_national_accounting_balance_diagnostics(
                     unexpected,
                 )
         logger.info(
-            "   USEEIO BLy y_old uses Cornerstone y_nab reindexed to USEEIO axis "
-            "(Cornerstone year scaling/inflation already applied to %s)",
+            "   USEEIO BLy: y_old dollar year=%s (model_base_year=%s, "
+            "useeio_A=%s); B_old intensities %s->%s $ when those years differ",
+            y_dollar_year,
             cfg.model_base_year,
+            cfg.scale_a_matrix_with_useeio_method,
+            ub.dollar_year,
+            y_dollar_year,
         )
     else:
         snap_key = resolve_snapshot_key()

--- a/bedrock/utils/validation/useeio_excel_baseline.py
+++ b/bedrock/utils/validation/useeio_excel_baseline.py
@@ -313,9 +313,10 @@ def derive_useeio_excel_y_nab_scaled_to_model_base_year(
     ``model_base_year`` (not workbook ``dollar_year``).
 
     Note:
-    This helper is currently used for diagnostics/support comparisons (e.g. CSV
-    exports), not for the active USEEIO BLy ``y_old`` path. The BLy USEEIO path
-    now uses Cornerstone ``derive_cornerstone_y_nab`` reindexed to USEEIO axis.
+    This helper is used for diagnostics/support comparisons (e.g. CSV exports).
+    The active USEEIO BLy ``y_old`` path uses Cornerstone ``derive_cornerstone_y_nab``
+    reindexed to the USEEIO axis, and rebases workbook ``B`` intensities from
+    workbook ``dollar_year`` to that ``y``'s dollar year when they differ.
     """
     from bedrock.extract.iot.io_2017 import load_summary_Uimp_usa  # noqa: PLC0415
     from bedrock.transform.eeio.derived_2017 import (  # noqa: PLC0415


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

Waterfall EF plot stack for USEEIO and CEDA group diagnostics:

- Adds Cumulative-vs-baseline histogram panels alongside the existing sequential (step-to-step) panels, so each group endpoint is readable against the pinned baseline without mentally stacking marginals.
- FINAL N overlays annotate pinned key sectors (BLy-ranked rugs + callouts) so large emitters are visible on the shipped-v0.3 vs baseline distribution (waste and gov't sectors excluded).
- Sequential cross-sheet N/D compares prefer `{N,D}_new_inflated` when the prior sheet emits it, so G2 vs G1 (and peers) stay on `model_base_year` footing instead of mixing detail-year and base-year dollars.
- USEEIO workbook BLy intensities rebase to the Cornerstone `y_nab` dollar year under A-scaling (detail-original-year `y` even when `model_base_year` is later), with matching USEEIO group sheet IDs after that rebase.

Shared helpers live in `ef_hist_panels` / `ef_progression` (`pct_series_*`, `annotate_key_sectors`, inflated-column preference).

## Testing

```powershell
uv run mypy bedrock
uv run black --check .
uv run ruff check .
uv run python -m bedrock.analysis.v0_3.plot_ef_v0_v03_useeio_groups
uv run python -m bedrock.analysis.v0_3.plot_ef_v0_v03_ceda_groups
```

