### PR TITLE
Stop a code missing from Sector_Levels from silently emptying a whole FBS method

### DIFF
--- a/bedrock/extract/flowbyactivity.py
+++ b/bedrock/extract/flowbyactivity.py
@@ -736,6 +736,15 @@ class FlowByActivity(_FlowBy):
                     convert_df_to_flowby=True,
                 )
             except ValueError:
+                # This discards every activity_set, not just the one that
+                # failed, so a fault in one silently zeroes the whole method.
+                # Log it - the silence is what makes this class of bug expensive
+                # to find.
+                log.exception(
+                    'Discarding ALL activity_sets for %s: one of them raised '
+                    'while being prepared. The method will return no rows.',
+                    self.full_name,
+                )
                 return FlowBySector(pd.DataFrame(), convert_df_to_flowby=True)
         log.info(f'Processing FlowBySector for {self.full_name}')
         # Primary FlowBySector generation approach:

--- a/bedrock/utils/mapping/sectormapping.py
+++ b/bedrock/utils/mapping/sectormapping.py
@@ -110,6 +110,20 @@ def assign_technological_correlation(mapping: pd.DataFrame) -> pd.DataFrame:
             .drop(columns=['Sector'])
             .rename(columns={'SectorLength': f'{i}Length'})
         )
+    # Sector_Levels does not register every code that can legitimately be a
+    # target. `non_naics` exists so a method can name an industry that is not a
+    # NAICS code at all, and industry_spec_key's docstring asks only for an
+    # activity-to-sector crosswalk in return - nothing tells the caller the code
+    # must also appear here. Left unfilled, the left merges above produce NaN
+    # lengths and the astype(int) below raises ValueError, which prepare_fbs
+    # catches and turns into an empty FlowBySector for the *whole* method, with
+    # no indication of the cause. Fall back to the code's own length: for the
+    # identity mappings non_naics creates, source and target lengths are equal
+    # either way, so SectorDifference is 0 and the score is unaffected.
+    for i in ['source', 'target']:
+        mapping[f'{i}Length'] = mapping[f'{i}Length'].fillna(
+            mapping[f'{i}_naics'].astype(str).str.len()
+        )
     mapping = mapping.assign(
         SectorDifference=mapping['targetLength'].astype(int)
         - mapping['sourceLength'].astype(int)


### PR DESCRIPTION
## The bug

`assign_technological_correlation` left-merges the naics key against `Sector_Levels` to get a length for each source and target code, then does:

```python
mapping['targetLength'].astype(int) - mapping['sourceLength'].astype(int)
```

A code absent from `Sector_Levels` leaves `NaN` there, and `astype(int)` raises `ValueError: cannot convert float NaN to integer`.

`prepare_fbs`'s activity_sets branch catches `ValueError` and returns an empty `FlowBySector` — for **every** activity_set, not just the one that failed. So naming a single unregistered code in `non_naics` makes the entire method produce no rows, with nothing in the log but `Error, dataframe is empty`.

Reproducible on `main` today:

```
non_naics + ['562000']  ->  ValueError: cannot convert float NaN to integer
```

## Why it matters

`non_naics` exists precisely so a method can target an industry that is not a NAICS code, and `industry_spec_key`'s docstring asks the caller only for an activity-to-sector crosswalk in return. Nothing tells you the code must *also* be registered in `Sector_Levels`.

The split is clean. Every code that works is in `Sector_Levels` (`S00401`, `S00402`, `531HSO`/`531HST`/`531ORE`, `S00203`, `S00300`, `S00900`); every code that kills the method is not (`562000`, and the `33329A`/`336500`/`541300` family the BEA equipment crosswalk needs). This cost most of a day to find, because the failure surfaced four levels away as an empty final-demand column.

## The fix

1. Fall back to the code's own string length when `Sector_Levels` has no entry. For the identity mappings `non_naics` creates, source and target lengths are equal whatever value is used, so `SectorDifference` is 0 and the correlation score is unaffected.
2. `log.exception` before discarding the activity sets. Control flow is unchanged — this only makes the failure visible.

## Verification

```
                                          before          after
non_naics + ['562000']                    ValueError      3711 rows
non_naics + ['562000','33329A','336500','541300']  —       3714 rows
```

**No behaviour change for anything that works today**: any input that now reaches the `fillna` would previously have raised. Confirmed on the NIPA_FD_2017 measurement, unchanged at 237/300 cells within 1% and −3.20% against the 2017 Use SUT.

## Context

Split out of `nipa_fd_allocation_fix`, where it is the enabling fix for moving the FBS into BEA commodity space. Standalone and useful on its own, so raising it separately rather than gating it behind that larger work. Broader plan on `plan_bea_code_space` (`.claude/plan/bea_code_space_cleanup.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)