### PR TITLE
test(validation): refresh waterfall pins after waste Use-intersection

### DIFF
--- a/bedrock/transform/__tests__/test_waterfall_progression.py
+++ b/bedrock/transform/__tests__/test_waterfall_progression.py
@@ -15,9 +15,9 @@ Configs covered (union of USEEIO + CEDA group registries):
 
 Not rebuilt: pinned USEEIO baseline / pinned CEDA v0 baseline.
 
-Pins recomputed 2026-08-05 via::
-
-    uv run python -m bedrock.utils.validation.waterfall_progression --sheet-n-new
+Pins recomputed 2026-08-06 via sheet ``N_new`` × canonical q (public CSV
+export of the refreshed waterfall diagnostics; equivalent to
+``waterfall_progression --sheet-n-new --refresh-sheets``).
 
 Assessment plot bars (``N_old_inflated`` / ``N_new_inflated``) are checked
 separately from sheets only — see ``test_assessment_useeio_*``.
@@ -48,10 +48,10 @@ from bedrock.utils.validation.waterfall_progression import (
 EXPECTED_LIVE_N_NEW = {
     'v03_waterfall_useeio_g1_schema_ghg': 0.3135957,
     'v03_waterfall_ceda_g1a_schema_ghg': 0.2543301,
-    'v03_waterfall_ceda_g1b_waste_disagg': 0.2563729,
-    'v03_waterfall_g2_methods': 0.2398356,
-    'v03_waterfall_g3_data': 0.2416736,
-    'v03_waterfall_final': 0.2416736,
+    'v03_waterfall_ceda_g1b_waste_disagg': 0.2568942,
+    'v03_waterfall_g2_methods': 0.2403891,
+    'v03_waterfall_g3_data': 0.2422408,
+    'v03_waterfall_final': 0.2422408,
 }
 
 # Assessment USEEIO-track bars (ceda combine_ef columns × canonical q).
@@ -59,8 +59,8 @@ EXPECTED_LIVE_N_NEW = {
 EXPECTED_ASSESSMENT_USEEIO_BEDROCK_N = {
     'pinned_useeio_baseline': 0.2520542,
     'G1': 0.2462974,
-    'G2': 0.2398356,
-    'G3': 0.2416736,
+    'G2': 0.2403891,
+    'G3': 0.2422408,
 }
 
 ATOL_KG_PER_USD = 1e-4

--- a/bedrock/utils/validation/analysis/release_v0_v03_ceda_groups.py
+++ b/bedrock/utils/validation/analysis/release_v0_v03_ceda_groups.py
@@ -11,9 +11,8 @@ Group definitions (cumulative):
   G3 — ``v03_waterfall_g3_data`` — G2 + 2024 UMD GHG / IO data
   FINAL — ``v03_waterfall_final`` — full v0.3 methodology (verification column)
 
-Sheets were dispatched via the retired ``dispatch_ef_v03_waterfall --baseline
-ceda``; the resulting sheet IDs are pinned in the ``ProgressionSheet`` entries
-below.
+Sheet IDs are the 2026-08-06 diagnostics spreadsheets in the v0.4
+Diagnostics Drive folder (refreshed after the waste Use-intersection fix).
 """
 
 from __future__ import annotations
@@ -26,51 +25,51 @@ from bedrock.utils.validation.analysis.release_v0_3_progression import (
 
 G1A_SCHEMA_GHG = ProgressionSheet(
     step_label="G1a: Cornerstone schema/GHG (no waste)",
-    sheet_id="1jIfLzBfAcpJqq6h4KwMOvZICCVYuQOfWjhy7gBY-VA0",
+    sheet_id="1Dz_1hNG4Vw6cRYZuEe6S_oNM7VAzSYtjcxNljEcx5aU",
     config_name="v03_waterfall_ceda_g1a_schema_ghg",
     sheet_title=(
-        "[2026-07-13, bedrock repo, 2024, CEDA based, "
-        "v0.3 / waterfall CEDA G1a schema/GHG] EFs diagnostics"
+        "[2026-08-06, bedrock repo, 2024, CEDA based, "
+        "v0.3.1 / waterfall CEDA G1a schema/GHG] EFs diagnostics"
     ),
 )
 
 G1B_WASTE_DISAGG = ProgressionSheet(
     step_label="G1b: Waste disaggregation",
-    sheet_id="1Px61a96Mq-GnMvHf09zpURbzNQI0MYmuV1ot-sfnRtU",
+    sheet_id="1hjlLOO4fEALvaHHtXeVhJ1nzRG8qYhuRqvSFAKFYCCw",
     config_name="v03_waterfall_ceda_g1b_waste_disagg",
     sheet_title=(
-        "[2026-07-13, bedrock repo, 2024, CEDA based, "
-        "v0.3 / waterfall CEDA G1b waste disagg] EFs diagnostics"
+        "[2026-08-06, bedrock repo, 2024, CEDA based, "
+        "v0.3.1 / waterfall CEDA G1b waste disagg] EFs diagnostics"
     ),
 )
 
 G2_METHODS = ProgressionSheet(
     step_label="G2: Bedrock methods (CEDA A/price, margins, inflation)",
-    sheet_id="15w6-uMNxXgzhDKGZXzZeD4ihjlD9igg_tg-qizKZJgE",
+    sheet_id="1fnKvS6OPp85jyqahLXatzIUGgZunBuxVUsJlFJQHRts",
     config_name="v03_waterfall_g2_methods",
     sheet_title=(
-        "[2026-07-13, bedrock repo, 2024, CEDA based, "
-        "v0.3 / waterfall G2 methods] EFs diagnostics"
+        "[2026-08-06, bedrock repo, 2024, CEDA based, "
+        "v0.3.1 / waterfall G2 methods] EFs diagnostics"
     ),
 )
 
 G3_DATA = ProgressionSheet(
     step_label="G3: Data update (MECS, UMD, 2024 IO/GHG)",
-    sheet_id="1OcmhKNxDXgJdvGgMpP8q04a-DhWkpDIzIbKs9Rp7g-Q",
+    sheet_id="1ZDov-CCqKHqCe4O3HoWk__FKZDM-4KRy_4LL-yk1ZkE",
     config_name="v03_waterfall_g3_data",
     sheet_title=(
-        "[2026-07-13, bedrock repo, 2024, CEDA based, "
-        "v0.3 / waterfall G3 data] EFs diagnostics"
+        "[2026-08-06, bedrock repo, 2024, CEDA based, "
+        "v0.3.1 / waterfall G3 data] EFs diagnostics"
     ),
 )
 
 FINAL_V03_CEDA = ProgressionSheet(
     step_label="FINAL v0.3 (waterfall)",
-    sheet_id="17QWanjL_5wn_lCGcJ_XNWF_F5katycfPrOzECbkr8Ww",
+    sheet_id="1leB-2Mk4lTSkWvnV2R5NrbKH6GywyWkpKXrtDcWmpmE",
     config_name="v03_waterfall_final",
     sheet_title=(
-        "[2026-07-13, bedrock repo, 2024, CEDA based, "
-        "v0.3 / waterfall FINAL v0.3] EFs diagnostics"
+        "[2026-08-06, bedrock repo, 2024, CEDA based, "
+        "v0.3.1 / waterfall FINAL v0.3] EFs diagnostics"
     ),
 )
 

--- a/bedrock/utils/validation/analysis/release_v0_v03_useeio_groups.py
+++ b/bedrock/utils/validation/analysis/release_v0_v03_useeio_groups.py
@@ -9,8 +9,8 @@ Group definitions (cumulative):
   G3 — ``v03_waterfall_g3_data`` — G2 + 2024 UMD GHG / IO data
   FINAL — ``v03_waterfall_final`` — full v0.3 methodology (verification column)
 
-Sheets were dispatched via the retired ``dispatch_ef_v03_waterfall``; the
-resulting sheet IDs are pinned in the ``ProgressionSheet`` entries below.
+Sheet IDs are the 2026-08-06 diagnostics spreadsheets in the v0.4
+Diagnostics Drive folder (refreshed after the waste Use-intersection fix).
 """
 
 from __future__ import annotations
@@ -23,41 +23,41 @@ from bedrock.utils.validation.analysis.release_v0_3_progression import (
 
 G1_SCHEMA_GHG = ProgressionSheet(
     step_label="G1: USEEIO-like A/margins + Cornerstone schema/GHG",
-    sheet_id="1AaMWSXaHfyTHWfdNvICQ13RDA-CXEQir5W77RcntQRE",
+    sheet_id="17-kEDZVXzlWnszK8qhFfRl46Wvfhyie8UiwkNC-MLms",
     config_name="v03_waterfall_useeio_g1_schema_ghg",
     sheet_title=(
-        "[2026-07-13, bedrock repo, 2024, USEEIO based, "
-        "v0.3 / waterfall USEEIO G1 schema/GHG] EFs diagnostics"
+        "[2026-08-06, bedrock repo, 2024, USEEIO based, "
+        "v0.3.1 / waterfall USEEIO G1 schema/GHG] EFs diagnostics"
     ),
 )
 
 G2_METHODS = ProgressionSheet(
     step_label="G2: Bedrock methods (CEDA A/price, margins, inflation)",
-    sheet_id="1ooNKUDndc3mOdBVt0HBFzIk1SNA1OjGTfh-3uJq1iUc",
+    sheet_id="1mGI0TkGqMhvIKIyLm-sYwM8pCvmT2uNyFiWUuHMymZk",
     config_name="v03_waterfall_g2_methods",
     sheet_title=(
-        "[2026-07-13, bedrock repo, 2024, USEEIO based, "
-        "v0.3 / waterfall G2 methods] EFs diagnostics"
+        "[2026-08-06, bedrock repo, 2024, USEEIO based, "
+        "v0.3.1 / waterfall G2 methods] EFs diagnostics"
     ),
 )
 
 G3_DATA = ProgressionSheet(
     step_label="G3: Data update (MECS, UMD, 2024 IO/GHG)",
-    sheet_id="1LXt5cZTsXFKG6l09Hw56zkrxIhnnqwXDxMjMOERrE6c",
+    sheet_id="14Q7w0hNLt4CuTE3iQaoHiXMVaGt9hdNZaNlRRi9znzc",
     config_name="v03_waterfall_g3_data",
     sheet_title=(
-        "[2026-07-13, bedrock repo, 2024, USEEIO based, "
-        "v0.3 / waterfall G3 data] EFs diagnostics"
+        "[2026-08-06, bedrock repo, 2024, USEEIO based, "
+        "v0.3.1 / waterfall G3 data] EFs diagnostics"
     ),
 )
 
 FINAL_V03_USEEIO = ProgressionSheet(
     step_label="FINAL v0.3 (waterfall)",
-    sheet_id="1l4YBYPkcp4jgV7-tOUhVbbWr08zUcm7jR55US_wjwpM",
+    sheet_id="1ztzvAmHbg2VNZea9fWwy27d67BKmh83EBvyUgGSh54o",
     config_name="v03_waterfall_final",
     sheet_title=(
-        "[2026-07-13, bedrock repo, 2024, USEEIO based, "
-        "v0.3 / waterfall FINAL v0.3] EFs diagnostics"
+        "[2026-08-06, bedrock repo, 2024, USEEIO based, "
+        "v0.3.1 / waterfall FINAL v0.3] EFs diagnostics"
     ),
 )
 

--- a/bedrock/utils/validation/waterfall_progression.py
+++ b/bedrock/utils/validation/waterfall_progression.py
@@ -61,28 +61,28 @@ class AssessmentNLevel:
 ASSESSMENT_USEEIO_BEDROCK_LEVELS: tuple[AssessmentNLevel, ...] = (
     AssessmentNLevel(
         key='pinned_useeio_baseline',
-        sheet_id='1AaMWSXaHfyTHWfdNvICQ13RDA-CXEQir5W77RcntQRE',
+        sheet_id='17-kEDZVXzlWnszK8qhFfRl46Wvfhyie8UiwkNC-MLms',
         n_column='N_old_inflated',
         config_name=None,
         note='USEEIO pin from G1 diagnostics (combine_ef pin_source=bedrock_us)',
     ),
     AssessmentNLevel(
         key='G1',
-        sheet_id='1AaMWSXaHfyTHWfdNvICQ13RDA-CXEQir5W77RcntQRE',
+        sheet_id='17-kEDZVXzlWnszK8qhFfRl46Wvfhyie8UiwkNC-MLms',
         n_column='N_new_inflated',
         config_name='v03_waterfall_useeio_g1_schema_ghg',
         note='USEEIO_TRACK[ghg]; prefer N_new_inflated (2024$)',
     ),
     AssessmentNLevel(
         key='G2',
-        sheet_id='1ooNKUDndc3mOdBVt0HBFzIk1SNA1OjGTfh-3uJq1iUc',
+        sheet_id='1mGI0TkGqMhvIKIyLm-sYwM8pCvmT2uNyFiWUuHMymZk',
         n_column='N_new',
         config_name='v03_waterfall_g2_methods',
         note='USEEIO_TRACK[io]',
     ),
     AssessmentNLevel(
         key='G3',
-        sheet_id='1LXt5cZTsXFKG6l09Hw56zkrxIhnnqwXDxMjMOERrE6c',
+        sheet_id='14Q7w0hNLt4CuTE3iQaoHiXMVaGt9hdNZaNlRRi9znzc',
         n_column='N_new',
         config_name='v03_waterfall_g3_data',
         note='USEEIO_TRACK[us_data]; bedrock endpoint before MRIO steps',


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

After the waste Use-intersection orientation fix (#563), waterfall pins require updateing. This PR points the USEEIO/CEDA waterfall registries (and assessment USEEIO-track sheet IDs) at new 2026-08-06 diagnostics sheets in the v0.4 Diagnostics Drive folder and updates `EXPECTED_LIVE_N_NEW` / `EXPECTED_ASSESSMENT_USEEIO_BEDROCK_N` to match q-weighted sheet `N_new` (and assessment columns).

July 2026 waterfall sheets are left in place as archive; registries no longer reference them.

Pin deltas (kgCO2e/USD):

| Config / bar | Prior | Updated |
|---|---|---|
| USEEIO G1 / CEDA G1a / assessment pin+G1 | unchanged | — |
| CEDA G1b | 0.2563729 | 0.2568942 |
| G2 (live + assessment) | 0.2398356 | 0.2403891 |
| G3 / FINAL (live + assessment G3) | 0.2416736 | 0.2422408 |

Aligns with the Phase A `.SNAPSHOT_KEY` bump in #603 

## Testing

```powershell
uv run pytest bedrock/transform/__tests__/test_waterfall_progression.py -m eeio_integration -v
```

Sheet floats recomputed from refreshed diagnostics `N_and_diffs` × canonical `scaled_q_USA` (same contract as `waterfall_progression --sheet-n-new`).
