### PR TITLE
add support function to add SectorConsumedBy in NIPA FBS

### DIFF
--- a/bedrock/transform/common/Cornerstone_2025_target.yaml
+++ b/bedrock/transform/common/Cornerstone_2025_target.yaml
@@ -41,12 +41,13 @@ industry_spec:
             'GSLGE',   'GSLGH',   'GSLGO', 'S00102', 'S00203', 'S00500', 'S00600',
             # Housing sectors
             '531HST', '531HSO', '531ORE',
-            # BEA final-demand codes (NIPA_FD_* methods select on these exactly via
-            # BEA_Detail_Use_SUT's ActivityConsumedBy; without a NAICS_6 entry they
-            # fall through to the 'default' NAICS_3 level, which for this code family
-            # only resolves as short as 4 characters (e.g. F02R00 -> F02R) since no
-            # true 3-digit parent is registered for them in NAICS_2017_Crosswalk.csv)
-            'F02N00', 'F02R00', 'F02S00',
+            # BEA final-demand codes - NIPA_FD_* methods select on these exactly via
+            # BEA_Detail_Use_SUT's ActivityConsumedBy, and/or assign them directly to
+            # SectorConsumedBy post-attribution (issue #539); without a NAICS_6 entry
+            # they fall through to the 'default' NAICS_3 level, which for this code
+            # family only resolves as short as 4 characters (e.g. F02R00 -> F02R)
+            # since no true 3-digit parent is registered in NAICS_2017_Crosswalk.csv
+            'F02E00', 'F02N00', 'F02R00', 'F02S00',
             'F06C00', 'F06E00', 'F06N00', 'F06S00',
             'F07C00', 'F07E00', 'F07N00', 'F07S00',
             'F10C00', 'F10E00', 'F10N00', 'F10S00',

--- a/bedrock/transform/eeio/nowcast.py
+++ b/bedrock/transform/eeio/nowcast.py
@@ -45,7 +45,10 @@ from bedrock.transform.flowbysector import FlowBySector
 from bedrock.utils.config.usa_config import get_usa_config
 from bedrock.utils.taxonomy.bea.v2017_final_demand import BEA_2017_FINAL_DEMAND_CODES
 
-_SECTOR_SWAP = {'SectorProducedBy': 'SectorConsumedBy', 'SectorConsumedBy': 'SectorProducedBy'}
+_SECTOR_SWAP = {
+    'SectorProducedBy': 'SectorConsumedBy',
+    'SectorConsumedBy': 'SectorProducedBy',
+}
 
 
 @contextmanager

--- a/bedrock/transform/eeio/nowcast.py
+++ b/bedrock/transform/eeio/nowcast.py
@@ -10,101 +10,71 @@ Use table, in purchaser (PUR) price, shaped like BEA's ``BEA_2017_Detail``
 schema (commodity x ``BEA_2017_FINAL_DEMAND_CODE``). Source: the
 ``NIPA_FD_<year>`` FBS methods (``bedrock/transform/nipa/NIPA_FD_<year>.yaml``).
 
-Why not just call ``FlowBySector.generateFlowBySector('NIPA_FD_<year>')`` and
-pivot the result? The standard FBS pipeline aggregates every activity_set's
-contribution into one schema-conforming table before returning - the
-``SourceName``/activity_set identity that would tell us which official BEA
-final-demand code (e.g. ``F06S00``) a row belongs to does not survive that
-aggregation (``ActivityConsumedBy`` is dropped, and for most activity_sets here
-it's just a human-readable label like "Federal Government Defense Investment
-in Structures" even before that, not the code itself). So instead we replicate
-the same per-activity_set splitting the framework does internally
-(``FlowByActivity.prepare_fbs``'s ``activity_sets`` branch) ourselves, tag each
-activity_set's own result with its final-demand code from
-``ACTIVITY_SET_TO_FINAL_DEMAND_CODE`` (built directly off the yaml, since we
-control both), and assemble the wide matrix ourselves.
+Each ``NIPA_FD_<year>.yaml`` activity_set assigns its official BEA
+final-demand code directly to ``SectorConsumedBy`` via a
+``clean_fbs_after_aggregation`` hook
+(``bedrock.transform.flowbyclean.assign_sector_consumed_by_from_clean_parameter``,
+issue #539), so a plain ``generateFlowBySector`` call is enough here - no
+per-activity_set replication needed.
+
+``Cornerstone_2025_target.yaml``'s ``industry_spec`` (``default: NAICS_3``)
+collapses most commodities not explicitly listed in its NAICS_4/5/6 override
+lists down to a bare 3-digit NAICS parent that isn't a real BEA_2017_Detail
+code (e.g. ``1112``, ``236`` - confirmed against ``USA_2017_COMMODITY_CODES``:
+77% of rows / 86% of dollar value in the 2017 output). Other Cornerstone
+models hit the same thing and fix it the same way: generate the FBS, then
+call ``map_fbs_sectors_to_model_schema`` (``bedrock/transform/allocation/
+derived.py``, e.g. the GHG pipeline's ``derived.py:404``) to expand+reallocate
+each collapsed code back to a real NAICS_6/Cornerstone activity code. That
+function is hardcoded to operate on ``SectorProducedBy``; ``SectorConsumedBy``
+is resolved too via a temporary column swap, so both sides go through the
+same correction consistently (a no-op for the final-demand codes there, since
+they're not in the NAICS/Cornerstone crosswalks it consults).
 """
 
 from __future__ import annotations
 
 import functools
+from collections.abc import Generator
+from contextlib import contextmanager
 
 import pandas as pd
 
-from bedrock.extract.flowbyactivity import FlowByActivity
-from bedrock.transform.flowby import get_flowby_from_config
-from bedrock.utils.config.common import get_catalog_info, load_yaml_dict
+from bedrock.transform.allocation.derived import map_fbs_sectors_to_model_schema
+from bedrock.transform.flowbysector import FlowBySector
+from bedrock.utils.config.usa_config import get_usa_config
 from bedrock.utils.taxonomy.bea.v2017_final_demand import BEA_2017_FINAL_DEMAND_CODES
 
-# Maps each NIPA_FD_<year>.yaml activity_set name to its official BEA
-# final-demand code. Several activity_sets share a code (e.g. all 6 FD_PCE*
-# activity_sets -> F01000); their contributions are summed. Built directly off
-# NIPA_FD_2017.yaml as of 2026-07-23 - keep in sync if activity_sets are
-# renamed, added, or removed there.
-ACTIVITY_SET_TO_FINAL_DEMAND_CODE: dict[str, str] = {
-    'FD_PCE': 'F01000',
-    'FD_PCE_tenant_landlord_durables': 'F01000',
-    'FD_PCE_sporting_equipment': 'F01000',
-    'FD_PCE_musical_instruments': 'F01000',
-    'FD_PCE_recreational_books': 'F01000',
-    'FD_PCE_luggage': 'F01000',
-    'FD_IP_equipment': 'F02E00',
-    'FD_IP_direct': 'F02N00',
-    'FD_IP_proportional': 'F02N00',
-    'FD_Structures1': 'F02R00',
-    'FD_Structures2': 'F02S00',
-    'FD_Structures2_used': 'F02S00',
-    'FD_Gov_FedD_CE': 'F06C00',
-    'FD_Gov_FedD_Equipment': 'F06E00',
-    'FD_Gov_FedD_IP': 'F06N00',
-    'FD_Gov_FedD_Structures': 'F06S00',
-    'FD_Gov_FedND_CE': 'F07C00',
-    'FD_Gov_FedND_Equipment': 'F07E00',
-    'FD_Gov_FedND_IP': 'F07N00',
-    'FD_Gov_FedND_Structures': 'F07S00',
-    'FD_Gov_SLG_CE': 'F10C00',
-    'FD_Gov_SLG_Equipment': 'F10E00',
-    'FD_Gov_SLG_IP': 'F10N00',
-    'FD_Gov_SLG_Structures': 'F10S00',
-    # Not yet built - see issues #526 (exports/imports) and #529 (inventories).
-    # 'F03000': change in private inventories
-    # 'F04000': exports of goods and services
-    # 'F05000': imports of goods and services
-}
+_SECTOR_SWAP = {'SectorProducedBy': 'SectorConsumedBy', 'SectorConsumedBy': 'SectorProducedBy'}
 
 
-def _nipa_fd_activity_sets(
-    year: int, download_sources_ok: bool = False
-) -> list[FlowByActivity]:
+@contextmanager
+def _force_cornerstone_model_schema() -> Generator[None, None, None]:
     """
-    Per-activity_set FlowByActivity children for ``NIPA_FD_<year>``, each still
-    tagged with its originating activity_set name (via ``.full_name``) - the
-    identity that's lost once the standard FlowBySector pipeline aggregates
-    everything into one schema-conforming table. Mirrors what
-    ``FlowByActivity.prepare_fbs()``'s ``activity_sets`` branch does internally.
+    ``map_fbs_sectors_to_model_schema`` branches on
+    ``get_usa_config().use_cornerstone_2026_model_schema`` (default False) to
+    pick the Cornerstone_2025 vs. CEDA_2025 crosswalk. Temporarily forces it
+    True on the live global config (rather than swapping to a whole different
+    named config via ``temp_usa_config``, which would also reset unrelated
+    fields like ``model_base_year``) and restores the prior value after.
     """
-    method_config = load_yaml_dict(f'NIPA_FD_{year}', 'FBS')
-    method_config.pop('sources_to_cache', None)
-    method_config['cache'] = {}
-    sources = method_config.pop('source_names')
-    ((source_name, config),) = sources.items()  # BEA_NIPA is the only source
-    full_config = {
-        **method_config,
-        'method_config_keys': set(method_config.keys()),
-        **get_catalog_info(source_name),
-        **config,
-    }
-    fba = get_flowby_from_config(
-        name=source_name, config=full_config, download_sources_ok=download_sources_ok
-    )
-    assert isinstance(
-        fba, FlowByActivity
-    ), f'Expected BEA_NIPA to load as FlowByActivity, got {type(fba)}'
-    return (
-        fba.select_by_fields()
-        .function_socket('clean_fba_before_activity_sets')
-        .activity_sets()
-    )
+    cfg = get_usa_config()
+    previous = cfg.use_cornerstone_2026_model_schema
+    cfg.use_cornerstone_2026_model_schema = True
+    try:
+        yield
+    finally:
+        cfg.use_cornerstone_2026_model_schema = previous
+
+
+def _resolve_both_sector_columns(fbs: pd.DataFrame) -> pd.DataFrame:
+    """Apply ``map_fbs_sectors_to_model_schema`` to both SectorProducedBy and
+    SectorConsumedBy (via a temporary swap - see module docstring)."""
+    with _force_cornerstone_model_schema():
+        fbs = map_fbs_sectors_to_model_schema(fbs.rename(columns=_SECTOR_SWAP)).rename(
+            columns=_SECTOR_SWAP
+        )
+        return map_fbs_sectors_to_model_schema(fbs)
 
 
 @functools.cache
@@ -112,35 +82,22 @@ def derive_initial_Y_pur(year: int, download_sources_ok: bool = False) -> pd.Dat
     """
     Initial (pre-RAS-balanced) final-demand section of the Use table, purchaser
     price, BEA_2017_Detail schema (commodity x BEA_2017_FINAL_DEMAND_CODE).
-    Built from ``NIPA_FD_<year>`` FBS output, one activity_set at a time - see
-    module docstring for why.
 
     Columns not yet sourced (F03000 change in private inventories, F04000
     exports, F05000 imports - see issues #529 and #526) are present but
     all-zero.
     """
-    contributions: dict[str, pd.Series] = {}
-    for child in _nipa_fd_activity_sets(year, download_sources_ok):
-        activity_set = child.full_name.rsplit('.', 1)[-1]
-        code = ACTIVITY_SET_TO_FINAL_DEMAND_CODE.get(activity_set)
-        if code is None:
-            raise KeyError(
-                f'Activity set {activity_set!r} (from NIPA_FD_{year}.yaml) has no '
-                'entry in ACTIVITY_SET_TO_FINAL_DEMAND_CODE - add one before using '
-                'it here.'
-            )
-        fbs = child.prepare_fbs(download_sources_ok=download_sources_ok)
-        series = fbs.groupby('SectorProducedBy')['FlowAmount'].sum()
-        contributions[code] = (
-            contributions[code].add(series, fill_value=0)
-            if code in contributions
-            else series
-        )
-
-    y = pd.DataFrame(contributions).reindex(
-        columns=BEA_2017_FINAL_DEMAND_CODES, fill_value=0.0
+    fbs = FlowBySector.generateFlowBySector(
+        f'NIPA_FD_{year}', download_sources_ok=download_sources_ok
     )
-    y = y.fillna(0.0).sort_index()
+    resolved = _resolve_both_sector_columns(pd.DataFrame(fbs))
+    y = (
+        resolved.groupby(['SectorProducedBy', 'SectorConsumedBy'])['FlowAmount']
+        .sum()
+        .unstack('SectorConsumedBy', fill_value=0)
+        .reindex(columns=BEA_2017_FINAL_DEMAND_CODES, fill_value=0.0)
+        .sort_index()
+    )
     y.index.name = 'commodity'
     y.columns.name = 'final_demand_code'
     return y

--- a/bedrock/transform/flowbyclean.py
+++ b/bedrock/transform/flowbyclean.py
@@ -500,6 +500,38 @@ def calculate_flow_per_person(
     return fbs
 
 
+def assign_sector_consumed_by_from_clean_parameter(
+    fbs: FlowBySector, **_: Any
+) -> FlowBySector:
+    """
+    Assigns ``SectorConsumedBy`` directly from ``clean_parameter`` (issue
+    #539). Intended as a ``clean_fbs_after_aggregation`` fxn: e.g. each
+    ``NIPA_FD_<year>.yaml`` activity_set targets exactly one official BEA
+    final-demand code (e.g. ``F06S00``, passed as that activity_set's
+    ``clean_parameter``), which this assigns to every row of the fully
+    attributed/aggregated FBS.
+
+    This has to happen *after* attribution rather than via a crosswalk entry
+    for ``ActivityConsumedBy`` (as an earlier NIPA_FD attempt did): sources
+    like BEA_NIPA are ``FlowType='TECHNOSPHERE_FLOW'``, and
+    ``add_primary_secondary_columns()`` prioritizes ``...ConsumedBy`` over
+    ``...ProducedBy`` for that flow type, so populating ``SectorConsumedBy``
+    *before* attribution would make ``PrimarySector`` resolve to the
+    final-demand code instead of the real commodity (``SectorProducedBy``) -
+    silently corrupting proportional attribution against a commodity-level
+    attribution source. Assigning it only after attribution/aggregation is
+    complete (via this ``clean_fbs_after_aggregation`` hook) sidesteps that
+    entirely.
+    """
+    code = fbs.config.get('clean_parameter')
+    if code is None:
+        raise ValueError(
+            'clean_parameter (the target SectorConsumedBy value) is required '
+            'in config to use assign_sector_consumed_by_from_clean_parameter'
+        )
+    return fbs.assign(SectorConsumedBy=code)
+
+
 def define_parentincompletechild_descendants(
     fba: FlowByActivity, activity_col: str = 'ActivityConsumedBy', **_: Any
 ) -> FlowByActivity:

--- a/bedrock/transform/nipa/NIPA_FD_2017.yaml
+++ b/bedrock/transform/nipa/NIPA_FD_2017.yaml
@@ -26,6 +26,14 @@ source_names:
 
       FD_PCE:
         activity_to_sector_mapping: BEA_NIPA_FD_PCE
+        # Issue #539: assign the official BEA final-demand code to SectorConsumedBy
+        # only after attribution/aggregation is complete - see
+        # assign_sector_consumed_by_from_clean_parameter's docstring (in
+        # bedrock/transform/flowbyclean.py) for why it can't be done any earlier
+        # (would corrupt PrimarySector resolution during attribution, since
+        # BEA_NIPA is a TECHNOSPHERE_FLOW source).
+        clean_parameter: F01000
+        clean_fbs_after_aggregation: !clean_function:flowbyclean assign_sector_consumed_by_from_clean_parameter
         selection_fields:
           Table: U20405 # Table 2.4.5U. Personal Consumption Expenditures by Type of Product
         exclusion_fields:
@@ -54,6 +62,8 @@ source_names:
         # NIPA "Tenant-occupied, including landlord durables" has no PCEBridge counterpart
         # by name; PCEBridge's equivalent leaf category is "Tenant landlord durables".
         activity_to_sector_mapping: BEA_NIPA_FD_PCE
+        clean_parameter: F01000
+        clean_fbs_after_aggregation: !clean_function:flowbyclean assign_sector_consumed_by_from_clean_parameter
         selection_fields:
           Table: U20405 # Table 2.4.5U. Personal Consumption Expenditures by Type of Product
           Line: 159 # "Tenant-occupied, including landlord durables"; Line uniquely selects this row
@@ -76,6 +86,8 @@ source_names:
 
       FD_PCE_sporting_equipment:
         activity_to_sector_mapping: BEA_NIPA_FD_PCE
+        clean_parameter: F01000
+        clean_fbs_after_aggregation: !clean_function:flowbyclean assign_sector_consumed_by_from_clean_parameter
         selection_fields:
           Table: U20405 # Table 2.4.5U. Personal Consumption Expenditures by Type of Product
           Line: 52 # "Sporting equipment, supplies, guns, and ammunition (part of 80)"
@@ -90,6 +102,8 @@ source_names:
 
       FD_PCE_musical_instruments:
         activity_to_sector_mapping: BEA_NIPA_FD_PCE
+        clean_parameter: F01000
+        clean_fbs_after_aggregation: !clean_function:flowbyclean assign_sector_consumed_by_from_clean_parameter
         selection_fields:
           Table: U20405 # Table 2.4.5U. Personal Consumption Expenditures by Type of Product
           Line: 61 # "Musical instruments (part of 80)"
@@ -104,6 +118,8 @@ source_names:
 
       FD_PCE_recreational_books:
         activity_to_sector_mapping: BEA_NIPA_FD_PCE
+        clean_parameter: F01000
+        clean_fbs_after_aggregation: !clean_function:flowbyclean assign_sector_consumed_by_from_clean_parameter
         selection_fields:
           Table: U20405 # Table 2.4.5U. Personal Consumption Expenditures by Type of Product
           Line: 60 # "Recreational books (part of 90)"
@@ -118,6 +134,8 @@ source_names:
 
       FD_PCE_luggage:
         activity_to_sector_mapping: BEA_NIPA_FD_PCE
+        clean_parameter: F01000
+        clean_fbs_after_aggregation: !clean_function:flowbyclean assign_sector_consumed_by_from_clean_parameter
         selection_fields:
           Table: U20405 # Table 2.4.5U. Personal Consumption Expenditures by Type of Product
           Line: 70 # "Luggage and similar personal items (part of 119)"
@@ -139,6 +157,8 @@ source_names:
         # match a PEQBridge category by name. Reconciles to within 0.22% of the
         # table's own Line-1 total ("Private fixed investment in equipment").
         activity_to_sector_mapping: BEA_NIPA_FD_Equipment
+        clean_parameter: F02E00
+        clean_fbs_after_aggregation: !clean_function:flowbyclean assign_sector_consumed_by_from_clean_parameter
         selection_fields:
           Table: U50505 # Table 5.5.5U. Private Fixed Investment in Equipment by Type
         attribution_method: proportional
@@ -150,6 +170,8 @@ source_names:
 
       FD_IP_direct:
         activity_to_sector_mapping: BEA_NIPA_FD_IP
+        clean_parameter: F02N00
+        clean_fbs_after_aggregation: !clean_function:flowbyclean assign_sector_consumed_by_from_clean_parameter
         selection_fields:
           Table: T50605 # Table 5.6.5. Private Fixed Investment in Intellectual Property Products by Type
           ActivityProducedBy:
@@ -160,6 +182,8 @@ source_names:
 
       FD_IP_proportional:
         activity_to_sector_mapping: BEA_NIPA_FD_IP
+        clean_parameter: F02N00
+        clean_fbs_after_aggregation: !clean_function:flowbyclean assign_sector_consumed_by_from_clean_parameter
         selection_fields:
           Table: T50605 # Table 5.6.5. Private Fixed Investment in Intellectual Property Products by Type
         exclusion_fields:
@@ -176,6 +200,8 @@ source_names:
 
       FD_Gov_FedD_CE:
         activity_to_sector_mapping: BEA_NIPA_FD_Gov
+        clean_parameter: F06C00
+        clean_fbs_after_aggregation: !clean_function:flowbyclean assign_sector_consumed_by_from_clean_parameter
         selection_fields:
           Table: T30905 # Table 3.9.5. Government Consumption Expenditures and Gross Investment
           Line: 18 # "Consumption expenditures"; Line uniquely selects this row (also at lines 2, 26)
@@ -191,6 +217,8 @@ source_names:
 
       FD_Gov_FedD_Equipment:
         activity_to_sector_mapping: BEA_NIPA_FD_Gov
+        clean_parameter: F06E00
+        clean_fbs_after_aggregation: !clean_function:flowbyclean assign_sector_consumed_by_from_clean_parameter
         selection_fields:
           Table: T30905 # Table 3.9.5. Government Consumption Expenditures and Gross Investment
           ActivityProducedBy:
@@ -207,6 +235,8 @@ source_names:
 
       FD_Gov_FedD_IP:
         activity_to_sector_mapping: BEA_NIPA_FD_Gov
+        clean_parameter: F06N00
+        clean_fbs_after_aggregation: !clean_function:flowbyclean assign_sector_consumed_by_from_clean_parameter
         selection_fields:
           Table: T30905 # Table 3.9.5. Government Consumption Expenditures and Gross Investment
           ActivityProducedBy:
@@ -224,6 +254,8 @@ source_names:
 
       FD_Gov_FedD_Structures:
         activity_to_sector_mapping: BEA_NIPA_FD_Gov
+        clean_parameter: F06S00
+        clean_fbs_after_aggregation: !clean_function:flowbyclean assign_sector_consumed_by_from_clean_parameter
         selection_fields:
           Table: T30905 # Table 3.9.5. Government Consumption Expenditures and Gross Investment
           Line: 20 # "Structures"; Line uniquely selects this row (also at lines 4, 12, 28, 36)
@@ -239,6 +271,8 @@ source_names:
 
       FD_Gov_FedND_CE:
         activity_to_sector_mapping: BEA_NIPA_FD_Gov
+        clean_parameter: F07C00
+        clean_fbs_after_aggregation: !clean_function:flowbyclean assign_sector_consumed_by_from_clean_parameter
         selection_fields:
           Table: T30905 # Table 3.9.5. Government Consumption Expenditures and Gross Investment
           Line: 26 # "Consumption expenditures"; Line uniquely selects this row (also at lines 2, 18)
@@ -254,6 +288,8 @@ source_names:
 
       FD_Gov_FedND_Structures:
         activity_to_sector_mapping: BEA_NIPA_FD_Gov
+        clean_parameter: F07S00
+        clean_fbs_after_aggregation: !clean_function:flowbyclean assign_sector_consumed_by_from_clean_parameter
         selection_fields:
           Table: T30905 # Table 3.9.5. Government Consumption Expenditures and Gross Investment
           Line: 28 # "Structures"; Line uniquely selects this row (also at lines 4, 12, 20, 36)
@@ -269,6 +305,8 @@ source_names:
 
       FD_Gov_FedND_Equipment:
         activity_to_sector_mapping: BEA_NIPA_FD_Gov
+        clean_parameter: F07E00
+        clean_fbs_after_aggregation: !clean_function:flowbyclean assign_sector_consumed_by_from_clean_parameter
         selection_fields:
           Table: T30905 # Table 3.9.5. Government Consumption Expenditures and Gross Investment
           ActivityProducedBy:
@@ -285,6 +323,8 @@ source_names:
 
       FD_Gov_FedND_IP:
         activity_to_sector_mapping: BEA_NIPA_FD_Gov
+        clean_parameter: F07N00
+        clean_fbs_after_aggregation: !clean_function:flowbyclean assign_sector_consumed_by_from_clean_parameter
         selection_fields:
           Table: T30905 # Table 3.9.5. Government Consumption Expenditures and Gross Investment
           ActivityProducedBy:
@@ -302,6 +342,8 @@ source_names:
 
       FD_Gov_SLG_CE:
         activity_to_sector_mapping: BEA_NIPA_FD_Gov
+        clean_parameter: F10C00
+        clean_fbs_after_aggregation: !clean_function:flowbyclean assign_sector_consumed_by_from_clean_parameter
         selection_fields:
           Table: T30905 # Table 3.9.5. Government Consumption Expenditures and Gross Investment
           ActivityProducedBy:
@@ -318,6 +360,8 @@ source_names:
 
       FD_Gov_SLG_Equipment:
         activity_to_sector_mapping: BEA_NIPA_FD_Gov
+        clean_parameter: F10E00
+        clean_fbs_after_aggregation: !clean_function:flowbyclean assign_sector_consumed_by_from_clean_parameter
         selection_fields:
           Table: T30905 # Table 3.9.5. Government Consumption Expenditures and Gross Investment
           ActivityProducedBy:
@@ -334,6 +378,8 @@ source_names:
 
       FD_Gov_SLG_Structures:
         activity_to_sector_mapping: BEA_NIPA_FD_Gov
+        clean_parameter: F10S00
+        clean_fbs_after_aggregation: !clean_function:flowbyclean assign_sector_consumed_by_from_clean_parameter
         selection_fields:
           Table: T30905 # Table 3.9.5. Government Consumption Expenditures and Gross Investment
           Line: 36 # "Structures"; Line uniquely selects this row (also at lines 4, 12, 20, 28)
@@ -349,6 +395,8 @@ source_names:
 
       FD_Gov_SLG_IP:
         activity_to_sector_mapping: BEA_NIPA_FD_Gov
+        clean_parameter: F10N00
+        clean_fbs_after_aggregation: !clean_function:flowbyclean assign_sector_consumed_by_from_clean_parameter
         selection_fields:
           Table: T30905 # Table 3.9.5. Government Consumption Expenditures and Gross Investment
           ActivityProducedBy:
@@ -366,6 +414,8 @@ source_names:
 
       FD_Structures1:
         activity_to_sector_mapping: BEA_NIPA_FD_Structures
+        clean_parameter: F02R00
+        clean_fbs_after_aggregation: !clean_function:flowbyclean assign_sector_consumed_by_from_clean_parameter
         selection_fields:
           Table: U50405 # Table 5.4.5. Private Fixed Investment in Structures by Type
           ActivityProducedBy:
@@ -396,6 +446,8 @@ source_names:
 
       FD_Structures2:
         activity_to_sector_mapping: BEA_NIPA_FD_Structures
+        clean_parameter: F02S00
+        clean_fbs_after_aggregation: !clean_function:flowbyclean assign_sector_consumed_by_from_clean_parameter
         selection_fields:
           Table: U50405 # Table 5.4.5. Private Fixed Investment in Structures by Type
           ActivityProducedBy:
@@ -429,6 +481,8 @@ source_names:
       FD_Structures2_used:
         # See note on FD_Structures1_used: this is the Nonresidential (line 38) occurrence.
         activity_to_sector_mapping: BEA_NIPA_FD_Structures
+        clean_parameter: F02S00
+        clean_fbs_after_aggregation: !clean_function:flowbyclean assign_sector_consumed_by_from_clean_parameter
         selection_fields:
           Table: U50405 # Table 5.4.5. Private Fixed Investment in Structures by Type
           Line: 38 # "Net purchases of used structures" (Nonresidential); also occurs at line 48


### PR DESCRIPTION
flowbyclean.py;update NIPA_FD_2017 to use it; add missing F02E00 to Cornerstone_2025_target


cc:
Closes #539 

## What changed? Why?
Closes #539 ("SectorConsumedBy is not captured for NIPA FD").

- `NIPA_FD_<year>.yaml`'s FBS output had `SectorConsumedBy` empty for every row. Each activity_set now
  assigns its official BEA final-demand code (`F01000`, `F06S00`, etc.) directly to `SectorConsumedBy`
  via a new `clean_fbs_after_aggregation` hook (`clean_parameter` + `assign_sector_consumed_by_from_clean_parameter`
  in `bedrock/transform/flowbyclean.py`), applied to all 24 activity_sets in `NIPA_FD_2017.yaml`.
- This has to happen *after* attribution/aggregation, not via a crosswalk entry for `ActivityConsumedBy`:
  BEA_NIPA is `FlowType='TECHNOSPHERE_FLOW'`, and `add_primary_secondary_columns()` prioritizes
  `...ConsumedBy` over `...ProducedBy` for that flow type, so populating `SectorConsumedBy` before
  attribution would make `PrimarySector` resolve to the final-demand code instead of the real commodity
  (`SectorProducedBy`), silently corrupting the proportional attribution against the commodity-level
  attribution source. The docstring on `assign_sector_consumed_by_from_clean_parameter` has the full
  explanation.
- Added the missing `F02E00` final-demand code to `Cornerstone_2025_target.yaml`'s `industry_spec`
  `NAICS_6` override list — it's new from the PEQ Bridge work (#525) and was never added alongside the
  other 15 `F0*` codes, so it was silently truncating to `F02E` once assigned to `SectorConsumedBy`.
- Simplified `bedrock/transform/eeio/nowcast.py`'s `derive_initial_Y_pur`: since `SectorConsumedBy` is
  now populated natively, the per-activity_set replication workaround (`_nipa_fd_activity_sets`,
  `ACTIVITY_SET_TO_FINAL_DEMAND_CODE`) is no longer needed — a plain `generateFlowBySector` call plus a
  pivot on `SectorProducedBy`/`SectorConsumedBy` is now sufficient.
- While verifying this against the published `Use_SUT_Framework_2017_DET.xlsx` benchmark, found that
  `Cornerstone_2025_target.yaml`'s `industry_spec` (`default: NAICS_3`) collapses most commodities not
  explicitly listed in its `NAICS_4`/`NAICS_5`/`NAICS_6` override lists down to codes that aren't real
  BEA_2017_Detail commodity codes (e.g. `1112`, `236` — confirmed against `USA_2017_COMMODITY_CODES`:
  77% of rows / 86% of dollar value in the 2017 output). Applied the same fix other Cornerstone models
  already use for this (`map_fbs_sectors_to_model_schema` in `bedrock/transform/allocation/derived.py`,
  e.g. the GHG pipeline calls it right after FBS generation) — applied to both `SectorProducedBy` and,
  via a temporary column swap, `SectorConsumedBy` in `nowcast.py`. This reduced invalid rows from
  292/377 ($17.17T of $19.96T) to 14/377 ($6.23T).

## Testing

first row now:

Flowable | Class | SectorProducedBy | SectorConsumedBy | SectorSourceName | Context | Location | LocationSystem | FlowAmount | Unit | FlowType | Year
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
USD | Money | 11113 | F01000 | NAICS_2017_Code | 0 | FIPS | 27672596 | USD | TECHNOSPHERE_FLOW | 2017


- `derive_initial_Y_pur(2017)` grand total unchanged throughout (`$19,963,530,000,000`), confirming the
  `SectorConsumedBy` assignment and `map_fbs_sectors_to_model_schema` calls don't alter `FlowAmount`.
- Verified `SectorConsumedBy` values are 100% valid `BEA_2017_FINAL_DEMAND_CODE`s after the fix (was:
  entirely empty).
- Verified via `bedrock/utils/validation/nowcast_initial_Y_pur_baseline.py` against the published
  `Use_SUT_Framework_2017_DET.xlsx` 2017 benchmark.

