### PR TITLE
feat(validation): select diagnostics baseline at dispatch time

### DIFF
--- a/.claude/skills/dispatch-ef-diagnostics/SKILL.md
+++ b/.claude/skills/dispatch-ef-diagnostics/SKILL.md
@@ -21,9 +21,9 @@ For the **A-matrix time-series epic**, the driver is `bedrock/analysis/a_matrix_
 | Workflow registered | `gh workflow list \| grep -i diagnostic` → expect `generate_diagnostics active` |
 | Configs exist **on the ref** | `git fetch origin <ref>` then `git cat-file -e origin/<ref>:bedrock/utils/config/configs/<cfg>.yaml`. Don't trust a spec sheet's "on main?" column — confirm. |
 | Google ADC + Drive | `gcloud auth application-default login` (Drive scope). Confirm read access + see what's already in the folder via `_drive_client().files().list(...)`. |
-| USEEIO baseline pin | `bedrock/utils/snapshots/useeio_baseline_pin.json` (currently `USEEIOv2.6.0-phoebe-23`, a GCS Excel). With `use_useeio_baseline=true` the workflow benchmarks against this pin **in addition to** the always-on CEDA-v0 comparison. |
+| USEEIO baseline pin | `bedrock/utils/snapshots/useeio_baseline_pin.json` (currently `USEEIOv2.6.0-phoebe-23`, a GCS Excel). Use workflow `baseline=useeio` (or `--baseline useeio` on the dispatcher). |
 
-Workflow inputs (`generate_diagnostics.yml`): `config_name, sheet_id, use_useeio_baseline (bool), model_base_year, usa_ghg_data_year, pr_url`. The **git-ref is `gh workflow run --ref`, not an input** — it selects the model code the run executes against.
+Workflow inputs (`generate_diagnostics.yml`): `config_name, sheet_id, baseline (ceda-v0|useeio|v0.3|snapshot SHA), model_base_year, usa_ghg_data_year, pr_url`. The **git-ref is `gh workflow run --ref`, not an input** — it selects the model code the run executes against.
 
 ## Clarify first — ask before acting
 
@@ -35,7 +35,7 @@ Do **not** create any sheet or dispatch until these are confirmed. Ask via `AskU
 | Scenarios | `bundle_v0_3` (or `isolate_a_matrix`, or both) |
 | Approaches | all in the scenario (e.g. restrict to `useeio_nowcast`) |
 | Years | `2019,2020,2021,2022,2023` — sets `model_base_year` + `usa_ghg_data_year` |
-| Baseline | CEDA-only (ask whether to also tick USEEIO via `--use-useeio-baseline`) |
+| Baseline | CEDA-only (`ceda-v0`); ask whether to use `useeio` or `v0.3` instead |
 | git-ref | `main` |
 | Throttle | `poll` (or `sleep:N` / `none`) |
 | Sheet title | `[{date}, {year}, {baseline} based, {approach label}, {scenario}] EFs diagnostics` |
@@ -67,12 +67,12 @@ Or for a simple feature-config list use the validation CLI:
 uv run python -m bedrock.utils.validation.dispatch_diagnostics \
     --git-ref main \
     --configs <cfg1>,<cfg2> \
-    --baseline-label "Bedrock v0.3 snapshot based" \
+    --baseline v0.3 \
     --dry-run
 ```
 
 A spec sheet's observed layout has two baseline-grouped tables:
-- **"compare to USEEIO Phoebe"** → run with `use_useeio_baseline=true`.
+- **"compare to USEEIO Phoebe"** → run with `baseline=useeio`.
 - **"compare to v0 ceda"** → CEDA-only (default).
 - A config in **both** is the user's call: one run with the box on already includes CEDA-v0 columns (so a separate CEDA-only sheet is partly redundant) vs. two distinct sheets. Surface it; let them choose.
 - These are **release snapshots → one run per config**, not the multi-year sweep. **Match each config's year to its YAML**: configs that set `v0_3_umd_2024_ghgia: true` or hard-code `model_base_year: 2024` (e.g. `…_2024_io_ghg`, `…_umd_2024_ghgia`, **and FINAL `…_v0_3`**) must run at 2024. When a config hard-codes its years, pass **no** `model_base_year`/`usa_ghg_data_year` override so the YAML wins.
@@ -125,7 +125,7 @@ These surface as a **failed GH run after a successful dispatch** — the sheet i
 | `--scenarios` | Comma list: `isolate_a_matrix`, `bundle_v0_3` (default `bundle_v0_3`). |
 | `--years` | Comma list (default `2019,2020,2021,2022,2023`). Sets `model_base_year` and `usa_ghg_data_year`. |
 | `--approaches` | Optional filter, e.g. `useeio_nowcast`. Default = all approaches in the scenario. |
-| `--use-useeio-baseline` | Add USEEIO baseline columns. Default = CEDA-only. |
+| `--use-useeio-baseline` | Epic dispatcher alias for `--baseline useeio`. |
 | `--throttle` | `poll` (default; blocks until prior runs clear), `sleep:N`, or `none`. |
 | `--dry-run` | Print the plan only. |
 | `--re-dispatch-from-csv` | Re-trigger cells already in `ef_run_index.csv` (recovery; **reuses** existing sheets). |
@@ -151,7 +151,7 @@ For a one-off cell by hand: create a sheet in the Drive folder named per the tem
 ```bash
 gh workflow run generate_diagnostics.yml --ref main \
   -f config_name=<config> -f sheet_id=<id> \
-  -f model_base_year=<year> -f usa_ghg_data_year=<year> -f use_useeio_baseline=false
+  -f model_base_year=<year> -f usa_ghg_data_year=<year> -f baseline=ceda-v0
 ```
 
 ## Reference

--- a/.github/workflows/generate_diagnostics.yml
+++ b/.github/workflows/generate_diagnostics.yml
@@ -17,11 +17,11 @@ on:
         required: false
         type: string
         default: ""
-      use_useeio_baseline:
-        description: "Benchmark to USEEIO GCS Excel baseline (URI, SHA, label from useeio_baseline_pin.json)"
+      baseline:
+        description: "Comparison target: ceda-v0 (default), useeio, v0.3, or a snapshot SHA. Overrides the config YAML for this run only."
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: "ceda-v0"
       model_base_year:
         description: "Override model_base_year (e.g. 2019..2024). Leave empty to use the YAML's value."
         required: false
@@ -69,24 +69,18 @@ jobs:
       - name: Generate diagnostics
         id: generate
         run: |
-          if [ "${{ github.event.inputs.use_useeio_baseline }}" = "true" ]; then
-            uv run python bedrock/utils/validation/generate_diagnostics.py \
-              --sheet_id "${{ github.event.inputs.sheet_id }}" \
-              --config_name "${{ github.event.inputs.config_name }}" \
-              --git_branch "${{ github.ref_name }}" \
-              ${{ github.event.inputs.pr_url && format('--pr_url "{0}"', github.event.inputs.pr_url) || '' }} \
-              ${{ github.event.inputs.model_base_year && format('--model_base_year {0}', github.event.inputs.model_base_year) || '' }} \
-              ${{ github.event.inputs.usa_ghg_data_year && format('--usa_ghg_data_year {0}', github.event.inputs.usa_ghg_data_year) || '' }} \
-              --useeio_baseline_pin_json bedrock/utils/snapshots/useeio_baseline_pin.json
-          else
-            uv run python bedrock/utils/validation/generate_diagnostics.py \
-              --sheet_id "${{ github.event.inputs.sheet_id }}" \
-              --config_name "${{ github.event.inputs.config_name }}" \
-              --git_branch "${{ github.ref_name }}" \
-              ${{ github.event.inputs.pr_url && format('--pr_url "{0}"', github.event.inputs.pr_url) || '' }} \
-              ${{ github.event.inputs.model_base_year && format('--model_base_year {0}', github.event.inputs.model_base_year) || '' }} \
-              ${{ github.event.inputs.usa_ghg_data_year && format('--usa_ghg_data_year {0}', github.event.inputs.usa_ghg_data_year) || '' }}
+          BASELINE="${{ github.event.inputs.baseline }}"
+          if [ -z "$BASELINE" ]; then
+            BASELINE="ceda-v0"
           fi
+          uv run python bedrock/utils/validation/generate_diagnostics.py \
+            --sheet_id "${{ github.event.inputs.sheet_id }}" \
+            --config_name "${{ github.event.inputs.config_name }}" \
+            --git_branch "${{ github.ref_name }}" \
+            --baseline "${BASELINE}" \
+            ${{ github.event.inputs.pr_url && format('--pr_url "{0}"', github.event.inputs.pr_url) || '' }} \
+            ${{ github.event.inputs.model_base_year && format('--model_base_year {0}', github.event.inputs.model_base_year) || '' }} \
+            ${{ github.event.inputs.usa_ghg_data_year && format('--usa_ghg_data_year {0}', github.event.inputs.usa_ghg_data_year) || '' }}
 
   notify_slack_failure:
     needs: diagnostics
@@ -108,7 +102,7 @@ jobs:
                   "type": "section",
                   "text": {
                       "type": "mrkdwn",
-                      "text": ":warning: *Bedrock Diagnostics Generation Failure*\nDiagnostics failed on `${{ github.ref_name }}` `${{ github.sha }}`\n\n*Configuration:* ${{ github.event.inputs.config_name }}\n*USEEIO baseline:* ${{ github.event.inputs.use_useeio_baseline }}\n*Target Google Sheets URL:* https://docs.google.com/spreadsheets/d/${{ github.event.inputs.sheet_id }}"
+                      "text": ":warning: *Bedrock Diagnostics Generation Failure*\nDiagnostics failed on `${{ github.ref_name }}` `${{ github.sha }}`\n\n*Configuration:* ${{ github.event.inputs.config_name }}\n*Baseline:* ${{ github.event.inputs.baseline }}\n*Target Google Sheets URL:* https://docs.google.com/spreadsheets/d/${{ github.event.inputs.sheet_id }}"
                   },
                   "accessory": {
                     "type": "button",
@@ -142,7 +136,7 @@ jobs:
                   "type": "section",
                   "text": {
                       "type": "mrkdwn",
-                      "text": ":white_check_mark: *Bedrock Diagnostics Generation Success*\nDiagnostics generated on `${{ github.ref_name }}` `${{ github.sha }}`\n\n*Configuration:* ${{ github.event.inputs.config_name }}\n*USEEIO baseline:* ${{ github.event.inputs.use_useeio_baseline }}\n*Google Sheets URL:* https://docs.google.com/spreadsheets/d/${{ github.event.inputs.sheet_id }}"
+                      "text": ":white_check_mark: *Bedrock Diagnostics Generation Success*\nDiagnostics generated on `${{ github.ref_name }}` `${{ github.sha }}`\n\n*Configuration:* ${{ github.event.inputs.config_name }}\n*Baseline:* ${{ github.event.inputs.baseline }}\n*Google Sheets URL:* https://docs.google.com/spreadsheets/d/${{ github.event.inputs.sheet_id }}"
                   },
                   "accessory": {
                     "type": "button",

--- a/bedrock/utils/config/feature_flag.md
+++ b/bedrock/utils/config/feature_flag.md
@@ -59,25 +59,19 @@ Create `bedrock/utils/config/configs/<name>.yaml`:
 - Set any hard prerequisites the validators or call site require (for
   example `load_E_from_flowsa: true` when the gated path loads E from
   flowsa).
-- Set `snapshot_version_or_git_sha` to the baseline diagnostics should
-  compare against — the value whose parquet EFs become `N_old` / `D_old`
-  on the sheet. Pick the baseline that matches the evaluation question:
-  - **Latest accepted Bedrock / Cornerstone model** — the SHA in
-    [`../snapshots/.SNAPSHOT_KEY`](../snapshots/.SNAPSHOT_KEY) (must also
-    appear on the `USAConfig.snapshot_version_or_git_sha` Literal). Use this
-    when the question is “what does this feature change relative to the
-    model users already receive?”
-  - **A prior Bedrock / Cornerstone release** — a release SHA in that
-    Literal (`# v0.2`, `# v0.3.0`, etc.).
-  - **Legacy CEDA-US v0** — set `'v0'`, or omit the key because the field
-    default is `'v0'`. Omitting the key does **not** select
-    `.SNAPSHOT_KEY`.
+- Leave `snapshot_version_or_git_sha` at its default (`'v0'`) or omit the
+  key. Choose the diagnostics comparison at dispatch /
+  `generate_diagnostics` time via `--baseline` (`ceda-v0`, `useeio`,
+  `v0.3`, …) — see
+  [`../validation/evaluate_feature_impact.md`](../validation/evaluate_feature_impact.md)
+  (§ Choose a baseline). Do not fork a config YAML only to change the
+  baseline.
 - Omit unrelated keys; `USAConfig` fills defaults for everything else.
 
-`'v0'` means the legacy CEDA-US baseline. A SHA from `.SNAPSHOT_KEY` or
-`snapshots/releases.py` represents a Bedrock / Cornerstone model snapshot.
-Both use the snapshot loader; do not label a Bedrock / Cornerstone snapshot
-as “CEDA snapshot” in diagnostics titles or findings.
+`'v0'` (and `--baseline ceda-v0`) means the legacy CEDA-US baseline.
+`--baseline v0.3` (or a raw SHA) selects a Bedrock / Cornerstone model
+snapshot. Do not label a Bedrock / Cornerstone snapshot as “CEDA snapshot”
+in diagnostics titles or findings.
 
 Config name = filename without `.yaml` (this is the `config_name` passed to
 `generate_diagnostics`).

--- a/bedrock/utils/config/usa_config.py
+++ b/bedrock/utils/config/usa_config.py
@@ -25,6 +25,7 @@ RETIRED_USA_CONFIG_STEMS: frozenset[str] = frozenset(
 DIAGNOSTICS_CLI_OVERRIDE_KEYS: frozenset[str] = frozenset(
     {
         'diagnostics_baseline_source',
+        'snapshot_version_or_git_sha',
         'useeio_baseline_xlsx_gs_uri',
         'useeio_baseline_xlsx_sha256',
         'useeio_model_version_label',
@@ -357,9 +358,10 @@ def set_global_usa_config(
             appended if missing).
         diagnostics_cli_overrides: If set, merged onto the YAML-loaded dict
             before ``USAConfig`` validation. Keys must be a subset of
-            ``DIAGNOSTICS_CLI_OVERRIDE_KEYS`` (diagnostics baseline + USEEIO pin
-            fields). Used by ``generate_diagnostics`` so one run can change those
-            fields without a forked config file.
+            ``DIAGNOSTICS_CLI_OVERRIDE_KEYS`` (diagnostics baseline source,
+            snapshot key, USEEIO pin fields, model years). Used by
+            ``generate_diagnostics`` so one run can change the comparison
+            target and years without a forked config file.
     """
     global _usa_config
     config_file_env = os.environ.get(USA_CONFIG_ENV_VAR)

--- a/bedrock/utils/snapshots/README.md
+++ b/bedrock/utils/snapshots/README.md
@@ -25,7 +25,7 @@ These are **independent** concepts and frequently point at different commits:
 | Snapshot artifacts | `gs://cornerstone-default/snapshots/<git_sha>/*.parquet` | The 10 parquet outputs of the canonical pipeline run at `<git_sha>`. See [`SNAPSHOT_NAMES`](names.py). |
 | Snapshot key | [`.SNAPSHOT_KEY`](.SNAPSHOT_KEY) | The single SHA that integration tests load via `load_current_snapshot(...)`. Bumping this is what "uses the new snapshot" means. |
 | Release tag | annotated git tag `v0.X.Y` | Marks a snapshot/release boundary so methodology evolution is easy to read in history. |
-| Named release | [`releases.py`](releases.py) | Reference-only map of release labels → snapshot SHAs. Not imported by runtime code; update in Phase A alongside `.SNAPSHOT_KEY`. |
+| Named release | [`releases.py`](releases.py) | Release label → snapshot SHA map. Imported by `diagnostics_baseline` so `--baseline v0.2` (etc.) resolves; update in Phase A alongside `.SNAPSHOT_KEY`. |
 | Diagnostic baseline pin | `USAConfig.snapshot_version_or_git_sha` | `Literal[...]` of SHAs that any config may point at as its diagnostic baseline. Every released snapshot SHA must be added here. |
 | Canonical config | [`2025_usa_cornerstone_v0_3.yaml`](../config/configs/2025_usa_cornerstone_v0_3.yaml) | The single config used to generate the snapshots that back `.SNAPSHOT_KEY`. Atomic configs are not snapshotted here; see "Adhoc snapshots" below. |
 | Cornerstone GHG FBS pin | [`cornerstone_ghg_fbs_2024_pin.json`](cornerstone_ghg_fbs_2024_pin.json) | Pins one `GHG_national_Cornerstone_2024` parquet in `transform/output_data` (filename + SHA256). Guards FBS regeneration in [`test_fbs.py`](../../transform/__tests__/test_fbs.py). See "Cornerstone GHG FBS pin" below. |

--- a/bedrock/utils/snapshots/README.md
+++ b/bedrock/utils/snapshots/README.md
@@ -4,7 +4,7 @@ Snapshots are the source of truth for what the bedrock pipeline produced at a sp
 They are:
 
 - The fixtures behind the snapshot integration tests in `bedrock/transform/__tests__/test_usa.py` (run twice every weekday on `main` via `test_integration.yml`)
-- The baseline that diagnostics runs compare against (`USAConfig.snapshot_version_or_git_sha`)
+- Parquet sources for diagnostics comparison baselines — selected at dispatch via `--baseline` (see [`../validation/evaluate_feature_impact.md`](../validation/evaluate_feature_impact.md)); allowed snapshot keys live on `USAConfig.snapshot_version_or_git_sha`
 - A reproducibility guarantee: every prior release remains independently reproducible because old snapshots are never deleted
 
 When the pipeline changes in a way that legitimately changes its outputs, the integration tests will diff against the previous snapshot and fail. That signal is intentional, and the fix is to regenerate the snapshot and bump `.SNAPSHOT_KEY`. Tagging a release is a separate event that may bundle the snapshot bump together with non-output-changing work (docs, polish, bug fixes). This document is the team-wide playbook for both flows.
@@ -25,8 +25,9 @@ These are **independent** concepts and frequently point at different commits:
 | Snapshot artifacts | `gs://cornerstone-default/snapshots/<git_sha>/*.parquet` | The 10 parquet outputs of the canonical pipeline run at `<git_sha>`. See [`SNAPSHOT_NAMES`](names.py). |
 | Snapshot key | [`.SNAPSHOT_KEY`](.SNAPSHOT_KEY) | The single SHA that integration tests load via `load_current_snapshot(...)`. Bumping this is what "uses the new snapshot" means. |
 | Release tag | annotated git tag `v0.X.Y` | Marks a snapshot/release boundary so methodology evolution is easy to read in history. |
-| Named release | [`releases.py`](releases.py) | Release label → snapshot SHA map. Imported by `diagnostics_baseline` so `--baseline v0.2` (etc.) resolves; update in Phase A alongside `.SNAPSHOT_KEY`. |
-| Diagnostic baseline pin | `USAConfig.snapshot_version_or_git_sha` | `Literal[...]` of SHAs that any config may point at as its diagnostic baseline. Every released snapshot SHA must be added here. |
+| Named release | [`releases.py`](releases.py) | Release label → snapshot SHA map. Imported by [`diagnostics_baseline`](../validation/diagnostics_baseline.py) so `--baseline v0.3` (etc.) resolves; update in Phase A alongside `.SNAPSHOT_KEY`. |
+| Diagnostics baseline alias | [`diagnostics_baseline.py`](../validation/diagnostics_baseline.py) `NAMED_BASELINES` | Short operator names (`ceda-v0`, `v0.3`, …) → `releases.py` constants. Add an entry when a new release is a common comparison target. Raw SHAs skip this map if they are already on the `Literal`. |
+| Allowed snapshot keys | `USAConfig.snapshot_version_or_git_sha` | `Literal[...]` of SHAs diagnostics may load as `N_old` / `D_old`. Every released snapshot SHA must appear here. YAML default is `'v0'`; dispatch `--baseline` overrides for that run only. |
 | Canonical config | [`2025_usa_cornerstone_v0_3.yaml`](../config/configs/2025_usa_cornerstone_v0_3.yaml) | The single config used to generate the snapshots that back `.SNAPSHOT_KEY`. Atomic configs are not snapshotted here; see "Adhoc snapshots" below. |
 | Cornerstone GHG FBS pin | [`cornerstone_ghg_fbs_2024_pin.json`](cornerstone_ghg_fbs_2024_pin.json) | Pins one `GHG_national_Cornerstone_2024` parquet in `transform/output_data` (filename + SHA256). Guards FBS regeneration in [`test_fbs.py`](../../transform/__tests__/test_fbs.py). See "Cornerstone GHG FBS pin" below. |
 
@@ -40,15 +41,16 @@ These are **independent** concepts and frequently point at different commits:
 
 The FBS pin and the runtime loader are independent: bumping the pin updates the regeneration test golden file; production still follows the latest GCS upload until `load_E_from_flowsa` is wired to the pin.
 
-| Store | Releases (`v0`, `v0.1`, `v0.2`) | Test-only SHAs |
+| Store | Releases (`v0`, `v0.1`, `v0.2`, `v0.3`) | Test-only SHAs |
 |---|---|---|
-| [`.SNAPSHOT_KEY`](.SNAPSHOT_KEY) | `7372464249...` (v0.2) | — |
-| [`releases.py`](releases.py) | `v0`, `v0_1`, `v0_2` | `TEST_*` (intermediate bumps, not release labels) |
-| `USAConfig.snapshot_version_or_git_sha` | `'v0'`, `1bda811e...` `# v0.1`, `7372464249...` `# v0.2` | `2ebb51f7...`, `9fe22d9a...` `# test` |
+| [`.SNAPSHOT_KEY`](.SNAPSHOT_KEY) | current release SHA | — |
+| [`releases.py`](releases.py) | `v0`, `v0_1`, `v0_2`, `v0_3_0`, … | `TEST_*` (intermediate bumps, not release labels) |
+| [`diagnostics_baseline.py`](../validation/diagnostics_baseline.py) `NAMED_BASELINES` | `ceda-v0`, `v0.3`, … | — |
+| `USAConfig.snapshot_version_or_git_sha` | `'v0'`, release SHAs with `# v0.x` comments | `2ebb51f7...`, `9fe22d9a...` `# test` |
 
 **Atomic config** — a YAML config that changes a single methodology flag relative to the baseline, used to measure that change in isolation. See [`../config/feature_flag.md`](../config/feature_flag.md). Diagnostics against a chosen snapshot or USEEIO baseline: [`../validation/evaluate_feature_impact.md`](../validation/evaluate_feature_impact.md).
 
-`v0.2` is the current integration baseline. `v0` and `v0.1` are earlier release snapshots. The two `TEST_*` SHAs are intermediate bumps kept in the Literal so atomic configs and test fixtures can pin them for comparison.
+`v0.2` is an earlier release snapshot. `v0` and `v0.1` predate it. The two `TEST_*` SHAs are intermediate bumps kept in the Literal so atomic configs and test fixtures can pin them for comparison.
 
 ## Versioning
 
@@ -130,8 +132,9 @@ Wait for the success notification in `#alerts-bedrock`. Artifacts will be at `gs
 On a new branch, make exactly these changes (and nothing else — keep the bump PR mechanical and reviewable in under a minute):
 
 - [ ] [`bedrock/utils/snapshots/.SNAPSHOT_KEY`](.SNAPSHOT_KEY) — replace the file's only line with the new SHA.
-- [ ] [`bedrock/utils/snapshots/releases.py`](releases.py) — add the new release constant (e.g. `v0_3_0 = "<sha>"`) with a trailing `# config: <stem>` comment (the `generate_snapshots --config_name` value). Leave prior release entries in place. Use underscores in the Python identifier; the git tag uses dots. Do **not** add entries for patch-only releases.
-- [ ] [`bedrock/utils/config/usa_config.py`](../config/usa_config.py) — extend the `snapshot_version_or_git_sha: Literal[...]` to include the new SHA, with a trailing comment noting the release label (e.g. `# v0.3.0`). Do **not** remove old SHAs — atomic configs and test fixtures may still reference them.
+- [ ] [`bedrock/utils/snapshots/releases.py`](releases.py) — add the new release constant (e.g. `v0_4_0 = "<sha>"`) with a trailing `# config: <stem>` comment (the `generate_snapshots --config_name` value). Leave prior release entries in place. Use underscores in the Python identifier; the git tag uses dots. Do **not** add entries for patch-only releases.
+- [ ] [`bedrock/utils/config/usa_config.py`](../config/usa_config.py) — extend the `snapshot_version_or_git_sha: Literal[...]` to include the new SHA, with a trailing comment noting the release label (e.g. `# v0.4.0`). Do **not** remove old SHAs — atomic configs and test fixtures may still reference them.
+- [ ] [`bedrock/utils/validation/diagnostics_baseline.py`](../validation/diagnostics_baseline.py) — when the release is a common diagnostics comparison target, add a short alias to `NAMED_BASELINES` (e.g. `'v0.4': releases.v0_4_0`, `'v0.4.0': releases.v0_4_0`). Operators can always pass the raw SHA via `--baseline` once the `Literal` includes it; the alias is for convenience (`--baseline v0.4`).
 - [ ] Title: `release: snapshot bump (anticipated v0.X.Y)`
 - [ ] Description: short summary of the output delta vs. the previous snapshot, plus the GCS URL `gs://cornerstone-default/snapshots/<new_sha>/`.
 
@@ -199,10 +202,10 @@ Post in `#alerts-bedrock` (and any other relevant channel):
 > Snapshot SHA: `<short_snapshot_sha>` (unchanged from previous release / new since `v0.X.<prev>`)
 > Canonical config: `2025_usa_cornerstone_v0_3`
 > Highlights: <one or two lines>
-> Downstream impact: <e.g. diagnostics baselines should bump to this SHA when ready>
+> Downstream impact: <e.g. use `--baseline v0.X` (or the new SHA) on diagnostics dispatch when comparing to this release>
 
-**B6. (Optional) Update downstream `snapshot_version_or_git_sha` defaults.**
-If you want existing configs to compare against the new baseline by default, follow up with a PR that flips their `snapshot_version_or_git_sha`. This is intentionally a separate PR so diagnostic baseline moves are explicit.
+**B6. (Optional) Announce diagnostics baseline for the release.**
+Model config YAMLs leave `snapshot_version_or_git_sha` at `'v0'`. To compare diagnostics against the new release snapshot, pass `--baseline v0.X` on `generate_diagnostics` / the workflow `baseline` input, or the raw SHA once it is on the `Literal`. See [`../validation/evaluate_feature_impact.md`](../validation/evaluate_feature_impact.md) (§ Choose a baseline). Do not flip YAML defaults solely to change the comparison target.
 
 ## Anatomy of the Phase A snapshot bump PR
 
@@ -226,12 +229,21 @@ A clean bump PR diff looks roughly like this (anticipating release `v0.3.0`):
          '1bda811e0169436ae90fd356fbef512ce7518ccb',  # v0.1
          '2ebb51f7190c3a62b5d8b2420bff9b20f57282fc',  # test
          '9fe22d9afdfdb6806397b2356eb3cf4c4c346744',  # test: snapshot from 2025_usa_cornerstone_fbs_schema
-         '7372464249c434c9bebb172c065a4d0e3702176e',  # v0.2 (current .SNAPSHOT_KEY)
-+        '<new_sha>',                                  # v0.3.0
+         '7372464249c434c9bebb172c065a4d0e3702176e',  # v0.2
++        '<new_sha>',                                  # v0.4.0
      ] = 'v0'
+
+--- a/bedrock/utils/validation/diagnostics_baseline.py
++++ b/bedrock/utils/validation/diagnostics_baseline.py
+ NAMED_BASELINES: dict[str, str] = {
+     'ceda-v0': releases.v0,
+     'v0.3': releases.v0_3_0,
++    'v0.4': releases.v0_4_0,
++    'v0.4.0': releases.v0_4_0,
+ }
 ```
 
-Three files, no other code touched. If anything else needs to change, it belongs in a separate PR.
+Four mechanical files (`.SNAPSHOT_KEY`, `releases.py`, `usa_config.py`, and optionally `diagnostics_baseline.py` when adding a named alias). If anything else needs to change, it belongs in a separate PR.
 
 ## Rolling back
 
@@ -303,7 +315,8 @@ After upload, `_load_cornerstone_ghg_fbs_from_gcs` picks up the new parquet on t
 | [`generate_snapshots.py`](generate_snapshots.py) | CLI that builds the 10 parquet snapshots and uploads to GCS |
 | [`loader.py`](loader.py) | `load_current_snapshot`, `load_configured_snapshot`, GCS download helpers |
 | [`names.py`](names.py) | `SnapshotName` literal type and `SNAPSHOT_NAMES` list |
-| [`releases.py`](releases.py) | Reference-only release label → snapshot SHA map (not imported by code) |
+| [`releases.py`](releases.py) | Release label → snapshot SHA map; imported by `diagnostics_baseline` |
+| [`../validation/diagnostics_baseline.py`](../validation/diagnostics_baseline.py) | Maps `--baseline` labels (`ceda-v0`, `v0.3`, …) to snapshot keys |
 | [`../config/usa_config.py`](../config/usa_config.py) | `USAConfig.snapshot_version_or_git_sha` `Literal` of allowed baseline SHAs |
 | [`../../../.github/workflows/generate_snapshots.yml`](../../../.github/workflows/generate_snapshots.yml) | `workflow_dispatch` CI that runs `generate_snapshots.py` |
 | [`../../../.github/workflows/test_integration.yml`](../../../.github/workflows/test_integration.yml) | Scheduled CI that diffs current pipeline output against `.SNAPSHOT_KEY` |

--- a/bedrock/utils/snapshots/releases.py
+++ b/bedrock/utils/snapshots/releases.py
@@ -1,7 +1,10 @@
-"""Reference-only map of release labels to snapshot SHAs.
+"""Release labels to snapshot SHAs.
 
-Not imported by runtime code. Integration tests use ``.SNAPSHOT_KEY``;
-diagnostics resolve baselines via ``USAConfig.snapshot_version_or_git_sha``.
+Imported by ``bedrock.utils.validation.diagnostics_baseline`` so
+``generate_diagnostics --baseline v0.2`` (etc.) can resolve labels to SHAs.
+Integration tests still prefer ``.SNAPSHOT_KEY`` for “current snapshot”
+identity; diagnostics runs select a baseline via CLI / workflow, which
+overrides ``USAConfig.snapshot_version_or_git_sha`` for that process.
 
 Each entry's ``# config:`` comment is the stem passed to
 ``generate_snapshots --config_name`` when that snapshot was built. Confirm

--- a/bedrock/utils/validation/diagnostics_baseline.py
+++ b/bedrock/utils/validation/diagnostics_baseline.py
@@ -1,0 +1,70 @@
+"""Resolve diagnostics ``--baseline`` into config overrides.
+
+Named targets: ``ceda-v0``, ``useeio``, ``v0.3``. Any snapshot key allowed on
+``USAConfig.snapshot_version_or_git_sha`` also works (older or future
+releases). Add a short alias to ``NAMED_BASELINES`` when a new release
+becomes a common comparison target.
+"""
+
+from __future__ import annotations
+
+import typing as ta
+from pathlib import Path
+
+from bedrock.utils.config.usa_config import USAConfig
+from bedrock.utils.snapshots import releases
+from bedrock.utils.validation.useeio_excel_baseline import (
+    load_useeio_baseline_pin_overrides,
+)
+
+DEFAULT_USEEIO_BASELINE_PIN_JSON = str(
+    Path(__file__).resolve().parent.parent / 'snapshots' / 'useeio_baseline_pin.json'
+)
+
+# Short operator names → snapshot key. ``useeio`` is handled separately.
+NAMED_BASELINES: dict[str, str] = {
+    'ceda-v0': releases.v0,
+    'ceda': releases.v0,
+    'v0': releases.v0,
+    'v0.3': releases.v0_3_0,
+    'v0.3.0': releases.v0_3_0,
+}
+
+
+def baseline_cli_overrides(
+    baseline: str,
+    *,
+    useeio_pin_json: str | None = None,
+) -> dict[str, object]:
+    """Build ``diagnostics_cli_overrides`` for ``--baseline``."""
+    key = baseline.strip()
+    if not key:
+        raise ValueError('baseline must be a non-empty string')
+
+    if key.lower() == 'useeio':
+        pin_path = useeio_pin_json or DEFAULT_USEEIO_BASELINE_PIN_JSON
+        overrides: dict[str, object] = dict(
+            load_useeio_baseline_pin_overrides(pin_path)
+        )
+        overrides['diagnostics_baseline_source'] = 'gcs_useeio_xlsx'
+        return overrides
+
+    snap = NAMED_BASELINES.get(key)
+    if snap is None:
+        allowed = set(
+            ta.get_args(
+                USAConfig.model_fields['snapshot_version_or_git_sha'].annotation
+            )
+        )
+        if key not in allowed:
+            named = ', '.join(['useeio', *sorted(NAMED_BASELINES)])
+            raise ValueError(
+                f'Unknown diagnostics baseline {key!r}. '
+                f'Use one of: {named}; or an allowed snapshot SHA.'
+            )
+        snap = key
+
+    return {
+        'diagnostics_baseline_source': 'gcs_snapshot',
+        'snapshot_version_or_git_sha': snap,
+    }

--- a/bedrock/utils/validation/dispatch_diagnostics.py
+++ b/bedrock/utils/validation/dispatch_diagnostics.py
@@ -9,7 +9,7 @@ Usage (feature configs)::
     uv run python -m bedrock.utils.validation.dispatch_diagnostics \\
         --git-ref main \\
         --configs my_atomic_config \\
-        --baseline-label "Bedrock v0.3 snapshot based" \\
+        --baseline v0.3 \\
         --dry-run
 """
 
@@ -81,15 +81,22 @@ def trigger_workflow(
     git_ref: str,
     config_name: str,
     sheet_id: str,
-    use_useeio_baseline: bool,
+    use_useeio_baseline: bool = False,
+    baseline: str | None = None,
     model_base_year: int | None = None,
     usa_ghg_data_year: int | None = None,
 ) -> None:
     """Trigger ``generate_diagnostics.yml`` via ``gh workflow run``.
 
+    ``baseline`` is the comparison target (``ceda-v0``, ``useeio``, ``v0.3``,
+    or a snapshot SHA). When omitted, ``use_useeio_baseline`` selects
+    ``useeio`` vs ``ceda-v0`` for back-compat with epic dispatchers.
+
     Omit ``model_base_year`` / ``usa_ghg_data_year`` to leave the config YAML's
     years unchanged (recommended for configs that hard-code years).
     """
+    if baseline is None:
+        baseline = "useeio" if use_useeio_baseline else "ceda-v0"
     cmd = [
         "gh",
         "workflow",
@@ -102,7 +109,7 @@ def trigger_workflow(
         "-f",
         f"sheet_id={sheet_id}",
         "-f",
-        f"use_useeio_baseline={'true' if use_useeio_baseline else 'false'}",
+        f"baseline={baseline}",
     ]
     if model_base_year is not None:
         cmd += ["-f", f"model_base_year={model_base_year}"]
@@ -255,7 +262,7 @@ def dispatch_feature_configs(
     *,
     git_ref: str,
     configs: tuple[str, ...],
-    baseline_label: str,
+    baseline: str = "ceda-v0",
     use_useeio_baseline: bool = False,
     drive_folder_id: str = V04_DIAGNOSTICS_DRIVE_FOLDER_ID,
     feature_label: str | None = None,
@@ -269,15 +276,20 @@ def dispatch_feature_configs(
 
     Default folder is v0.4 Diagnostics. Titles follow
     ``feature_sheet_title``. Skips titles already present in the index CSV.
+
+    ``baseline`` selects the comparison target (``ceda-v0``, ``useeio``,
+    ``v0.3``, …) and is written into the sheet title. ``use_useeio_baseline``
+    forces ``baseline='useeio'`` for back-compat.
     """
     if not configs:
         raise ValueError("At least one --configs stem is required")
-    if not baseline_label.strip():
-        raise ValueError("--baseline-label is required")
+    if use_useeio_baseline:
+        baseline = "useeio"
 
     today = title_date or dt.datetime.utcnow().strftime("%Y-%m-%d")
     index = index_path or _DEFAULT_FEATURE_INDEX
     n_dispatched = 0
+    use_useeio = baseline.strip().lower() == "useeio"
 
     for config_name in configs:
         model_base_year, usa_ghg_data_year = _years_for_config(config_name)
@@ -285,7 +297,7 @@ def dispatch_feature_configs(
         title = feature_sheet_title(
             today=today,
             model_year=model_base_year,
-            baseline_label=baseline_label,
+            baseline_label=baseline,
             feature_label=label,
         )
         if _already_recorded_title(index, title):
@@ -294,12 +306,14 @@ def dispatch_feature_configs(
 
         if dry_run:
             logger.info(
-                "DRY-RUN would create: %s | folder=%s config=%s use_useeio=%s "
-                "model_base_year=%d usa_ghg_data_year=%d pass_years=%s",
+                "DRY-RUN would create: %s | folder=%s config=%s baseline=%s "
+                "use_useeio=%s model_base_year=%d usa_ghg_data_year=%d "
+                "pass_years=%s",
                 title,
                 drive_folder_id,
                 config_name,
-                use_useeio_baseline,
+                baseline,
+                use_useeio,
                 model_base_year,
                 usa_ghg_data_year,
                 pass_year_overrides,
@@ -316,7 +330,7 @@ def dispatch_feature_configs(
             git_ref=git_ref,
             config_name=config_name,
             sheet_id=sheet_id,
-            use_useeio_baseline=use_useeio_baseline,
+            baseline=baseline,
             model_base_year=model_base_year if pass_year_overrides else None,
             usa_ghg_data_year=usa_ghg_data_year if pass_year_overrides else None,
         )
@@ -324,10 +338,10 @@ def dispatch_feature_configs(
             index,
             {
                 "config_name": config_name,
-                "baseline_label": baseline_label,
+                "baseline_label": baseline,
                 "sheet_id": sheet_id,
                 "sheet_title": title,
-                "useeio_box_ticked": str(use_useeio_baseline).lower(),
+                "useeio_box_ticked": str(use_useeio).lower(),
                 "model_base_year": model_base_year,
                 "usa_ghg_data_year": usa_ghg_data_year,
                 "git_ref": git_ref,
@@ -353,18 +367,14 @@ def main() -> None:
         help="Comma-separated USA config stems (filename without .yaml).",
     )
     parser.add_argument(
-        "--baseline-label",
-        required=True,
-        help=(
-            'Title baseline text, e.g. "CEDA-US v0 based", '
-            '"Bedrock v0.3 snapshot based", '
-            '"USEEIO USEEIOv2.6.0-phoebe-23 based".'
-        ),
+        "--baseline",
+        default="ceda-v0",
+        help="Comparison target: ceda-v0 | useeio | v0.3 (or a snapshot SHA). Default: ceda-v0.",
     )
     parser.add_argument(
         "--use-useeio-baseline",
         action="store_true",
-        help="Tick the USEEIO Excel baseline pin on the workflow.",
+        help="Alias for --baseline useeio.",
     )
     parser.add_argument(
         "--drive-folder-id",
@@ -409,7 +419,7 @@ def main() -> None:
     dispatch_feature_configs(
         git_ref=args.git_ref,
         configs=configs,
-        baseline_label=args.baseline_label,
+        baseline=args.baseline,
         use_useeio_baseline=args.use_useeio_baseline,
         drive_folder_id=args.drive_folder_id,
         feature_label=args.feature_label or None,

--- a/bedrock/utils/validation/evaluate_feature_impact.md
+++ b/bedrock/utils/validation/evaluate_feature_impact.md
@@ -19,32 +19,20 @@ Post-run plotting and multi-run merges:
 
 ## Choose a baseline
 
-Three baseline identities map onto two loader modes:
+Pick the comparison at dispatch time via ``--baseline`` (or the workflow
+``baseline`` input). Do not fork a config YAML only to change it.
 
-| Baseline identity | How | What the sheet compares |
-|---|---|---|
-| **CEDA-US v0** | Leave `snapshot_version_or_git_sha` at its default, `'v0'`; leave the USEEIO box unticked | `N_old` / `D_old` are the legacy CEDA-US v0 snapshot EFs |
-| **Bedrock / Cornerstone model snapshot** | Set `snapshot_version_or_git_sha` to the desired model snapshot SHA. For the latest accepted model, use the SHA in `bedrock/utils/snapshots/.SNAPSHOT_KEY`. Leave the USEEIO box unticked | `N_old` / `D_old` are the selected Bedrock / Cornerstone snapshot EFs |
-| **USEEIO Excel baseline** | Tick `use_useeio_baseline` / pass `--useeio_baseline_pin_json` | `N_old` / `D_old` are the D/N rows from the workbook in `useeio_baseline_pin.json`. Emits `_purchaser` N columns (model-purchaser vs USEEIO-purchaser) |
+| ``--baseline`` | What the sheet compares |
+|---|---|
+| ``ceda-v0`` (default) | Legacy CEDA-US v0 snapshot EFs |
+| ``useeio`` | USEEIO Excel pin (`useeio_baseline_pin.json`); emits `_purchaser` N columns |
+| ``v0.3`` | Current Bedrock / Cornerstone v0.3 snapshot EFs |
+| a snapshot SHA | Any key allowed on `USAConfig.snapshot_version_or_git_sha` (older or future releases) |
 
-CEDA-US v0 and Bedrock / Cornerstone snapshots both use
-`diagnostics_baseline_source='gcs_snapshot'`; `snapshot_version_or_git_sha`
-selects which snapshot. The USEEIO workbook uses
-`diagnostics_baseline_source='gcs_useeio_xlsx'` and is pinned by URI, SHA-256,
-and model-version label.
+Leave `snapshot_version_or_git_sha` at its YAML default (`'v0'`). The baseline
+is **one per sheet** — run separate sheets for separate baselines.
 
-The baseline is **one per sheet**. Snapshot and USEEIO modes are mutually
-exclusive. A USEEIO run does not also carry a CEDA-US or Bedrock / Cornerstone
-snapshot comparison; run a separate sheet for each baseline. `_purchaser`
-columns appear only on USEEIO-baseline sheets.
-
-Use precise baseline labels in sheet titles and run indexes: `CEDA-US v0
-based`, `Bedrock <release-or-short-SHA> snapshot based`, or `USEEIO
-<model-version-label> based`. Do not use bare `CEDA based` for a Bedrock /
-Cornerstone snapshot.
-
-Trust `config_summary` for resolved years and baseline fields, not the
-dispatch override alone.
+Trust `config_summary` for the resolved baseline fields.
 
 ## Sheets, Drive folders, and naming
 
@@ -109,12 +97,12 @@ the module CLI (default folder = v0.4 Diagnostics):
 uv run python -m bedrock.utils.validation.dispatch_diagnostics `
   --git-ref <branch-or-main> `
   --configs <config_stem> `
-  --baseline-label "Bedrock v0.3 snapshot based" `
+  --baseline v0.3 `
   --dry-run
 ```
 
-Omit `--dry-run` once titles are reviewed. Pass `--use-useeio-baseline` when
-the baseline is the USEEIO pin. Run-index default:
+Omit `--dry-run` once titles are reviewed. Use `--baseline useeio` for the
+USEEIO pin. Run-index default:
 `bedrock/utils/validation/output/ef_run_index_feature.csv`.
 
 ## One-off diagnostics run
@@ -129,11 +117,11 @@ the baseline is the USEEIO pin. Run-index default:
 gh workflow run generate_diagnostics.yml --ref <branch-or-main> `
   -f config_name=<config_stem> `
   -f sheet_id=<google_sheet_id> `
-  -f use_useeio_baseline=false
+  -f baseline=ceda-v0
 ```
 
 Optional inputs: `pr_url`, `model_base_year`, `usa_ghg_data_year`,
-`use_useeio_baseline=true`.
+`baseline` (`ceda-v0`, `useeio`, `v0.3`, or a snapshot SHA).
 
 Leave year overrides empty when the YAML already sets the correct
 `model_base_year` / `usa_ghg_data_year`. Overriding a year a flag forbids
@@ -150,17 +138,11 @@ many runs without waiting drops pending ones.
 ```powershell
 uv run python -m bedrock.utils.validation.generate_diagnostics `
   --sheet_id <google_sheet_id> `
-  --config_name <config_stem>
-```
-
-USEEIO pin:
-
-```powershell
-uv run python -m bedrock.utils.validation.generate_diagnostics `
-  --sheet_id <google_sheet_id> `
   --config_name <config_stem> `
-  --useeio_baseline_pin_json bedrock/utils/snapshots/useeio_baseline_pin.json
+  --baseline ceda-v0
 ```
+
+Other common targets: `--baseline v0.3`, `--baseline useeio`.
 
 Requires Google application-default credentials with Sheets write access.
 
@@ -221,7 +203,8 @@ guide covers the single-flag (or small list) path.
 - How large are % and absolute changes on `D_and_N_significant_sectors`
   versus the full distribution?
 - Does `config_summary` show the intended flag, years, and baseline
-  (`snapshot_version_or_git_sha` / USEEIO pin fields)?
+  (`diagnostics_baseline_source`, `baseline_snapshot_key_used` / USEEIO pin
+  fields)?
 - Are apparent agreements methodological tautologies (shared frozen structure
   with the baseline) rather than independent validation?
 
@@ -231,9 +214,11 @@ guide covers the single-flag (or small list) path.
   locks years → `ValueError` during config validation. Prefer the YAML’s
   years; align the sheet title year if it was wrong.
 - **Interim config pinned to an old snapshot.** A YAML that sets
-  `snapshot_version_or_git_sha` and flips an interim flag may fail to
-  resolve methods on current `main`. Run against the ref that matches the
-  pin, or fold the effect into a bundled config that `main` supports.
+  `snapshot_version_or_git_sha` (legacy pin) and flips an interim flag may
+  fail to resolve methods on current `main`. Prefer selecting the
+  comparison via `--baseline` / workflow `baseline`, and run against the
+  git ref that matches any *model* pin the config still needs, or fold the
+  effect into a bundled config that `main` supports.
 - **Empty sheet after a “successful” dispatch.** The workflow triggered but
   the model job failed; check the Actions log. Re-dispatch reuses the same
   `sheet_id`.

--- a/bedrock/utils/validation/generate_diagnostics.py
+++ b/bedrock/utils/validation/generate_diagnostics.py
@@ -20,6 +20,10 @@ from bedrock.utils.config.usa_config import (
 )
 from bedrock.utils.io.gcp import delete_default_sheet1, update_sheet_tab
 from bedrock.utils.snapshots.loader import resolve_snapshot_key
+from bedrock.utils.validation.diagnostics_baseline import (
+    DEFAULT_USEEIO_BASELINE_PIN_JSON,
+    baseline_cli_overrides,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -37,10 +41,25 @@ logger = logging.getLogger(__name__)
 @click.option('--git_branch', default=None, type=str, help='Override git branch name')
 @click.option('--pr_url', default=None, type=str, help='Override PR URL')
 @click.option(
+    '--baseline',
+    default=None,
+    type=str,
+    help=(
+        'Comparison target for this run (does not edit the config YAML). '
+        'ceda-v0 | useeio | v0.3, or any allowed snapshot SHA.'
+    ),
+)
+@click.option(
     '--diagnostics_baseline_source',
     default=None,
     type=click.Choice(['gcs_snapshot', 'gcs_useeio_xlsx']),
     help='Override diagnostics baseline source (merged onto config YAML)',
+)
+@click.option(
+    '--snapshot_version_or_git_sha',
+    default=None,
+    type=str,
+    help='Low-level snapshot key override; prefer --baseline.',
 )
 @click.option(
     '--useeio_baseline_pin_json',
@@ -50,7 +69,8 @@ logger = logging.getLogger(__name__)
         'JSON with gs_uri, sha256, model_version_label (see '
         'bedrock/utils/snapshots/useeio_baseline_pin.json). Selects '
         "diagnostics_baseline_source='gcs_useeio_xlsx' unless overridden by "
-        '--diagnostics_baseline_source.'
+        '--diagnostics_baseline_source. Implied by --baseline useeio '
+        f'(default pin: {DEFAULT_USEEIO_BASELINE_PIN_JSON}).'
     ),
 )
 @click.option(
@@ -77,13 +97,20 @@ def generate_diagnostics(
     config_name: str,
     git_branch: str | None,
     pr_url: str | None,
+    baseline: str | None,
     diagnostics_baseline_source: str | None,
+    snapshot_version_or_git_sha: str | None,
     useeio_baseline_pin_json: str | None,
     model_base_year: int | None,
     usa_ghg_data_year: int | None,
 ) -> None:
     total_start = time.time()
     overrides: dict[str, object] = {}
+
+    # Precedence: explicit USEEIO pin > --baseline > lower-level snapshot
+    # source/SHA flags > YAML defaults. Pin and --baseline useeio both select
+    # Excel mode; --snapshot_version_or_git_sha / --diagnostics_baseline_source
+    # can still force snapshot mode afterward (tests rely on that).
     if useeio_baseline_pin_json is not None:
         from bedrock.utils.validation.useeio_excel_baseline import (
             load_useeio_baseline_pin_overrides,
@@ -92,6 +119,17 @@ def generate_diagnostics(
         pin_fragment = load_useeio_baseline_pin_overrides(useeio_baseline_pin_json)
         overrides.update(pin_fragment)
         overrides['diagnostics_baseline_source'] = 'gcs_useeio_xlsx'
+    elif baseline is not None:
+        overrides.update(
+            baseline_cli_overrides(
+                baseline,
+                useeio_pin_json=None,
+            )
+        )
+
+    if snapshot_version_or_git_sha is not None:
+        overrides['snapshot_version_or_git_sha'] = snapshot_version_or_git_sha
+        overrides.setdefault('diagnostics_baseline_source', 'gcs_snapshot')
     if diagnostics_baseline_source is not None:
         overrides['diagnostics_baseline_source'] = diagnostics_baseline_source
     if model_base_year is not None:


### PR DESCRIPTION
cc: @WesIngwersen 
Closes:

## What changed? Why?

Diagnostics comparison target is selected at dispatch time via `--baseline` (or the `generate_diagnostics.yml` workflow `baseline` input), not by editing `snapshot_version_or_git_sha` in the model config YAML.

Named baselines: `ceda-v0` (default), `useeio`, `v0.3`. Any snapshot key allowed on `USAConfig.snapshot_version_or_git_sha` also works for older or future releases. The workflow exposes a single `baseline` input; `use_useeio_baseline` was removed from `generate_diagnostics.yml` (Slack notifications report `baseline` only). Epic dispatchers may still accept `--use-useeio-baseline`, which maps to `baseline=useeio` in `trigger_workflow` before calling `gh`.

- `bedrock/utils/validation/diagnostics_baseline.py` maps `--baseline` → `diagnostics_cli_overrides`
- `generate_diagnostics.py` merges overrides through the existing `set_global_usa_config` path; adds `--snapshot_version_or_git_sha` for low-level use
- `dispatch_diagnostics.py` passes `baseline` to the workflow; sheet titles use the baseline key
- Playbooks (`evaluate_feature_impact.md`, `feature_flag.md`) instruct leaving YAML at `'v0'` and choosing the comparison at dispatch
- `bedrock/utils/snapshots/README.md` Phase A checklist and § B6 document snapshot-bump steps for `NAMED_BASELINES` and dispatch-time baseline selection

## Testing

Note the new "comparison target" in the workflow which is accessible (and replaces the USEEIO checkbox)

<img width="461" height="649" alt="image" src="https://github.com/user-attachments/assets/01f34c93-3828-4f34-9e50-e65485edece9" />
