### PR TITLE
chore(validation): pin post-#513 v03 waterfall diagnostics sheets

### DIFF
--- a/bedrock/utils/validation/analysis/release_v0_v03_ceda_groups.py
+++ b/bedrock/utils/validation/analysis/release_v0_v03_ceda_groups.py
@@ -27,50 +27,50 @@ from bedrock.utils.validation.analysis.release_v0_3_progression import (
 
 G1A_SCHEMA_GHG = ProgressionSheet(
     step_label="G1a: Cornerstone schema/GHG (no waste)",
-    sheet_id="1rFe4PmoEqDZ2NNUf5gx9jyvy3IQJEE7QGxXkygvVjhU",
+    sheet_id="1jIfLzBfAcpJqq6h4KwMOvZICCVYuQOfWjhy7gBY-VA0",
     config_name="v03_waterfall_ceda_g1a_schema_ghg",
     sheet_title=(
-        "[2026-07-10, bedrock repo, 2024, CEDA based, "
+        "[2026-07-13, bedrock repo, 2024, CEDA based, "
         "v0.3 / waterfall CEDA G1a schema/GHG] EFs diagnostics"
     ),
 )
 
 G1B_WASTE_DISAGG = ProgressionSheet(
     step_label="G1b: Waste disaggregation",
-    sheet_id="1cTWFxTt2ux51Lk6x6pesJiOMKlNMgZABquV3GCJhJXE",
+    sheet_id="1Px61a96Mq-GnMvHf09zpURbzNQI0MYmuV1ot-sfnRtU",
     config_name="v03_waterfall_ceda_g1b_waste_disagg",
     sheet_title=(
-        "[2026-07-10, bedrock repo, 2024, CEDA based, "
+        "[2026-07-13, bedrock repo, 2024, CEDA based, "
         "v0.3 / waterfall CEDA G1b waste disagg] EFs diagnostics"
     ),
 )
 
 G2_METHODS = ProgressionSheet(
     step_label="G2: Bedrock methods (CEDA A/price, margins, inflation)",
-    sheet_id="1SrBs3qrWdPGExxCCMoblDslmzGxps4BUq4EHMGSiNeA",
+    sheet_id="15w6-uMNxXgzhDKGZXzZeD4ihjlD9igg_tg-qizKZJgE",
     config_name="v03_waterfall_g2_methods",
     sheet_title=(
-        "[2026-07-10, bedrock repo, 2024, CEDA based, "
+        "[2026-07-13, bedrock repo, 2024, CEDA based, "
         "v0.3 / waterfall G2 methods] EFs diagnostics"
     ),
 )
 
 G3_DATA = ProgressionSheet(
     step_label="G3: Data update (MECS, UMD, 2024 IO/GHG)",
-    sheet_id="1TgyffESrSghyfwEez_nE3vPpuLusus4uoa10bSSO1BA",
+    sheet_id="1OcmhKNxDXgJdvGgMpP8q04a-DhWkpDIzIbKs9Rp7g-Q",
     config_name="v03_waterfall_g3_data",
     sheet_title=(
-        "[2026-07-10, bedrock repo, 2024, CEDA based, "
+        "[2026-07-13, bedrock repo, 2024, CEDA based, "
         "v0.3 / waterfall G3 data] EFs diagnostics"
     ),
 )
 
 FINAL_V03_CEDA = ProgressionSheet(
     step_label="FINAL v0.3 (waterfall)",
-    sheet_id="19b0Nmuz4Ymj-jKlCrGWVymgpcBereD738DNcTN3kZgA",
+    sheet_id="17QWanjL_5wn_lCGcJ_XNWF_F5katycfPrOzECbkr8Ww",
     config_name="v03_waterfall_final",
     sheet_title=(
-        "[2026-07-10, bedrock repo, 2024, CEDA based, "
+        "[2026-07-13, bedrock repo, 2024, CEDA based, "
         "v0.3 / waterfall FINAL v0.3] EFs diagnostics"
     ),
 )

--- a/bedrock/utils/validation/analysis/release_v0_v03_useeio_groups.py
+++ b/bedrock/utils/validation/analysis/release_v0_v03_useeio_groups.py
@@ -24,40 +24,40 @@ from bedrock.utils.validation.analysis.release_v0_3_progression import (
 
 G1_SCHEMA_GHG = ProgressionSheet(
     step_label="G1: USEEIO-like A/margins + Cornerstone schema/GHG",
-    sheet_id="18Nz4dfrv0kvSFo3G1dGrOgM_1HLC9843o4-yrO6m-uM",
+    sheet_id="1AaMWSXaHfyTHWfdNvICQ13RDA-CXEQir5W77RcntQRE",
     config_name="v03_waterfall_useeio_g1_schema_ghg",
     sheet_title=(
-        "[2026-07-09, bedrock repo, 2024, USEEIO based, "
+        "[2026-07-13, bedrock repo, 2024, USEEIO based, "
         "v0.3 / waterfall USEEIO G1 schema/GHG] EFs diagnostics"
     ),
 )
 
 G2_METHODS = ProgressionSheet(
     step_label="G2: Bedrock methods (CEDA A/price, margins, inflation)",
-    sheet_id="1SogCbcLbRAE96R8ymij7B8uueIPYCk8MZIeSI5Km-5E",
+    sheet_id="1ooNKUDndc3mOdBVt0HBFzIk1SNA1OjGTfh-3uJq1iUc",
     config_name="v03_waterfall_g2_methods",
     sheet_title=(
-        "[2026-07-11, bedrock repo, 2024, USEEIO based, "
+        "[2026-07-13, bedrock repo, 2024, USEEIO based, "
         "v0.3 / waterfall G2 methods] EFs diagnostics"
     ),
 )
 
 G3_DATA = ProgressionSheet(
     step_label="G3: Data update (MECS, UMD, 2024 IO/GHG)",
-    sheet_id="1F_v_m5y6o0OYJc1uTeFUn0qPys18s-N9TZmlqu-8SzY",
+    sheet_id="1LXt5cZTsXFKG6l09Hw56zkrxIhnnqwXDxMjMOERrE6c",
     config_name="v03_waterfall_g3_data",
     sheet_title=(
-        "[2026-07-11, bedrock repo, 2024, USEEIO based, "
+        "[2026-07-13, bedrock repo, 2024, USEEIO based, "
         "v0.3 / waterfall G3 data] EFs diagnostics"
     ),
 )
 
 FINAL_V03_USEEIO = ProgressionSheet(
     step_label="FINAL v0.3 (waterfall)",
-    sheet_id="1rWmekEraXOgXx5eEgf3zW86gDzgxh4uqe3Izsq6m_zo",
+    sheet_id="1l4YBYPkcp4jgV7-tOUhVbbWr08zUcm7jR55US_wjwpM",
     config_name="v03_waterfall_final",
     sheet_title=(
-        "[2026-07-11, bedrock repo, 2024, USEEIO based, "
+        "[2026-07-13, bedrock repo, 2024, USEEIO based, "
         "v0.3 / waterfall FINAL v0.3] EFs diagnostics"
     ),
 )


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

Points the USEEIO and CEDA `v03_waterfall_*` group registries at diagnostics sheets redispatched from `main` after #513 (many-to-one industry `x` expand). Sheet titles are dated `2026-07-13`; Drive folder `107RNHx1OUGN6roYdRi3BbdCSrMNFhl6u`.

Registries: `release_v0_v03_useeio_groups.py` (4 sheets), `release_v0_v03_ceda_groups.py` (5 sheets).

## Testing

```powershell
uv run python -m bedrock.analysis.v0_3.plot_ef_v0_v03_useeio_groups
uv run python -m bedrock.analysis.v0_3.plot_ef_v0_v03_ceda_groups

uv run python -m bedrock.utils.validation.analysis.combine_ef_diagnostics `
  --combo v0_to_v03_useeio_groups `
  --output-xlsx bedrock/analysis/v0_3/output/release_v0_v03_groups/ef_diagnostics_merged_v0_to_v03_useeio_groups_useeio.xlsx

uv run python -m bedrock.utils.validation.analysis.combine_ef_diagnostics `
  --combo v0_to_v03_ceda_groups `
  --output-xlsx bedrock/analysis/v0_3/output/release_v0_v03_groups/ef_diagnostics_merged_v0_to_v03_ceda_groups_ceda.xlsx
```