### PR TITLE
test(validation): live-rebuild waterfall configs against sheet N_new

### DIFF
--- a/bedrock/transform/__tests__/test_waterfall_progression.py
+++ b/bedrock/transform/__tests__/test_waterfall_progression.py
@@ -1,0 +1,128 @@
+"""Live reproducibility of v0.3 waterfall configs (except pinned baselines).
+
+Each live case rebuilds ``derive_Aq_usa`` + ``derive_B_usa_non_finetuned`` for
+one ``v03_waterfall_*`` config, q-weights ``1ᵀ B L`` with canonical
+``scaled_q_USA``, and compares to the diagnostics sheet ``N_new`` pin.
+
+Configs covered (union of USEEIO + CEDA group registries):
+
+* ``v03_waterfall_useeio_g1_schema_ghg``
+* ``v03_waterfall_ceda_g1a_schema_ghg``
+* ``v03_waterfall_ceda_g1b_waste_disagg``
+* ``v03_waterfall_g2_methods``
+* ``v03_waterfall_g3_data``
+* ``v03_waterfall_final``
+
+Not rebuilt: pinned USEEIO baseline / pinned CEDA v0 baseline.
+
+Pins recomputed 2026-08-05 via::
+
+    uv run python -m bedrock.utils.validation.waterfall_progression --sheet-n-new
+
+Assessment plot bars (``N_old_inflated`` / ``N_new_inflated``) are checked
+separately from sheets only — see ``test_assessment_useeio_*``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+
+import pytest
+
+from bedrock.utils.validation.waterfall_progression import (
+    ASSESSMENT_USEEIO_BEDROCK_LEVELS,
+    assert_useeio_track_sheet_ids_match_registry,
+    assessment_useeio_bedrock_levels,
+    live_waterfall_configs,
+    sheet_n_new_levels,
+)
+
+# q-weighted sheet N_new (kgCO2e/USD). Source: --sheet-n-new.
+# Live 1ᵀBL matches these. USEEIO G1 (~0.314) is *not* the assessment G1 bar:
+# that config builds B with deflate_x_to_detail_io_year_for_B, so N_new is in
+# usa_detail_original_year dollars; the figure uses N_new_inflated (PI rebase
+# to model_base_year 2024$). G2/G3/FINAL assessment bars use N_new and match.
+EXPECTED_LIVE_N_NEW = {
+    'v03_waterfall_useeio_g1_schema_ghg': 0.3135957,
+    'v03_waterfall_ceda_g1a_schema_ghg': 0.2543301,
+    'v03_waterfall_ceda_g1b_waste_disagg': 0.2563729,
+    'v03_waterfall_g2_methods': 0.2398356,
+    'v03_waterfall_g3_data': 0.2416736,
+    'v03_waterfall_final': 0.2416736,
+}
+
+# Assessment USEEIO-track bars (ceda combine_ef columns × canonical q).
+# Pin/G1 use inflated columns; G2/G3 use N_new (= live pins above).
+EXPECTED_ASSESSMENT_USEEIO_BEDROCK_N = {
+    'pinned_useeio_baseline': 0.2520542,
+    'G1': 0.2462974,
+    'G2': 0.2398356,
+    'G3': 0.2416736,
+}
+
+ATOL_KG_PER_USD = 1e-4
+_STEP_TIMEOUT_S = 3600
+
+
+def _run_progression_cli(arg: str) -> float:
+    proc = subprocess.run(
+        [sys.executable, '-m', 'bedrock.utils.validation.waterfall_progression', arg],
+        capture_output=True,
+        text=True,
+        timeout=_STEP_TIMEOUT_S,
+        check=False,
+    )
+    assert proc.returncode == 0, (
+        f'waterfall step {arg!r} failed (rc={proc.returncode}):\n'
+        f'stdout tail: {proc.stdout[-2000:]}\nstderr tail: {proc.stderr[-2000:]}'
+    )
+    match = re.search(r'\{"weighted_avg_n_kg_per_usd":\s*([-0-9.eE]+)\}', proc.stdout)
+    assert match, f'no JSON result on stdout for {arg!r}: {proc.stdout[-2000:]}'
+    return float(json.loads(match.group(0))['weighted_avg_n_kg_per_usd'])
+
+
+@pytest.mark.eeio_integration
+def test_live_waterfall_config_set_matches_registries() -> None:
+    configs = live_waterfall_configs()
+    assert set(configs) == set(EXPECTED_LIVE_N_NEW)
+    assert len(configs) == len(EXPECTED_LIVE_N_NEW)
+
+
+@pytest.mark.eeio_integration
+def test_sheet_n_new_pins_match_expected() -> None:
+    """Diagnostics N_new × canonical q still matches the live expected pins."""
+    levels = sheet_n_new_levels()
+    assert set(levels) == set(EXPECTED_LIVE_N_NEW)
+    for config_name, expected in EXPECTED_LIVE_N_NEW.items():
+        assert levels[config_name] == pytest.approx(
+            expected, abs=ATOL_KG_PER_USD
+        ), config_name
+
+
+@pytest.mark.eeio_integration
+@pytest.mark.parametrize('config_name', list(EXPECTED_LIVE_N_NEW))
+def test_live_config_matches_sheet_n_new(config_name: str) -> None:
+    """Full model rebuild: live 1ᵀBL @ canonical q == sheet N_new pin."""
+    level = _run_progression_cli(config_name)
+    assert level == pytest.approx(EXPECTED_LIVE_N_NEW[config_name], abs=ATOL_KG_PER_USD)
+
+
+@pytest.mark.eeio_integration
+def test_assessment_useeio_sheet_ids_match_registry() -> None:
+    assert_useeio_track_sheet_ids_match_registry()
+    pin, g1 = ASSESSMENT_USEEIO_BEDROCK_LEVELS[0], ASSESSMENT_USEEIO_BEDROCK_LEVELS[1]
+    assert pin.sheet_id == g1.sheet_id
+    assert pin.n_column == 'N_old_inflated'
+    assert g1.n_column == 'N_new_inflated'
+
+
+@pytest.mark.eeio_integration
+def test_assessment_useeio_bedrock_weighted_n_from_sheets() -> None:
+    """Sheet × canonical q reproduces assessment bedrock bars (no rebuild)."""
+    levels = assessment_useeio_bedrock_levels()
+    assert set(levels) == set(EXPECTED_ASSESSMENT_USEEIO_BEDROCK_N)
+    for key, expected in EXPECTED_ASSESSMENT_USEEIO_BEDROCK_N.items():
+        assert levels[key] == pytest.approx(expected, abs=ATOL_KG_PER_USD), key

--- a/bedrock/transform/eeio/cornerstone_year_scaling.py
+++ b/bedrock/transform/eeio/cornerstone_year_scaling.py
@@ -188,3 +188,18 @@ def scale_cornerstone_q(
         )
 
     return q_scaled
+
+
+def scale_cornerstone_B(
+    B: pd.DataFrame,
+    target_year: USA_SUMMARY_MUT_YEARS,
+    original_year: USA_SUMMARY_MUT_YEARS,
+) -> pd.DataFrame:
+    """Scale B columns using summary q ratios (legacy pre-IO-adjustments footing)."""
+    ratio = (
+        derive_summary_q_usa(original_year) / derive_summary_q_usa(target_year)
+    ).fillna(1.0)
+    return ta.cast(
+        pd.DataFrame,
+        _apply_summary_ratio_to_sectors(ratio, B, axis='columns'),
+    )

--- a/bedrock/transform/eeio/derived_cornerstone.py
+++ b/bedrock/transform/eeio/derived_cornerstone.py
@@ -65,6 +65,7 @@ from bedrock.transform.eeio.cornerstone_expansion import (
 )
 from bedrock.transform.eeio.cornerstone_year_scaling import (
     scale_cornerstone_A,
+    scale_cornerstone_B,
     scale_cornerstone_q,
 )
 from bedrock.transform.eeio.derived_2017 import (
@@ -82,6 +83,7 @@ from bedrock.utils.economic.inflation_helpers_cornerstone import (
     get_cornerstone_industry_price_ratio,
     inflate_cornerstone_A_matrix_with_commodity_pi,
     inflate_cornerstone_A_matrix_with_industry_pi,
+    inflate_cornerstone_B_matrix_with_industry_pi,
     inflate_cornerstone_q_or_y_with_commodity_pi,
     inflate_cornerstone_q_or_y_with_industry_pi,
     inflate_cornerstone_V_with_industry_pi,
@@ -690,8 +692,25 @@ def derive_cornerstone_B_via_vnorm() -> pd.DataFrame:
 
 @functools.cache
 def derive_cornerstone_B_non_finetuned() -> pd.DataFrame:
-    """Year-scaled + inflated B, derived self-contained from CEDA v7 → cornerstone."""
-    return derive_cornerstone_B_via_vnorm()
+    """Year-scaled + inflated B, derived self-contained from CEDA v7 → cornerstone.
+
+    When ``use_ghg_year_x_in_B`` is true, B is already on the GHG-year footing
+    and stays on vnorm only. On the legacy footing, B is scaled 2017 →
+    ``usa_io_data_year`` with summary q ratios and then inflated to
+    ``model_base_year`` with the industry PI.
+    """
+    cfg = get_usa_config()
+    if cfg.use_ghg_year_x_in_B:
+        return derive_cornerstone_B_via_vnorm()
+    return inflate_cornerstone_B_matrix_with_industry_pi(
+        scale_cornerstone_B(
+            B=derive_cornerstone_B_via_vnorm(),
+            original_year=cfg.usa_detail_original_year,
+            target_year=cfg.usa_io_data_year,
+        ),
+        original_year=cfg.usa_io_data_year,
+        target_year=cfg.model_base_year,
+    )
 
 
 @functools.cache

--- a/bedrock/utils/economic/inflation_helpers_cornerstone.py
+++ b/bedrock/utils/economic/inflation_helpers_cornerstone.py
@@ -225,6 +225,14 @@ def inflate_cornerstone_q_or_y_with_industry_pi(
     return q_or_y * price_ratio.reindex(q_or_y.index, fill_value=1.0)
 
 
+def inflate_cornerstone_B_matrix_with_industry_pi(
+    B: pd.DataFrame, original_year: int, target_year: int
+) -> pd.DataFrame:
+    """Inflate B's monetary denominators via the industry PI (legacy footing)."""
+    price_ratio = get_cornerstone_industry_price_ratio(target_year, original_year)
+    return B * price_ratio.reindex(B.columns, fill_value=1.0).values
+
+
 def inflate_cornerstone_V_with_industry_pi(
     V: pd.DataFrame,
     *,

--- a/bedrock/utils/validation/__tests__/test_diagnostics_helpers.py
+++ b/bedrock/utils/validation/__tests__/test_diagnostics_helpers.py
@@ -58,7 +58,7 @@ class TestDNNewInflatedEligibility:
         )
         ok, reason = d_n_new_inflated_eligibility(cfg)
         assert ok is False
-        assert 'no denominator inflation adjustment' in reason
+        assert 'double-apply' in reason
 
     def test_skip_legacy_non_cornerstone(self) -> None:
         cfg = USAConfig(

--- a/bedrock/utils/validation/diagnostics_helpers.py
+++ b/bedrock/utils/validation/diagnostics_helpers.py
@@ -152,8 +152,9 @@ def d_n_new_inflated_eligibility(cfg: USAConfig) -> tuple[bool, str]:
         )
     return (
         False,
-        'B is not built with deflate_x_to_detail_io_year_for_B or '
-        'use_E_data_year_for_x_in_B; no denominator inflation adjustment applies',
+        'derive_cornerstone_B_non_finetuned already applies '
+        'inflate_cornerstone_B_matrix_with_industry_pi to model_base_year; '
+        'skipping second denominator inflation pass (would double-apply)',
     )
 
 

--- a/bedrock/utils/validation/waterfall_progression.py
+++ b/bedrock/utils/validation/waterfall_progression.py
@@ -125,6 +125,8 @@ def _series_from_snapshot_frame(frame: pd.DataFrame | pd.Series) -> pd.Series[fl
     squeezed = frame.squeeze()
     if isinstance(squeezed, pd.DataFrame):
         squeezed = squeezed.iloc[:, 0]
+    if not isinstance(squeezed, pd.Series):
+        raise TypeError(f'expected Series after squeeze, got {type(squeezed).__name__}')
     return squeezed.astype(float)
 
 

--- a/bedrock/utils/validation/waterfall_progression.py
+++ b/bedrock/utils/validation/waterfall_progression.py
@@ -1,0 +1,369 @@
+"""Live reproducibility of v0.3 waterfall configs (q-weighted N).
+
+Rebuilds every ``v03_waterfall_*`` config on the USEEIO and CEDA group
+registries and checks that live ``1ᵀ B L``, weighted by canonical v0.3
+``scaled_q_USA``, matches the diagnostics sheet ``N_new`` for that config.
+
+Out of scope (no live rebuild)
+------------------------------
+* Pinned USEEIO baseline (``N_old_inflated`` on the USEEIO G1 sheet)
+* Pinned CEDA v0 baseline (frozen snapshots / Excel baseline)
+
+Configs under test (unique ``config_name`` union of both registries)
+--------------------------------------------------------------------
+* ``v03_waterfall_useeio_g1_schema_ghg``
+* ``v03_waterfall_ceda_g1a_schema_ghg``
+* ``v03_waterfall_ceda_g1b_waste_disagg``
+* ``v03_waterfall_g2_methods`` (shared)
+* ``v03_waterfall_g3_data`` (shared)
+* ``v03_waterfall_final`` (shared)
+
+Expected floats are sheet ``N_new`` × canonical q (not assessment
+``N_*_inflated`` columns). Recompute::
+
+    uv run python -m bedrock.utils.validation.waterfall_progression --sheet-n-new
+
+Optional: ``--assessment-useeio`` recomputes ceda assessment USEEIO-track bars
+(pin / G1 inflated / G2 / G3) for plot alignment; that path does not rebuild.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+
+import pandas as pd
+
+from bedrock.utils.config.usa_config import CANONICAL_USA_CONFIG
+from bedrock.utils.validation.analysis import (
+    release_v0_v03_ceda_groups as ceda_groups,
+)
+from bedrock.utils.validation.analysis import (
+    release_v0_v03_useeio_groups as useeio_groups,
+)
+
+
+@dataclass(frozen=True)
+class AssessmentNLevel:
+    """One q-weighted N bar on the assessment USEEIO→bedrock chain."""
+
+    key: str
+    sheet_id: str
+    n_column: str
+    config_name: str | None
+    note: str
+
+
+# Keys / sheet IDs must match ceda ``USEEIO_TRACK`` + ``ef_combos.US_VS_USEEIO``.
+# Sheet objects: ``release_v0_v03_useeio_groups``.
+ASSESSMENT_USEEIO_BEDROCK_LEVELS: tuple[AssessmentNLevel, ...] = (
+    AssessmentNLevel(
+        key='pinned_useeio_baseline',
+        sheet_id='1AaMWSXaHfyTHWfdNvICQ13RDA-CXEQir5W77RcntQRE',
+        n_column='N_old_inflated',
+        config_name=None,
+        note='USEEIO pin from G1 diagnostics (combine_ef pin_source=bedrock_us)',
+    ),
+    AssessmentNLevel(
+        key='G1',
+        sheet_id='1AaMWSXaHfyTHWfdNvICQ13RDA-CXEQir5W77RcntQRE',
+        n_column='N_new_inflated',
+        config_name='v03_waterfall_useeio_g1_schema_ghg',
+        note='USEEIO_TRACK[ghg]; prefer N_new_inflated (2024$)',
+    ),
+    AssessmentNLevel(
+        key='G2',
+        sheet_id='1ooNKUDndc3mOdBVt0HBFzIk1SNA1OjGTfh-3uJq1iUc',
+        n_column='N_new',
+        config_name='v03_waterfall_g2_methods',
+        note='USEEIO_TRACK[io]',
+    ),
+    AssessmentNLevel(
+        key='G3',
+        sheet_id='1LXt5cZTsXFKG6l09Hw56zkrxIhnnqwXDxMjMOERrE6c',
+        n_column='N_new',
+        config_name='v03_waterfall_g3_data',
+        note='USEEIO_TRACK[us_data]; bedrock endpoint before MRIO steps',
+    ),
+)
+
+
+def live_waterfall_configs() -> tuple[str, ...]:
+    """Unique waterfall config names across USEEIO + CEDA group registries."""
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for sheet in (
+        *useeio_groups.V0_V03_USEEIO_GROUP_SHEETS,
+        *ceda_groups.V0_V03_CEDA_GROUP_SHEETS,
+    ):
+        if sheet.config_name not in seen:
+            seen.add(sheet.config_name)
+            ordered.append(sheet.config_name)
+    return tuple(ordered)
+
+
+def _primary_sheet_id_for_config(config_name: str) -> str:
+    """Diagnostics sheet used to pin live ``N_new`` for *config_name*.
+
+    Shared G2/G3/FINAL names prefer the USEEIO-track sheet (CEDA-track sheets
+    for those configs carry the same ``N_new`` for the metric here).
+    """
+    for sheet in (
+        *useeio_groups.V0_V03_USEEIO_GROUP_SHEETS,
+        *ceda_groups.V0_V03_CEDA_GROUP_SHEETS,
+    ):
+        if sheet.config_name == config_name:
+            return sheet.sheet_id
+    raise KeyError(f'no waterfall ProgressionSheet for config {config_name!r}')
+
+
+def _series_from_snapshot_frame(frame: pd.DataFrame | pd.Series) -> pd.Series[float]:
+    if isinstance(frame, pd.Series):
+        return frame.astype(float)
+    squeezed = frame.squeeze()
+    if isinstance(squeezed, pd.DataFrame):
+        squeezed = squeezed.iloc[:, 0]
+    return squeezed.astype(float)
+
+
+def load_canonical_v0_3_q() -> pd.Series[float]:
+    """Shipped v0.3 commodity ``q`` (``scaled_q_USA`` at ``.SNAPSHOT_KEY``)."""
+    from bedrock.utils.snapshots.loader import load_current_snapshot  # noqa: PLC0415
+
+    q = _series_from_snapshot_frame(load_current_snapshot('scaled_q_USA'))
+    q.index = q.index.astype(str)
+    return q
+
+
+def weighted_avg_n_from_vectors(
+    N: pd.Series[float],
+    q: pd.Series[float],
+) -> float:
+    """Σ(N·q)/Σq on the intersection of N and q indices (finite, nonzero q)."""
+    n = N.astype(float)
+    n.index = n.index.astype(str)
+    q_aligned = q.reindex(n.index).astype(float)
+    mask = n.notna() & q_aligned.notna() & (q_aligned != 0)
+    n = n.loc[mask]
+    q_aligned = q_aligned.loc[mask]
+    denom = float(q_aligned.sum())
+    if denom == 0.0:
+        raise ValueError('canonical q has zero sum on sectors overlapping N')
+    return float((n * q_aligned).sum() / denom)
+
+
+# Back-compat alias used by earlier call sites / scratch scripts.
+_weighted_avg_n_from_vectors = weighted_avg_n_from_vectors
+
+
+def _n_series_from_diagnostics_tab(
+    sheet_id: str,
+    n_column: str,
+    *,
+    refresh: bool = False,
+) -> pd.Series[float]:
+    """Load one N column from a diagnostics ``N_and_diffs`` tab."""
+    from bedrock.utils.validation.analysis.fetch import load_tab  # noqa: PLC0415
+
+    df = load_tab(sheet_id, 'N_and_diffs', refresh=refresh)
+    sector_col = 'sector' if 'sector' in df.columns else 'index'
+    if n_column not in df.columns:
+        # Mirror ceda combine_ef._bedrock_value_col fallback.
+        if n_column == 'N_new_inflated' and 'N_new' in df.columns:
+            n_column = 'N_new'
+        else:
+            raise KeyError(
+                f'sheet {sheet_id!r} N_and_diffs missing {n_column!r}; '
+                f'columns={list(df.columns)}'
+            )
+    n = pd.to_numeric(df[n_column], errors='coerce')
+    series = pd.Series(n.to_numpy(), index=df[sector_col].astype(str), dtype=float)
+    return series
+
+
+def sheet_n_new_levels(*, refresh: bool = False) -> dict[str, float]:
+    """q-weighted sheet ``N_new`` for every live waterfall config."""
+    q = load_canonical_v0_3_q()
+    return {
+        config_name: weighted_avg_n_from_vectors(
+            _n_series_from_diagnostics_tab(
+                _primary_sheet_id_for_config(config_name),
+                'N_new',
+                refresh=refresh,
+            ),
+            q,
+        )
+        for config_name in live_waterfall_configs()
+    }
+
+
+def weighted_avg_n_from_assessment_level(
+    level: AssessmentNLevel,
+    *,
+    q: pd.Series[float] | None = None,
+    refresh: bool = False,
+) -> float:
+    """q-weighted N for one assessment bar, from the pinned diagnostics sheet."""
+    if q is None:
+        q = load_canonical_v0_3_q()
+    n = _n_series_from_diagnostics_tab(level.sheet_id, level.n_column, refresh=refresh)
+    return weighted_avg_n_from_vectors(n, q)
+
+
+def assessment_useeio_bedrock_levels(
+    *,
+    refresh: bool = False,
+) -> dict[str, float]:
+    """Recompute all bedrock-owned USEEIO-track assessment bars from sheets."""
+    q = load_canonical_v0_3_q()
+    return {
+        level.key: weighted_avg_n_from_assessment_level(level, q=q, refresh=refresh)
+        for level in ASSESSMENT_USEEIO_BEDROCK_LEVELS
+    }
+
+
+def assert_useeio_track_sheet_ids_match_registry() -> None:
+    """Fail if ``ASSESSMENT_*`` sheet IDs drift from ``release_v0_v03_useeio_groups``."""
+    from bedrock.utils.validation.analysis import (  # noqa: PLC0415
+        release_v0_v03_useeio_groups as reg,
+    )
+
+    expected = {
+        'G1': reg.G1_SCHEMA_GHG.sheet_id,
+        'G2': reg.G2_METHODS.sheet_id,
+        'G3': reg.G3_DATA.sheet_id,
+    }
+    by_key = {lvl.key: lvl.sheet_id for lvl in ASSESSMENT_USEEIO_BEDROCK_LEVELS}
+    for key, sheet_id in expected.items():
+        if by_key[key] != sheet_id:
+            raise AssertionError(
+                f'ASSESSMENT_USEEIO_BEDROCK_LEVELS[{key!r}].sheet_id='
+                f'{by_key[key]!r} != release_v0_v03_useeio_groups {sheet_id!r} '
+                '(ceda USEEIO_TRACK must stay aligned with the registry)'
+            )
+    pin = by_key['pinned_useeio_baseline']
+    if pin != expected['G1']:
+        raise AssertionError(
+            'USEEIO pin sheet must be the G1 diagnostics sheet '
+            f'(got pin={pin!r}, G1={expected["G1"]!r})'
+        )
+
+
+def _weighted_avg_n(
+    B: pd.DataFrame,
+    Adom: pd.DataFrame,
+    Aimp: pd.DataFrame,
+    q: 'pd.Series[float]',
+) -> float:
+    """Σ(N·q)/Σq with N = 1ᵀ B L, L = (I − (Adom+Aimp))⁻¹."""
+    from bedrock.utils.math.formulas import (  # noqa: PLC0415
+        compute_L_matrix,
+        compute_M_matrix,
+        compute_n,
+    )
+
+    N = compute_n(M=compute_M_matrix(B=B, L=compute_L_matrix(A=Adom + Aimp)))
+    return weighted_avg_n_from_vectors(N, q)
+
+
+def weighted_avg_n_for_config(config_name: str) -> float:
+    """Live ``1ᵀ B L`` for *config_name*, weighted by canonical v0.3 ``q``.
+
+    Matches diagnostics sheet ``N_new`` for that config when the model is
+    reproducible. Does not apply the diagnostics ``N_new_inflated`` PI rebase.
+    """
+    import bedrock.utils.config.common as common  # noqa: PLC0415
+    from bedrock.utils.config.usa_config import (  # noqa: PLC0415
+        reset_usa_config,
+        set_global_usa_config,
+    )
+
+    common.download_fba_on_api_error = True
+    reset_usa_config(should_reset_env_var=True)
+    set_global_usa_config(config_name)
+
+    from bedrock.transform.eeio.derived import (  # noqa: PLC0415
+        derive_Aq_usa,
+        derive_B_usa_non_finetuned,
+    )
+
+    aq = derive_Aq_usa()
+    return _weighted_avg_n(
+        B=derive_B_usa_non_finetuned(),
+        Adom=aq.Adom,
+        Aimp=aq.Aimp,
+        q=load_canonical_v0_3_q(),
+    )
+
+
+def weighted_avg_n_v0_baseline() -> float:
+    """CEDA v0 snapshot N, weighted by canonical v0.3 ``q`` (pinned baseline)."""
+    from bedrock.utils.snapshots.loader import load_snapshot  # noqa: PLC0415
+
+    return _weighted_avg_n(
+        B=load_snapshot('B_USA_non_finetuned', 'v0'),
+        Adom=load_snapshot('Adom_USA', 'v0'),
+        Aimp=load_snapshot('Aimp_USA', 'v0'),
+        q=load_canonical_v0_3_q(),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('config_name', nargs='?', default=None)
+    group.add_argument(
+        '--v0-baseline',
+        action='store_true',
+        help=(
+            'N from frozen CEDA v0 snapshots, weighted by canonical v0.3 '
+            f'scaled_q_USA (config {CANONICAL_USA_CONFIG})'
+        ),
+    )
+    group.add_argument(
+        '--sheet-n-new',
+        action='store_true',
+        help=(
+            'recompute q-weighted sheet N_new for every live waterfall config '
+            '(refresh EXPECTED_LIVE_N_NEW pins)'
+        ),
+    )
+    group.add_argument(
+        '--assessment-useeio',
+        action='store_true',
+        help=(
+            'recompute bedrock-owned USEEIO-track assessment bars from '
+            'diagnostics sheets (ceda combine_ef column rules + canonical q)'
+        ),
+    )
+    parser.add_argument(
+        '--refresh-sheets',
+        action='store_true',
+        help='bypass analysis/.cache and re-fetch Google Sheet tabs',
+    )
+    args = parser.parse_args(argv)
+
+    if args.sheet_n_new:
+        levels = sheet_n_new_levels(refresh=args.refresh_sheets)
+        json.dump({'sheet_n_new': levels}, sys.stdout)
+        return 0
+
+    if args.assessment_useeio:
+        assert_useeio_track_sheet_ids_match_registry()
+        levels = assessment_useeio_bedrock_levels(refresh=args.refresh_sheets)
+        json.dump({'assessment_useeio_bedrock': levels}, sys.stdout)
+        return 0
+
+    level = (
+        weighted_avg_n_v0_baseline()
+        if args.v0_baseline
+        else weighted_avg_n_for_config(args.config_name)
+    )
+    json.dump({'weighted_avg_n_kg_per_usd': level}, sys.stdout)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
cc:
Closes:
Supersedes #559

Adds an integration test guaranteeing the release-waterfall progression keeps working, and fixes a B year-scaling regression on the legacy-footing configs.

## What changed? Why?
Adds `eeio_integration` live reproducibility for the six unique `v03_waterfall_*` configs (union of the USEEIO and CEDA group registries). These tests run on the twice-weekday scheduled integration workflow. Each live case runs in a fresh subprocess so `functools.cache` state cannot leak between configs, rebuilds `derive_Aq_usa` / `derive_B_usa_non_finetuned`, q-weights `1ᵀ B L` with canonical `scaled_q_USA`, and asserts against diagnostics sheet `N_new` (tolerance `1e-4` kgCO2e/USD). Pinned USEEIO / CEDA v0 baselines are not rebuilt.

A sheet-only check covers the assessment USEEIO-track bars (`N_old_inflated` / `N_new_inflated` / `N_new` per ceda `combine_ef`). USEEIO G1 live `N_new` differs from the assessment G1 bar: that config builds B with `deflate_x_to_detail_io_year_for_B`, so `N_new` is in `usa_detail_original_year` dollars while the figure uses PI-rebased `N_new_inflated` at `model_base_year`. G2 / G3 / FINAL assessment bars use `N_new` and match the live pins.

Helper / CLI: `bedrock.utils.validation.waterfall_progression` (`--sheet-n-new`, `--assessment-useeio`, or a config name).

Also restores legacy-footing B year-scaling in `derive_cornerstone_B_non_finetuned`: when `use_ghg_year_x_in_B` is false, scale B to `usa_io_data_year` and inflate to `model_base_year`; when true, keep plain vnorm (pre-#482 behavior needed for waterfall configs that still use that footing).

## Testing

```powershell
uv run black --check .
uv run ruff check .
uv run pytest bedrock/transform/__tests__/test_waterfall_progression.py -m eeio_integration -k "not live_config_matches" -v
# full live rebuilds (GCS):
uv run pytest bedrock/transform/__tests__/test_waterfall_progression.py -m eeio_integration -v
```

