### PR TITLE
Support service-account impersonation in google-login for blocked ADC Drive scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ These flags are grouped into themes:
 |---|---|
 | Schema / taxonomy | `use_cornerstone_2026_model_schema`, `implement_waste_disaggregation`, `implement_electricity_reallocation` |
 | Economic IOT (input-output tables) | `use_E_data_year_for_x_in_B`, `iot_before_or_after_redefinition` |
-| GHG attribution — sector methods | `update_transportation_ghg_method`, `update_electricity_ghg_method` |
-| GHG attribution — gas coverage | `update_flowsa_refrigerant_method`, `add_new_ghg_activities` |
+| GHG attribution | `new_ghg_method`, `update_mecs_method`, `v0_3_umd_2023_ghgia`, `v0_3_umd_2024_ghgia` |
 | Data vintage | `model_base_year`, `usa_base_io_data_year`, `ipcc_ar_version` |
 
 See [`USAConfig`](bedrock/utils/config/usa_config.py) for the full list.
@@ -77,50 +76,7 @@ After cloning the repository, in the root directory:
    ```bash
    ./scripts/google-login
    ```
-   This will open a browser. Log in with your Cornerstone email — if your
-   browser is signed into multiple Google accounts, make sure you pick the
-   Cornerstone one at the consent screen.
-
-   Bedrock needs Application Default Credentials (ADC) with Drive and Sheets
-   scopes (for EF diagnostics sheets on the Cornerstone Drive) in addition to
-   the usual `cloud-platform` scope (for GCS).
-
-   > **Note:** Running a bare `gcloud auth application-default login`
-   > afterwards overwrites these credentials with identity-only scopes, which
-   > causes `HttpError 403 ACCESS_TOKEN_SCOPE_INSUFFICIENT` on Sheets/Drive
-   > calls. Always re-authenticate via `./scripts/google-login`.
-
-   **If the browser shows "Access blocked":** Google is rolling out a block
-   on Drive/Sheets scopes for gcloud's default OAuth client
-   ([docs](https://docs.cloud.google.com/docs/authentication/troubleshoot-adc#access_blocked_when_using_scopes)),
-   so for some accounts the login above fails at the consent screen. The fix
-   is to impersonate the diagnostics service account, which already has
-   access to the EF diagnostics folder on the Cornerstone Drive (it is what
-   CI uses to write the sheets):
-
-   1. Ask a `cornerstone-data` project owner to grant you impersonation
-      rights (one-time):
-
-      ```bash
-      gcloud iam service-accounts add-iam-policy-binding \
-        github-actions-cornerstone@cornerstone-data.iam.gserviceaccount.com \
-        --project=cornerstone-data \
-        --member="user:YOU@cornerstonedata.org" \
-        --role=roles/iam.serviceAccountTokenCreator
-      ```
-
-   2. Log in with impersonation:
-
-      ```bash
-      BEDROCK_IMPERSONATE_SA=github-actions-cornerstone@cornerstone-data.iam.gserviceaccount.com \
-        ./scripts/google-login
-      ```
-
-   In this mode all ADC calls act as the service account: Drive/Sheets
-   diagnostics work, and GCS reads work, but GCS *uploads* will not (the
-   service account is read-only on the bucket). If you need to upload to
-   GCS, re-run `./scripts/google-login` without the variable to switch back
-   to your user credentials.
+   This will open a browser. Log in with your Cornerstone email.
 
 4. **Confirm setup successful:**
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ These flags are grouped into themes:
 |---|---|
 | Schema / taxonomy | `use_cornerstone_2026_model_schema`, `implement_waste_disaggregation`, `implement_electricity_reallocation` |
 | Economic IOT (input-output tables) | `use_E_data_year_for_x_in_B`, `iot_before_or_after_redefinition` |
-| GHG attribution | `new_ghg_method`, `update_mecs_method`, `v0_3_umd_2023_ghgia`, `v0_3_umd_2024_ghgia` |
+| GHG attribution — sector methods | `update_transportation_ghg_method`, `update_electricity_ghg_method` |
+| GHG attribution — gas coverage | `update_flowsa_refrigerant_method`, `add_new_ghg_activities` |
 | Data vintage | `model_base_year`, `usa_base_io_data_year`, `ipcc_ar_version` |
 
 See [`USAConfig`](bedrock/utils/config/usa_config.py) for the full list.
@@ -76,7 +77,50 @@ After cloning the repository, in the root directory:
    ```bash
    ./scripts/google-login
    ```
-   This will open a browser. Log in with your Cornerstone email.
+   This will open a browser. Log in with your Cornerstone email — if your
+   browser is signed into multiple Google accounts, make sure you pick the
+   Cornerstone one at the consent screen.
+
+   Bedrock needs Application Default Credentials (ADC) with Drive and Sheets
+   scopes (for EF diagnostics sheets on the Cornerstone Drive) in addition to
+   the usual `cloud-platform` scope (for GCS).
+
+   > **Note:** Running a bare `gcloud auth application-default login`
+   > afterwards overwrites these credentials with identity-only scopes, which
+   > causes `HttpError 403 ACCESS_TOKEN_SCOPE_INSUFFICIENT` on Sheets/Drive
+   > calls. Always re-authenticate via `./scripts/google-login`.
+
+   **If the browser shows "Access blocked":** Google is rolling out a block
+   on Drive/Sheets scopes for gcloud's default OAuth client
+   ([docs](https://docs.cloud.google.com/docs/authentication/troubleshoot-adc#access_blocked_when_using_scopes)),
+   so for some accounts the login above fails at the consent screen. The fix
+   is to impersonate the diagnostics service account, which already has
+   access to the EF diagnostics folder on the Cornerstone Drive (it is what
+   CI uses to write the sheets):
+
+   1. Ask a `cornerstone-data` project owner to grant you impersonation
+      rights (one-time):
+
+      ```bash
+      gcloud iam service-accounts add-iam-policy-binding \
+        github-actions-cornerstone@cornerstone-data.iam.gserviceaccount.com \
+        --project=cornerstone-data \
+        --member="user:YOU@cornerstonedata.org" \
+        --role=roles/iam.serviceAccountTokenCreator
+      ```
+
+   2. Log in with impersonation:
+
+      ```bash
+      BEDROCK_IMPERSONATE_SA=github-actions-cornerstone@cornerstone-data.iam.gserviceaccount.com \
+        ./scripts/google-login
+      ```
+
+   In this mode all ADC calls act as the service account: Drive/Sheets
+   diagnostics work, and GCS reads work, but GCS *uploads* will not (the
+   service account is read-only on the bucket). If you need to upload to
+   GCS, re-run `./scripts/google-login` without the variable to switch back
+   to your user credentials.
 
 4. **Confirm setup successful:**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ dependencies = [
     "pyyaml>=6.0,<7.0.0",
     "typing-extensions>=4.5.0,<5.0.0",
     # Google Cloud Platform
-    "google-auth>=2.17.0,<3.0.0",
+    # >=2.44.0: fixes TypeError in impersonated ADC refresh (google-auth #1884)
+    "google-auth>=2.44.0,<3.0.0",
     "google-cloud-storage>=2.12.0,<3.0.0",
     "google-api-python-client>=2.102.0,<3.0.0",
     # Utilities

--- a/scripts/google-login
+++ b/scripts/google-login
@@ -24,9 +24,13 @@ SCOPES="openid,https://www.googleapis.com/auth/userinfo.email,https://www.google
 gcloud config set project cornerstone-data
 
 if [[ -n "${BEDROCK_IMPERSONATE_SA:-}" ]]; then
+    # Deliberately no --scopes here: on some gcloud versions the flag leaks the
+    # Drive scope into the (blocked) user consent screen. Bedrock's code applies
+    # Drive/Sheets scopes when minting service-account tokens at runtime
+    # (google.auth.default(scopes=...) in bedrock/utils/io/gcp.py), so the
+    # login only needs default scopes.
     gcloud auth application-default login \
-        --impersonate-service-account="$BEDROCK_IMPERSONATE_SA" \
-        --scopes="$SCOPES"
+        --impersonate-service-account="$BEDROCK_IMPERSONATE_SA"
 else
     gcloud auth application-default login --scopes="$SCOPES"
 fi

--- a/scripts/google-login
+++ b/scripts/google-login
@@ -3,5 +3,30 @@
 # Exit if any command fails
 set -e
 
+# Google is rolling out a block on Drive/Sheets ("sensitive") scopes for
+# gcloud's built-in OAuth client, which makes this login fail for some
+# accounts with an "Access blocked" page in the browser. If that happens to
+# you, the supported path is to impersonate the diagnostics service account
+# (which is already shared on the Cornerstone Drive) instead of holding
+# Drive scopes on your user credentials:
+#
+#   BEDROCK_IMPERSONATE_SA=github-actions-cornerstone@cornerstone-data.iam.gserviceaccount.com \
+#     ./scripts/google-login
+#
+# This requires roles/iam.serviceAccountTokenCreator on that service account
+# (ask a cornerstone-data project owner). See "Authenticate with GCP" in the
+# README for details and trade-offs.
+#
+# Ref: https://docs.cloud.google.com/docs/authentication/troubleshoot-adc#access_blocked_when_using_scopes
+
+SCOPES="openid,https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/drive,https://www.googleapis.com/auth/spreadsheets"
+
 gcloud config set project cornerstone-data
-gcloud auth application-default login --scopes=openid,https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/drive
+
+if [[ -n "${BEDROCK_IMPERSONATE_SA:-}" ]]; then
+    gcloud auth application-default login \
+        --impersonate-service-account="$BEDROCK_IMPERSONATE_SA" \
+        --scopes="$SCOPES"
+else
+    gcloud auth application-default login --scopes="$SCOPES"
+fi

--- a/scripts/google-login
+++ b/scripts/google-login
@@ -3,32 +3,17 @@
 # Exit if any command fails
 set -e
 
-# Google is rolling out a block on Drive/Sheets ("sensitive") scopes for
-# gcloud's built-in OAuth client, which makes this login fail for some
-# accounts with an "Access blocked" page in the browser. If that happens to
-# you, the supported path is to impersonate the diagnostics service account
-# (which is already shared on the Cornerstone Drive) instead of holding
-# Drive scopes on your user credentials:
-#
-#   BEDROCK_IMPERSONATE_SA=github-actions-cornerstone@cornerstone-data.iam.gserviceaccount.com \
-#     ./scripts/google-login
-#
-# This requires roles/iam.serviceAccountTokenCreator on that service account
-# (ask a cornerstone-data project owner). See "Authenticate with GCP" in the
-# README for details and trade-offs.
-#
-# Ref: https://docs.cloud.google.com/docs/authentication/troubleshoot-adc#access_blocked_when_using_scopes
+# If the browser shows "Access blocked" (Google blocks Drive/Sheets scopes on
+# gcloud's default OAuth client), impersonate the diagnostics service account
+# instead (requires roles/iam.serviceAccountTokenCreator on it):
+#   BEDROCK_IMPERSONATE_SA=github-actions-cornerstone@cornerstone-data.iam.gserviceaccount.com ./scripts/google-login
 
 SCOPES="openid,https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/drive,https://www.googleapis.com/auth/spreadsheets"
 
 gcloud config set project cornerstone-data
 
 if [[ -n "${BEDROCK_IMPERSONATE_SA:-}" ]]; then
-    # Deliberately no --scopes here: on some gcloud versions the flag leaks the
-    # Drive scope into the (blocked) user consent screen. Bedrock's code applies
-    # Drive/Sheets scopes when minting service-account tokens at runtime
-    # (google.auth.default(scopes=...) in bedrock/utils/io/gcp.py), so the
-    # login only needs default scopes.
+    # No --scopes here: Drive/Sheets scopes are applied at token time by the code.
     gcloud auth application-default login \
         --impersonate-service-account="$BEDROCK_IMPERSONATE_SA"
 else

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.11.*"
 
 [[package]]
@@ -189,7 +189,7 @@ requires-dist = [
     { name = "esupy", git = "https://github.com/USEPA/esupy.git" },
     { name = "fedelemflowlist", git = "https://github.com/FLCAC-admin/fedelemflowlist.git" },
     { name = "google-api-python-client", specifier = ">=2.102.0,<3.0.0" },
-    { name = "google-auth", specifier = ">=2.17.0,<3.0.0" },
+    { name = "google-auth", specifier = ">=2.44.0,<3.0.0" },
     { name = "google-cloud-storage", specifier = ">=2.12.0,<3.0.0" },
     { name = "matplotlib", specifier = ">=3.10.6" },
     { name = "numpy", specifier = ">=2.2.6,<3.0.0" },
@@ -288,15 +288,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/35/c1/8c4c199ae1663feee579a15861e34f10b29da11ae6ea0ad7b6a847ef3823/botocore-1.40.70.tar.gz", hash = "sha256:61b1f2cecd54d1b28a081116fa113b97bf4e17da57c62ae2c2751fe4c528af1f", size = 14444592, upload-time = "2025-11-10T20:29:04.046Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/55/d2/507fd0ee4dd574d2bdbdeac5df83f39d2cae1ffe97d4622cca6f6bab39f1/botocore-1.40.70-py3-none-any.whl", hash = "sha256:4a394ad25f5d9f1ef0bed610365744523eeb5c22de6862ab25d8c93f9f6d295c", size = 14106829, upload-time = "2025-11-10T20:29:01.101Z" },
-]
-
-[[package]]
-name = "cachetools"
-version = "6.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cc/7e/b975b5814bd36faf009faebe22c1072a1fa1168db34d285ef0ba071ad78c/cachetools-6.2.1.tar.gz", hash = "sha256:3f391e4bd8f8bf0931169baf7456cc822705f4e2a31f840d218f445b9a854201", size = 31325, upload-time = "2025-10-12T14:55:30.139Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/c5/1e741d26306c42e2bf6ab740b2202872727e0f606033c9dd713f8b93f5a8/cachetools-6.2.1-py3-none-any.whl", hash = "sha256:09868944b6dde876dfd44e1d47e18484541eaf12f26f29b7af91b26cc892d701", size = 11280, upload-time = "2025-10-12T14:55:28.382Z" },
 ]
 
 [[package]]
@@ -457,6 +448,49 @@ wheels = [
 [package.optional-dependencies]
 toml = [
     { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
+[[package]]
+name = "cryptography"
+version = "49.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d3/4a83af35d65e3fad632c926fad684c193ea4398569ccb0bbbc7fe8f5dc9a/cryptography-49.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc1e275c2f1d97b1a6450b8b0ea3ebfa6e087a611c2b26cb2404d48588abab7b", size = 3993685, upload-time = "2026-06-12T20:02:14.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a7/f9dac0ab7f80368c56993a7bf638ef9935f825c91902798481fac0898138/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c83782480a4a9da4d0feb51950131ba32e12e70813848b3343f6e18c28a66838", size = 4676239, upload-time = "2026-06-12T20:02:28.793Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/70/2ba3769dd0ae167e2f33dfa9592d45db6ff9a61d62ca1a5b3d1bdd09068f/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:b39efa323140595abd3ecca8529d321ae50f55f3aa3ba9cc81ea56a6011953d5", size = 4715584, upload-time = "2026-06-12T20:01:27.495Z" },
+    { url = "https://files.pythonhosted.org/packages/94/64/2923570ac1c0bd3a737aa366ac3abbbbde273042308b8cde95e2364a6e6a/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:b47db11c2c3525083296069b98ac5221907455e989ae0c2e3008bde851921615", size = 4675885, upload-time = "2026-06-12T20:01:55.49Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f8/614dc7e051418cfe53d55173c1e24c6b0085e89996fe90508c2fdf769aef/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:084ef1af862eb07ec46d25f68689f2102a9fc0e05ce7b80f14f5fe51e4eef0f6", size = 4715449, upload-time = "2026-06-12T20:02:05.469Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/50/a9caea39ad19c431c1a3f8a31114df65b260cdfe67786b6c7e7c040c4c44/cryptography-49.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:be9fcb48a55f023493482827d4f459bd263cc20efde64f204b97c123201850c6", size = 3783731, upload-time = "2026-06-12T20:02:43.319Z" },
 ]
 
 [[package]]
@@ -646,16 +680,15 @@ wheels = [
 
 [[package]]
 name = "google-auth"
-version = "2.43.0"
+version = "2.56.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cachetools" },
+    { name = "cryptography" },
     { name = "pyasn1-modules" },
-    { name = "rsa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/ef/66d14cf0e01b08d2d51ffc3c20410c4e134a1548fc246a6081eae585a4fe/google_auth-2.43.0.tar.gz", hash = "sha256:88228eee5fc21b62a1b5fe773ca15e67778cb07dc8363adcb4a8827b52d81483", size = 296359, upload-time = "2025-11-06T00:13:36.587Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/33/dbc946a407401b975f0719658f18e664ece2109f79ffd1ff3bf226c205f4/google_auth-2.56.2.tar.gz", hash = "sha256:e28f103ca8091fb7012b99c44243d7366c29863713b8e34a220c3322b7a07051", size = 365820, upload-time = "2026-07-21T21:53:28.188Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/d1/385110a9ae86d91cc14c5282c61fe9f4dc41c0b9f7d423c6ad77038c4448/google_auth-2.43.0-py2.py3-none-any.whl", hash = "sha256:af628ba6fa493f75c7e9dbe9373d148ca9f4399b5ea29976519e0a3848eddd16", size = 223114, upload-time = "2025-11-06T00:13:35.209Z" },
+    { url = "https://files.pythonhosted.org/packages/88/63/50636aae68c9bf17c891c7eb18b49baa9bd6b31d2a97b8de4813a9fc8d1c/google_auth-2.56.2-py3-none-any.whl", hash = "sha256:c8270ea95b2697b74e3d8438ae9c5b898e38b623b915c7b5c5635921e7de68a6", size = 258588, upload-time = "2026-07-21T21:53:26.399Z" },
 ]
 
 [[package]]
@@ -2194,18 +2227,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/f9/ce43dbe62767432273ed2584cef71fef8411bddfb64125d4c19128015018/rpds_py-0.28.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:6aa1bfce3f83baf00d9c5fcdbba93a3ab79958b4c7d7d1f55e7fe68c20e63912", size = 561530, upload-time = "2025-10-22T22:24:22.958Z" },
     { url = "https://files.pythonhosted.org/packages/46/c9/ffe77999ed8f81e30713dd38fd9ecaa161f28ec48bb80fa1cd9118399c27/rpds_py-0.28.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:7b0f9dceb221792b3ee6acb5438eb1f02b0cb2c247796a72b016dcc92c6de829", size = 585453, upload-time = "2025-10-22T22:24:24.779Z" },
     { url = "https://files.pythonhosted.org/packages/ed/d2/4a73b18821fd4669762c855fd1f4e80ceb66fb72d71162d14da58444a763/rpds_py-0.28.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:5d0145edba8abd3db0ab22b5300c99dc152f5c9021fab861be0f0544dc3cbc5f", size = 552199, upload-time = "2025-10-22T22:24:26.54Z" },
-]
-
-[[package]]
-name = "rsa"
-version = "4.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
cc: @jvendries
Closes:

## What changed? Why?

Google is rolling out a block on Drive/Sheets ("sensitive") scopes for gcloud's **default** OAuth client ([docs](https://docs.cloud.google.com/docs/authentication/troubleshoot-adc#access_blocked_when_using_scopes)). For accounts where enforcement has landed, `./scripts/google-login` fails at the browser consent screen with "Access blocked" — re-picking accounts or re-running with different scopes cannot fix it. gcloud's own warning names the remedies: "you must provide your own client ID **or use service account impersonation**."

- `scripts/google-login`: plain login unchanged as the default; adds an opt-in impersonation mode:

  ```bash
  BEDROCK_IMPERSONATE_SA=github-actions-cornerstone@cornerstone-data.iam.gserviceaccount.com \
    ./scripts/google-login
  ```

  Drive/Sheets scopes ride on short-lived tokens minted for the diagnostics service account (the same identity CI uses to write EF diagnostics sheets, already shared on the Cornerstone Drive), so the blocked consent screen never appears — the user consent requests only `cloud-platform`. Requires a one-time `roles/iam.serviceAccountTokenCreator` grant on the service account (project owners can add people with one command).

- `pyproject.toml` / `uv.lock`: bump google-auth floor to `>=2.44.0`. The previously locked 2.43.0 has a bug in impersonated-credential refresh (`TypeError: 'str' object is not callable`, [google-auth #1884](https://github.com/googleapis/google-auth-library-python/issues/1884)), fixed upstream in 2.44.0. Plain user-credential ADC never hits this code path, which is why 2.43.0 worked fine until now.

- Also adds the `spreadsheets` scope to the plain login.

## Testing

- End-to-end from a real workstation: impersonated login (consent URL confirmed to request only `cloud-platform`), Drive folder listing, and blank-sheet creation in the EF diagnostics folder via `bedrock.utils.io.gcp`.
- A/B on the google-auth bump with identical code and credentials: 2.43.0 reproduces the impersonated-refresh `TypeError`; the relocked version works.
- `bash -n scripts/google-login`.