### PR TITLE
adds script to generate `q` needed for ceda figures

### DIFF
--- a/bedrock/analysis/v0_3/README.md
+++ b/bedrock/analysis/v0_3/README.md
@@ -16,11 +16,25 @@ Plot outputs land in `output/release_v0_3/` or `output/release_v0_v03_groups/`
 
 | Script | Purpose |
 |--------|---------|
+| `export_q_v0_3_cornerstone.py` | Export USA `scaled_q_USA` (commodity gross output) to Excel for ceda v0.3 weighted-N waterfalls. |
 | `plot_ef_release_v0_3.py` | Release progression histograms, FINAL v0.2 vs v0.3 overlays, and BLy charts from registered sheets. |
 | `plot_ef_v0_v03_useeio_groups.py` | Stacked G1→G2→G3 wholesale USEEIO progression (sequential + cumulative-vs-pin panels, FINAL overlays, producer). FINAL N overlay flags pinned key sectors. |
 | `plot_ef_v0_v03_ceda_groups.py` | Stacked G1a→G1b→G2→G3 wholesale CEDA progression (sequential + cumulative-vs-v0 panels, FINAL overlays, producer). FINAL N overlay flags pinned key sectors. |
 | `dispatch_ef_release_v0_3.py` | Dispatch v0.3 release steps (MECS through FINAL) to the EF time-series Drive folder; appends to `output/release_v0_3/ef_run_index_release_v0_3.csv`. |
 | `dispatch_ef_v03_waterfall.py` | Dispatch `v03_waterfall_*` group endpoints (USEEIO or CEDA baseline) to the v03 waterfall Drive folder; appends to a baseline-specific run index CSV. |
+
+## Export USA q (for ceda weighted-N)
+
+```powershell
+# Default: bedrock/analysis/v0_3/output/q_v0_3_cornerstone.xlsx
+uv run python -m bedrock.analysis.v0_3.export_q_v0_3_cornerstone
+
+# Drop directly into the ceda assessment output folder
+uv run python -m bedrock.analysis.v0_3.export_q_v0_3_cornerstone `
+    --out ../ceda/projects/v0_3_assessment/output/q_v0_3_cornerstone.xlsx
+```
+
+Uses the current snapshot key (`.SNAPSHOT_KEY`) unless `--snapshot-key` is set.
 
 ## Plot
 

--- a/bedrock/analysis/v0_3/README.md
+++ b/bedrock/analysis/v0_3/README.md
@@ -16,7 +16,7 @@ Plot outputs land in `output/release_v0_3/` or `output/release_v0_v03_groups/`
 
 | Script | Purpose |
 |--------|---------|
-| `export_q_v0_3_cornerstone.py` | Export USA `scaled_q_USA` (commodity gross output) to Excel for ceda v0.3 weighted-N waterfalls. |
+| `export_q_v0_3_cornerstone.py` | Dispatch USA `scaled_q_USA` (commodity gross output) to a Google Sheet for ceda v0.3 weighted-N waterfalls. |
 | `plot_ef_release_v0_3.py` | Release progression histograms, FINAL v0.2 vs v0.3 overlays, and BLy charts from registered sheets. |
 | `plot_ef_v0_v03_useeio_groups.py` | Stacked G1→G2→G3 wholesale USEEIO progression (sequential + cumulative-vs-pin panels, FINAL overlays, producer). FINAL N overlay flags pinned key sectors. |
 | `plot_ef_v0_v03_ceda_groups.py` | Stacked G1a→G1b→G2→G3 wholesale CEDA progression (sequential + cumulative-vs-v0 panels, FINAL overlays, producer). FINAL N overlay flags pinned key sectors. |
@@ -26,15 +26,18 @@ Plot outputs land in `output/release_v0_3/` or `output/release_v0_v03_groups/`
 ## Export USA q (for ceda weighted-N)
 
 ```powershell
-# Default: bedrock/analysis/v0_3/output/q_v0_3_cornerstone.xlsx
+# Default: create/update Google Sheet ``q_v0_3_cornerstone`` in the v0.3
+# waterfall Drive folder (tabs: q, README, optional extra_codes).
 uv run python -m bedrock.analysis.v0_3.export_q_v0_3_cornerstone
 
-# Drop directly into the ceda assessment output folder
+# Override Drive folder or sheet title
 uv run python -m bedrock.analysis.v0_3.export_q_v0_3_cornerstone `
-    --out ../ceda/projects/v0_3_assessment/output/q_v0_3_cornerstone.xlsx
+    --folder-id <DRIVE_FOLDER_ID> --sheet-title q_v0_3_cornerstone
 ```
 
 Uses the current snapshot key (`.SNAPSHOT_KEY`) unless `--snapshot-key` is set.
+Default Drive folder: `V03_WATERFALL_DRIVE_FOLDER_ID` in
+`bedrock.analysis.v0_3.constants`.
 
 ## Plot
 

--- a/bedrock/analysis/v0_3/constants.py
+++ b/bedrock/analysis/v0_3/constants.py
@@ -1,0 +1,7 @@
+"""Shared constants for the v0.3 analysis package."""
+
+from __future__ import annotations
+
+# v0.3 wholesale waterfall diagnostics Drive folder (separate from Step 7 EF
+# time-series). Used by dispatch_ef_v03_waterfall and export_q_v0_3_cornerstone.
+V03_WATERFALL_DRIVE_FOLDER_ID = "107RNHx1OUGN6roYdRi3BbdCSrMNFhl6u"

--- a/bedrock/analysis/v0_3/dispatch_ef_v03_waterfall.py
+++ b/bedrock/analysis/v0_3/dispatch_ef_v03_waterfall.py
@@ -24,6 +24,7 @@ from bedrock.analysis.a_matrix_time_series.dispatch_ef_time_series import (
     _throttle,
     _trigger_workflow,
 )
+from bedrock.analysis.v0_3.constants import V03_WATERFALL_DRIVE_FOLDER_ID
 from bedrock.utils.config.usa_config import _load_usa_config_from_file_name
 from bedrock.utils.validation.analysis.release_v0_v03_ceda_groups import (
     V03_WATERFALL_CEDA_CONFIGS,
@@ -33,9 +34,6 @@ from bedrock.utils.validation.analysis.release_v0_v03_useeio_groups import (
 )
 
 logger = logging.getLogger(__name__)
-
-# v0.3 wholesale waterfall diagnostics (separate from Step 7 EF time-series folder).
-V03_WATERFALL_DRIVE_FOLDER_ID = "107RNHx1OUGN6roYdRi3BbdCSrMNFhl6u"
 
 _OUTPUT_DIR = Path(__file__).resolve().parent / "output" / "release_v0_v03_groups"
 

--- a/bedrock/analysis/v0_3/export_q_v0_3_cornerstone.py
+++ b/bedrock/analysis/v0_3/export_q_v0_3_cornerstone.py
@@ -1,0 +1,150 @@
+"""Export bedrock v0.3 USA commodity gross output (q) to Excel.
+
+Loads snapshot object ``scaled_q_USA`` (commodity ``q`` = V column sums), joins
+Cornerstone commodity metadata, and writes a two-sheet workbook used by the
+ceda v0.3 assessment weighted-N waterfalls.
+
+Typical drop path for ceda figures::
+
+    uv run python -m bedrock.analysis.v0_3.export_q_v0_3_cornerstone \\
+        --out ../ceda/projects/v0_3_assessment/output/q_v0_3_cornerstone.xlsx
+
+Default ``--out`` is this package's gitignored ``output/q_v0_3_cornerstone.xlsx``.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+from bedrock.utils.snapshots.loader import (
+    current_snapshot_key,
+    load_current_snapshot,
+    load_snapshot,
+)
+from bedrock.utils.taxonomy.cornerstone.commodities import COMMODITIES, COMMODITY_DESC
+
+DEFAULT_OUT = Path(__file__).resolve().parent / "output" / "q_v0_3_cornerstone.xlsx"
+DEFAULT_CONFIG = "2025_usa_cornerstone_v0_3"
+DEFAULT_RELEASE = "v0_3_0"
+SNAPSHOT_OBJECT = "scaled_q_USA"
+PUBLISH_LOCATION = "US"
+
+
+def build_q_frame(q: pd.Series) -> tuple[pd.DataFrame, list[str]]:
+    """Align ``q`` to canonical commodity order; return frame + any extra codes."""
+    q = pd.Series(q, name="q")
+    q.index = q.index.astype(str)
+    meta = pd.DataFrame(
+        [
+            {
+                "Code": code,
+                "Code_Loc": f"{code}/{PUBLISH_LOCATION}",
+                "Location": PUBLISH_LOCATION,
+                "Name": COMMODITY_DESC[code],
+                "q": float(q[code]) if code in q.index else float("nan"),
+            }
+            for code in COMMODITIES
+        ]
+    )
+    extra = sorted(set(q.index) - set(COMMODITIES))
+    return meta, extra
+
+
+def export_q_xlsx(
+    out_path: Path,
+    *,
+    snapshot_key: str | None = None,
+    config: str = DEFAULT_CONFIG,
+    release: str = DEFAULT_RELEASE,
+) -> Path:
+    """Write ``q`` + ``README`` sheets; return ``out_path``."""
+    if snapshot_key is None:
+        key = current_snapshot_key()
+        q = load_current_snapshot(SNAPSHOT_OBJECT).squeeze()
+    else:
+        key = snapshot_key
+        q = load_snapshot(SNAPSHOT_OBJECT, key=key).squeeze()
+
+    meta, extra = build_q_frame(q)
+    missing = int(meta["q"].isna().sum())
+    if missing:
+        raise ValueError(
+            f"{missing} commodities missing from {SNAPSHOT_OBJECT} "
+            f"(snapshot_key={key})"
+        )
+
+    out_path = out_path.resolve()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with pd.ExcelWriter(out_path, engine="openpyxl") as writer:
+        meta.to_excel(writer, sheet_name="q", index=False)
+        pd.DataFrame(
+            {
+                "config": [config],
+                "release": [release],
+                "snapshot_key": [key],
+                "snapshot_object": [SNAPSHOT_OBJECT],
+                "n_commodities": [len(meta)],
+                "n_missing_in_q": [missing],
+                "n_extra_in_q": [len(extra)],
+                "units_note": [
+                    "Commodity gross output (q = V column sums), USD"
+                ],
+            }
+        ).to_excel(writer, sheet_name="README", index=False)
+        if extra:
+            pd.DataFrame(
+                {"Code": extra, "q": [float(q[c]) for c in extra]}
+            ).to_excel(writer, sheet_name="extra_codes", index=False)
+
+    return out_path
+
+
+def main(argv: list[str] | None = None) -> None:
+    p = argparse.ArgumentParser(
+        description=(
+            "Export bedrock v0.3 USA scaled_q_USA to Excel for ceda weighted-N "
+            "waterfalls."
+        )
+    )
+    p.add_argument(
+        "--out",
+        type=Path,
+        default=DEFAULT_OUT,
+        help=f"Output xlsx path (default: {DEFAULT_OUT})",
+    )
+    p.add_argument(
+        "--snapshot-key",
+        default=None,
+        help=(
+            "Snapshot SHA to load (default: bedrock.utils.snapshots/.SNAPSHOT_KEY "
+            "via load_current_snapshot)."
+        ),
+    )
+    p.add_argument(
+        "--config",
+        default=DEFAULT_CONFIG,
+        help=f"Provenance config label written to README (default: {DEFAULT_CONFIG})",
+    )
+    p.add_argument(
+        "--release",
+        default=DEFAULT_RELEASE,
+        help=f"Provenance release label written to README (default: {DEFAULT_RELEASE})",
+    )
+    args = p.parse_args(argv)
+
+    out = export_q_xlsx(
+        args.out,
+        snapshot_key=args.snapshot_key,
+        config=args.config,
+        release=args.release,
+    )
+    q_df = pd.read_excel(out, sheet_name="q")
+    print(f"wrote {out}")
+    print(f"n={len(q_df)}  Σq={q_df['q'].sum():.6e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bedrock/analysis/v0_3/export_q_v0_3_cornerstone.py
+++ b/bedrock/analysis/v0_3/export_q_v0_3_cornerstone.py
@@ -1,24 +1,36 @@
-"""Export bedrock v0.3 USA commodity gross output (q) to Excel.
+"""Dispatch bedrock v0.3 USA commodity gross output (q) to a Google Sheet.
 
 Loads snapshot object ``scaled_q_USA`` (commodity ``q`` = V column sums), joins
-Cornerstone commodity metadata, and writes a two-sheet workbook used by the
-ceda v0.3 assessment weighted-N waterfalls.
+Cornerstone commodity metadata, and writes ``q`` / ``README`` tabs (plus
+``extra_codes`` when needed) used by the ceda v0.3 assessment weighted-N
+waterfalls.
 
-Typical drop path for ceda figures::
+By default creates or updates a spreadsheet named ``q_v0_3_cornerstone`` in the
+v0.3 waterfall Drive folder.
+
+Typical usage::
+
+    uv run python -m bedrock.analysis.v0_3.export_q_v0_3_cornerstone
 
     uv run python -m bedrock.analysis.v0_3.export_q_v0_3_cornerstone \\
-        --out ../ceda/projects/v0_3_assessment/output/q_v0_3_cornerstone.xlsx
-
-Default ``--out`` is this package's gitignored ``output/q_v0_3_cornerstone.xlsx``.
+        --folder-id <DRIVE_FOLDER_ID>
 """
 
 from __future__ import annotations
 
 import argparse
-from pathlib import Path
+import logging
 
 import pandas as pd
 
+from bedrock.analysis.v0_3.constants import V03_WATERFALL_DRIVE_FOLDER_ID
+from bedrock.utils.io.gcp import (
+    DRIVE_MIME_SPREADSHEET,
+    create_spreadsheet_in_folder,
+    delete_default_sheet1,
+    list_drive_folder,
+    update_sheet_tab,
+)
 from bedrock.utils.snapshots.loader import (
     current_snapshot_key,
     load_current_snapshot,
@@ -27,11 +39,14 @@ from bedrock.utils.snapshots.loader import (
 from bedrock.utils.snapshots.names import SnapshotName
 from bedrock.utils.taxonomy.cornerstone.commodities import COMMODITIES, COMMODITY_DESC
 
-DEFAULT_OUT = Path(__file__).resolve().parent / "output" / "q_v0_3_cornerstone.xlsx"
+logger = logging.getLogger(__name__)
+
 DEFAULT_CONFIG = "2025_usa_cornerstone_v0_3"
 DEFAULT_RELEASE = "v0_3_0"
+DEFAULT_DRIVE_FOLDER_ID = V03_WATERFALL_DRIVE_FOLDER_ID
 SNAPSHOT_OBJECT: SnapshotName = "scaled_q_USA"
 PUBLISH_LOCATION = "US"
+SHEET_TITLE = "q_v0_3_cornerstone"
 
 
 def _series_from_snapshot(frame: pd.DataFrame) -> pd.Series[float]:
@@ -63,21 +78,65 @@ def build_q_frame(q: pd.Series) -> tuple[pd.DataFrame, list[str]]:
     return meta, extra
 
 
-def export_q_xlsx(
-    out_path: Path,
-    *,
-    snapshot_key: str | None = None,
-    config: str = DEFAULT_CONFIG,
-    release: str = DEFAULT_RELEASE,
-) -> Path:
-    """Write ``q`` + ``README`` sheets; return ``out_path``."""
+def _load_q(snapshot_key: str | None) -> tuple[pd.Series[float], str]:
     if snapshot_key is None:
         key = current_snapshot_key()
         q = _series_from_snapshot(load_current_snapshot(SNAPSHOT_OBJECT))
     else:
         key = snapshot_key
         q = _series_from_snapshot(load_snapshot(SNAPSHOT_OBJECT, key=key))
+    return q, key
 
+
+def _readme_frame(
+    *,
+    config: str,
+    release: str,
+    snapshot_key: str,
+    n_commodities: int,
+    n_missing: int,
+    n_extra: int,
+) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "config": [config],
+            "release": [release],
+            "snapshot_key": [snapshot_key],
+            "snapshot_object": [SNAPSHOT_OBJECT],
+            "n_commodities": [n_commodities],
+            "n_missing_in_q": [n_missing],
+            "n_extra_in_q": [n_extra],
+            "units_note": ["Commodity gross output (q = V column sums), USD"],
+        }
+    )
+
+
+def _resolve_sheet_id(folder_id: str, title: str) -> str:
+    """Return existing spreadsheet id with ``title`` in ``folder_id``, or create one."""
+    matches = [
+        row
+        for row in list_drive_folder(folder_id, mime_type=DRIVE_MIME_SPREADSHEET)
+        if row.get("name") == title
+    ]
+    if matches:
+        sheet_id = matches[0]["id"]
+        logger.info('reusing spreadsheet "%s" (%s)', title, sheet_id)
+        return sheet_id
+    sheet_id = create_spreadsheet_in_folder(title=title, folder_id=folder_id)
+    logger.info('created spreadsheet "%s" (%s)', title, sheet_id)
+    return sheet_id
+
+
+def dispatch_q_sheet(
+    *,
+    folder_id: str = DEFAULT_DRIVE_FOLDER_ID,
+    sheet_title: str = SHEET_TITLE,
+    snapshot_key: str | None = None,
+    config: str = DEFAULT_CONFIG,
+    release: str = DEFAULT_RELEASE,
+) -> str:
+    """Write q / README tabs to a Drive spreadsheet; return sheet id."""
+    q, key = _load_q(snapshot_key)
     meta, extra = build_q_frame(q)
     missing = int(meta["q"].isna().sum())
     if missing:
@@ -86,42 +145,53 @@ def export_q_xlsx(
             f"(snapshot_key={key})"
         )
 
-    out_path = out_path.resolve()
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-    with pd.ExcelWriter(out_path, engine="openpyxl") as writer:
-        meta.to_excel(writer, sheet_name="q", index=False)
-        pd.DataFrame(
-            {
-                "config": [config],
-                "release": [release],
-                "snapshot_key": [key],
-                "snapshot_object": [SNAPSHOT_OBJECT],
-                "n_commodities": [len(meta)],
-                "n_missing_in_q": [missing],
-                "n_extra_in_q": [len(extra)],
-                "units_note": ["Commodity gross output (q = V column sums), USD"],
-            }
-        ).to_excel(writer, sheet_name="README", index=False)
-        if extra:
-            pd.DataFrame({"Code": extra, "q": [float(q[c]) for c in extra]}).to_excel(
-                writer, sheet_name="extra_codes", index=False
-            )
-
-    return out_path
+    sheet_id = _resolve_sheet_id(folder_id, sheet_title)
+    update_sheet_tab(sheet_id, "q", meta, clean_nans=True)
+    update_sheet_tab(
+        sheet_id,
+        "README",
+        _readme_frame(
+            config=config,
+            release=release,
+            snapshot_key=key,
+            n_commodities=len(meta),
+            n_missing=missing,
+            n_extra=len(extra),
+        ),
+    )
+    if extra:
+        update_sheet_tab(
+            sheet_id,
+            "extra_codes",
+            pd.DataFrame({"Code": extra, "q": [float(q[c]) for c in extra]}),
+            clean_nans=True,
+        )
+    try:
+        delete_default_sheet1(sheet_id)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Sheet1 cleanup skipped (%s: %s)", type(e).__name__, e)
+    return sheet_id
 
 
 def main(argv: list[str] | None = None) -> None:
     p = argparse.ArgumentParser(
         description=(
-            "Export bedrock v0.3 USA scaled_q_USA to Excel for ceda weighted-N "
-            "waterfalls."
+            "Dispatch bedrock v0.3 USA scaled_q_USA to a Google Sheet for ceda "
+            "weighted-N waterfalls."
         )
     )
     p.add_argument(
-        "--out",
-        type=Path,
-        default=DEFAULT_OUT,
-        help=f"Output xlsx path (default: {DEFAULT_OUT})",
+        "--folder-id",
+        default=DEFAULT_DRIVE_FOLDER_ID,
+        help=(
+            "Drive folder ID for the spreadsheet "
+            f"(default: v0.3 waterfall folder {DEFAULT_DRIVE_FOLDER_ID})."
+        ),
+    )
+    p.add_argument(
+        "--sheet-title",
+        default=SHEET_TITLE,
+        help=f"Spreadsheet title in Drive (default: {SHEET_TITLE}).",
     )
     p.add_argument(
         "--snapshot-key",
@@ -143,16 +213,17 @@ def main(argv: list[str] | None = None) -> None:
     )
     args = p.parse_args(argv)
 
-    out = export_q_xlsx(
-        args.out,
+    sheet_id = dispatch_q_sheet(
+        folder_id=args.folder_id,
+        sheet_title=args.sheet_title,
         snapshot_key=args.snapshot_key,
         config=args.config,
         release=args.release,
     )
-    q_df = pd.read_excel(out, sheet_name="q")
-    print(f"wrote {out}")
-    print(f"n={len(q_df)}  Σq={q_df['q'].sum():.6e}")
+    print(f"dispatched sheet_id={sheet_id}")
+    print(f"https://docs.google.com/spreadsheets/d/{sheet_id}/edit")
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
     main()

--- a/bedrock/analysis/v0_3/export_q_v0_3_cornerstone.py
+++ b/bedrock/analysis/v0_3/export_q_v0_3_cornerstone.py
@@ -24,13 +24,23 @@ from bedrock.utils.snapshots.loader import (
     load_current_snapshot,
     load_snapshot,
 )
+from bedrock.utils.snapshots.names import SnapshotName
 from bedrock.utils.taxonomy.cornerstone.commodities import COMMODITIES, COMMODITY_DESC
 
 DEFAULT_OUT = Path(__file__).resolve().parent / "output" / "q_v0_3_cornerstone.xlsx"
 DEFAULT_CONFIG = "2025_usa_cornerstone_v0_3"
 DEFAULT_RELEASE = "v0_3_0"
-SNAPSHOT_OBJECT = "scaled_q_USA"
+SNAPSHOT_OBJECT: SnapshotName = "scaled_q_USA"
 PUBLISH_LOCATION = "US"
+
+
+def _series_from_snapshot(frame: pd.DataFrame) -> pd.Series[float]:
+    squeezed = frame.squeeze()
+    if not isinstance(squeezed, pd.Series):
+        raise TypeError(
+            f"Expected Series after squeeze of {SNAPSHOT_OBJECT}, got {type(squeezed)}"
+        )
+    return squeezed.astype(float)
 
 
 def build_q_frame(q: pd.Series) -> tuple[pd.DataFrame, list[str]]:
@@ -63,10 +73,10 @@ def export_q_xlsx(
     """Write ``q`` + ``README`` sheets; return ``out_path``."""
     if snapshot_key is None:
         key = current_snapshot_key()
-        q = load_current_snapshot(SNAPSHOT_OBJECT).squeeze()
+        q = _series_from_snapshot(load_current_snapshot(SNAPSHOT_OBJECT))
     else:
         key = snapshot_key
-        q = load_snapshot(SNAPSHOT_OBJECT, key=key).squeeze()
+        q = _series_from_snapshot(load_snapshot(SNAPSHOT_OBJECT, key=key))
 
     meta, extra = build_q_frame(q)
     missing = int(meta["q"].isna().sum())
@@ -89,15 +99,13 @@ def export_q_xlsx(
                 "n_commodities": [len(meta)],
                 "n_missing_in_q": [missing],
                 "n_extra_in_q": [len(extra)],
-                "units_note": [
-                    "Commodity gross output (q = V column sums), USD"
-                ],
+                "units_note": ["Commodity gross output (q = V column sums), USD"],
             }
         ).to_excel(writer, sheet_name="README", index=False)
         if extra:
-            pd.DataFrame(
-                {"Code": extra, "q": [float(q[c]) for c in extra]}
-            ).to_excel(writer, sheet_name="extra_codes", index=False)
+            pd.DataFrame({"Code": extra, "q": [float(q[c]) for c in extra]}).to_excel(
+                writer, sheet_name="extra_codes", index=False
+            )
 
     return out_path
 


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

This adds the script needed to generate bedrock `q` which is used for the weighted N waterfalls in ceda. ceda will be updated to point to this script upon `FileNotFoundError`.

## Testing

```
uv run python -m bedrock.analysis.v0_3.export_q_v0_3_cornerstone
# optional: --folder-id ... --sheet-title ... --snapshot-key ...
```

