### PR TITLE
fix(validation): rebase snapshot EF baselines by their dollar year

### DIFF
--- a/bedrock/utils/snapshots/README.md
+++ b/bedrock/utils/snapshots/README.md
@@ -132,7 +132,7 @@ Wait for the success notification in `#alerts-bedrock`. Artifacts will be at `gs
 On a new branch, make exactly these changes (and nothing else — keep the bump PR mechanical and reviewable in under a minute):
 
 - [ ] [`bedrock/utils/snapshots/.SNAPSHOT_KEY`](.SNAPSHOT_KEY) — replace the file's only line with the new SHA.
-- [ ] [`bedrock/utils/snapshots/releases.py`](releases.py) — add the new release constant (e.g. `v0_4_0 = "<sha>"`) with a trailing `# config: <stem>` comment (the `generate_snapshots --config_name` value). Leave prior release entries in place. Use underscores in the Python identifier; the git tag uses dots. Do **not** add entries for patch-only releases.
+- [ ] [`bedrock/utils/snapshots/releases.py`](releases.py) — add the new release constant (e.g. `v0_4_0 = "<sha>"`) with a trailing `# config: <stem>` comment (the `generate_snapshots --config_name` value). Leave prior release entries in place. Use underscores in the Python identifier; the git tag uses dots. Do **not** add entries for patch-only releases. Register the snapshot's EF dollar year (``B`` / ``D`` / ``N`` intensity year) in ``EF_DOLLAR_YEAR_BY_SNAPSHOT_KEY`` in the same edit.
 - [ ] [`bedrock/utils/config/usa_config.py`](../config/usa_config.py) — extend the `snapshot_version_or_git_sha: Literal[...]` to include the new SHA, with a trailing comment noting the release label (e.g. `# v0.4.0`). Do **not** remove old SHAs — atomic configs and test fixtures may still reference them.
 - [ ] [`bedrock/utils/validation/diagnostics_baseline.py`](../validation/diagnostics_baseline.py) — when the release is a common diagnostics comparison target, add a short alias to `NAMED_BASELINES` (e.g. `'v0.4': releases.v0_4_0`, `'v0.4.0': releases.v0_4_0`). Operators can always pass the raw SHA via `--baseline` once the `Literal` includes it; the alias is for convenience (`--baseline v0.4`).
 - [ ] Title: `release: snapshot bump (anticipated v0.X.Y)`
@@ -221,6 +221,11 @@ A clean bump PR diff looks roughly like this (anticipating release `v0.3.0`):
 +++ b/bedrock/utils/snapshots/releases.py
  v0_2 = "7372464249c434c9bebb172c065a4d0e3702176e"  # config: 2025_usa_cornerstone_v0_2
 +v0_3_0 = "<new_sha>"  # config: 2025_usa_cornerstone_v0_3
++
++ EF_DOLLAR_YEAR_BY_SNAPSHOT_KEY: dict[str, int] = {
++     ...
++     v0_3_0: 2024,
++ }
 
 --- a/bedrock/utils/config/usa_config.py
 +++ b/bedrock/utils/config/usa_config.py
@@ -243,7 +248,7 @@ A clean bump PR diff looks roughly like this (anticipating release `v0.3.0`):
  }
 ```
 
-Four mechanical files (`.SNAPSHOT_KEY`, `releases.py`, `usa_config.py`, and optionally `diagnostics_baseline.py` when adding a named alias). If anything else needs to change, it belongs in a separate PR.
+Four mechanical files (`.SNAPSHOT_KEY`, `releases.py` including ``EF_DOLLAR_YEAR_BY_SNAPSHOT_KEY``, `usa_config.py`, and optionally `diagnostics_baseline.py` when adding a named alias). If anything else needs to change, it belongs in a separate PR.
 
 ## Rolling back
 

--- a/bedrock/utils/snapshots/releases.py
+++ b/bedrock/utils/snapshots/releases.py
@@ -13,6 +13,11 @@ via the `generate_snapshots workflow
 
 Update the current release entry in Phase A when ``.SNAPSHOT_KEY`` changes.
 Patch releases that leave ``.SNAPSHOT_KEY`` unchanged do not add entries here.
+
+``EF_DOLLAR_YEAR_BY_SNAPSHOT_KEY`` records the dollar year of ``B`` (and thus
+``D`` / ``N``) intensities in each snapshot. Diagnostics rebase snapshot EFs
+from that year to the live ``model_base_year``. Update the map in the same
+Phase A change that adds a new snapshot key.
 """
 
 # Release snapshots (GCS prefix or git SHA)
@@ -32,3 +37,28 @@ TEST_config_default = (
     "2ebb51f7190c3a62b5d8b2420bff9b20f57282fc"  # config: 2025_usa_cornerstone_v0_2
 )
 TEST_fbs_schema = "9fe22d9afdfdb6806397b2356eb3cf4c4c346744"  # config: 2025_usa_cornerstone_fbs_schema
+
+# Dollar year of B/D/N in each snapshotted model used as a diagnostics baseline.
+EF_DOLLAR_YEAR_BY_SNAPSHOT_KEY: dict[str, int] = {
+    v0: 2023,
+    v0_1: 2023,
+    v0_2: 2023,
+    v0_3_0_alpha: 2023,
+    v0_3_beta: 2024,
+    v0_3_0: 2024,
+    TEST_config_default: 2023,
+    TEST_fbs_schema: 2023,
+}
+
+
+def ef_dollar_year_for_snapshot(key: str) -> int:
+    """Return the EF denominator dollar year for a GCS snapshot key."""
+    try:
+        return EF_DOLLAR_YEAR_BY_SNAPSHOT_KEY[key]
+    except KeyError as exc:
+        known = ', '.join(sorted(EF_DOLLAR_YEAR_BY_SNAPSHOT_KEY))
+        raise ValueError(
+            f'No EF dollar year registered for snapshot key {key!r}. '
+            f'Add it to EF_DOLLAR_YEAR_BY_SNAPSHOT_KEY in '
+            f'bedrock.utils.snapshots.releases (known: {known}).'
+        ) from exc

--- a/bedrock/utils/validation/diagnostics_helpers.py
+++ b/bedrock/utils/validation/diagnostics_helpers.py
@@ -28,8 +28,12 @@ from bedrock.utils.schemas.cornerstone_schemas import (
     ELECTRICITY_AGGREGATE_SECTOR,
     ELECTRICITY_DISAGG_SECTORS,
 )
-from bedrock.utils.snapshots.loader import load_configured_snapshot
+from bedrock.utils.snapshots.loader import (
+    load_configured_snapshot,
+    resolve_snapshot_key,
+)
 from bedrock.utils.snapshots.names import SnapshotName
+from bedrock.utils.snapshots.releases import ef_dollar_year_for_snapshot
 from bedrock.utils.taxonomy.bea.ceda_v7 import CEDA_V7_SECTOR_DESC
 
 logger = logging.getLogger(__name__)
@@ -807,10 +811,15 @@ def pull_efs_for_diagnostics() -> EfsForDiagnostics:
             f'in {time.time() - t0:.1f}s'
         )
     else:
+        snap_key = resolve_snapshot_key()
+        old_base_year = ef_dollar_year_for_snapshot(snap_key)
         B_old = load_configured_snapshot(B_snapshot_name)
         Adom_old = load_configured_snapshot(Adom_snapshot_name)
         Aimp_old = load_configured_snapshot(Aimp_snapshot_name)
-        logger.info(f'[TIMING] Old snapshots loaded in {time.time() - t0:.1f}s')
+        logger.info(
+            f'[TIMING] Old snapshots loaded (key={snap_key}, '
+            f'dollar_year={old_base_year}) in {time.time() - t0:.1f}s'
+        )
 
         t0 = time.time()
         L_old = compute_L_matrix(A=Adom_old + Aimp_old)
@@ -820,7 +829,6 @@ def pull_efs_for_diagnostics() -> EfsForDiagnostics:
         logger.info(
             f'[TIMING] Old L, M, D, N matrices computed in {time.time() - t0:.1f}s'
         )
-        old_base_year = 2023
 
     t0 = time.time()
     D_old_inflated = inflation_adjust_ef_denom_to_new_base_year(
@@ -833,7 +841,10 @@ def pull_efs_for_diagnostics() -> EfsForDiagnostics:
         new_base_year=new_base_year,
         old_base_year=old_base_year,
     )
-    logger.info(f'[TIMING] Inflation adjustment completed in {time.time() - t0:.1f}s')
+    logger.info(
+        f'[TIMING] Inflation adjustment ({old_base_year}→{new_base_year} $) '
+        f'completed in {time.time() - t0:.1f}s'
+    )
 
     n_new_purchaser: pd.DataFrame | None = None
     n_old_purchaser: pd.DataFrame | None = None


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?
Diagnostics percent-diffs for GCS snapshot baselines rebase old `D`/`N` from a fixed `old_base_year=2023` to the live `model_base_year`. That was correct for CEDA v0 (2023$) baselines, but wrong for the v0.3 release snapshot (`c60bdf43`), whose `B`/`D`/`N` are already in 2024$. Against `--baseline v0.3` with `model_base_year=2024`, every sector picked up a spurious `PI_2023/PI_2024` rescale in `N_perc_diff` / `D_perc_diff`, masking real model deltas (e.g. waste Use-intersection orientation fixes).

`EF_DOLLAR_YEAR_BY_SNAPSHOT_KEY` in `bedrock/utils/snapshots/releases.py` records the EF intensity dollar year per snapshot key used as a diagnostics baseline. `pull_efs_for_diagnostics` resolves that year via `ef_dollar_year_for_snapshot(resolve_snapshot_key())`. The snapshot Phase A bump checklist documents registering the year alongside a new release key.

## Testing

- Inspect logs on a re-run of `generate_diagnostics` with `--baseline v0.3` and `2025_usa_cornerstone_v0_3`: expect `dollar_year=2024` and inflation `2024→2024 $` (identity).
- Spot-check `N_and_diffs`: with live main vs v0.3 snapshot (no model drift), `N_perc_diff` should be ~0 rather than ~price-index scale.

```powershell
# After push, re-dispatch from the PR branch tip:
gh workflow run generate_diagnostics.yml --ref by_fix_diagnostics_year `
  -f config_name=2025_usa_cornerstone_v0_3 `
  -f baseline=v0.3 `
  -f sheet_id=<sheet_id> `
  -f model_base_year=2024 `
  -f usa_ghg_data_year=2024
```