### PR TITLE
Update stewi pinned commit in uv.lock and generate 2024 egrid FBS

### DIFF
--- a/bedrock/transform/allocation/__tests__/test_egrid_fbs_method.py
+++ b/bedrock/transform/allocation/__tests__/test_egrid_fbs_method.py
@@ -1,0 +1,113 @@
+"""Unit tests for year-keyed electricity-disagg eGRID FBS selection."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from bedrock.transform.allocation import derived as allocation_derived
+from bedrock.transform.allocation.derived import egrid_fbs_method_for_year
+from bedrock.utils.config.usa_config import USAConfig, reset_usa_config
+
+
+@pytest.fixture(autouse=True)
+def _reset_usa_config() -> Generator[None, None, None]:
+    reset_usa_config(should_reset_env_var=True)
+    yield
+    reset_usa_config(should_reset_env_var=True)
+
+
+@pytest.mark.parametrize(
+    ('year', 'expected'),
+    [
+        (2023, 'GHG_national_Cornerstone_2023_egrid'),
+        (2024, 'GHG_national_Cornerstone_2024_egrid'),
+    ],
+)
+def test_egrid_fbs_method_for_year(year: int, expected: str) -> None:
+    assert egrid_fbs_method_for_year(year) == expected
+
+
+def test_egrid_fbs_method_for_year_unsupported() -> None:
+    with pytest.raises(ValueError, match='unsupported'):
+        egrid_fbs_method_for_year(2022)
+
+
+@pytest.mark.parametrize(
+    ('year', 'expected_method'),
+    [
+        (2023, 'GHG_national_Cornerstone_2023_egrid'),
+        (2024, 'GHG_national_Cornerstone_2024_egrid'),
+    ],
+)
+def test_load_egrid_fbs_selects_method_by_ghg_year(
+    year: int,
+    expected_method: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = USAConfig(
+        usa_ghg_data_year=year,  # type: ignore[arg-type]
+        use_cornerstone_ghg_model=True,
+        implement_waste_disaggregation=True,
+        implement_electricity_reallocation=True,
+        implement_electricity_disaggregation=True,
+    )
+    monkeypatch.setattr(allocation_derived, 'get_usa_config', lambda: cfg)
+
+    sentinel = pd.DataFrame({'ok': [1]})
+    gcs_calls: list[str] = []
+
+    def fake_gcs(
+        *, base_name: str | None = None, year: int | None = None
+    ) -> pd.DataFrame:
+        assert base_name is not None
+        gcs_calls.append(base_name)
+        return sentinel
+
+    monkeypatch.setattr(
+        allocation_derived,
+        '_load_cornerstone_ghg_fbs_from_gcs',
+        fake_gcs,
+    )
+    flowsa = MagicMock()
+    monkeypatch.setattr(allocation_derived, 'getFlowBySector', flowsa)
+
+    out = allocation_derived._load_egrid_fbs_for_electricity_disagg()
+    assert out is sentinel
+    assert gcs_calls == [expected_method]
+    flowsa.assert_not_called()
+
+
+def test_load_egrid_fbs_falls_back_to_flowsa(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = USAConfig(
+        usa_ghg_data_year=2024,
+        use_cornerstone_ghg_model=True,
+        implement_waste_disaggregation=True,
+        implement_electricity_reallocation=True,
+        implement_electricity_disaggregation=True,
+    )
+    monkeypatch.setattr(allocation_derived, 'get_usa_config', lambda: cfg)
+
+    def raise_missing(**_kwargs: object) -> pd.DataFrame:
+        raise FileNotFoundError('missing')
+
+    sentinel = pd.DataFrame({'ok': [1]})
+    flowsa = MagicMock(return_value=sentinel)
+    monkeypatch.setattr(
+        allocation_derived,
+        '_load_cornerstone_ghg_fbs_from_gcs',
+        raise_missing,
+    )
+    monkeypatch.setattr(allocation_derived, 'getFlowBySector', flowsa)
+
+    out = allocation_derived._load_egrid_fbs_for_electricity_disagg()
+    assert out is sentinel
+    flowsa.assert_called_once_with(
+        methodname='GHG_national_Cornerstone_2024_egrid',
+        download_FBS_if_missing=True,
+    )

--- a/bedrock/transform/allocation/derived.py
+++ b/bedrock/transform/allocation/derived.py
@@ -158,20 +158,42 @@ def map_fbs_sectors_to_model_schema(fbs: pd.DataFrame) -> pd.DataFrame:
     return pd.DataFrame(FlowBySector(fbs2).aggregate_flowby())
 
 
-_EGRID_FBS_METHOD = 'GHG_national_Cornerstone_2023_egrid'
+_EGRID_FBS_METHOD_BY_YEAR: dict[int, str] = {
+    2023: 'GHG_national_Cornerstone_2023_egrid',
+    2024: 'GHG_national_Cornerstone_2024_egrid',
+}
+
+
+def egrid_fbs_method_for_year(year: int) -> str:
+    """Return the eGRID-backed Cornerstone GHG FBS method name for *year*."""
+    try:
+        return _EGRID_FBS_METHOD_BY_YEAR[year]
+    except KeyError as exc:
+        supported = ', '.join(str(y) for y in sorted(_EGRID_FBS_METHOD_BY_YEAR))
+        raise ValueError(
+            f'usa_ghg_data_year={year} is unsupported for the electricity-'
+            f'disaggregation eGRID FBS; supported years: {supported}'
+        ) from exc
 
 
 def _load_egrid_fbs_for_electricity_disagg() -> pd.DataFrame:
-    """Load the eGRID-based national GHG FBS for electricity disaggregation."""
+    """Load the eGRID-based national GHG FBS for electricity disaggregation.
+
+    Selects ``GHG_national_Cornerstone_<year>_egrid`` from
+    ``usa_ghg_data_year`` so v0.2 (2023) and v0.3 (2024) electricity configs
+    stay year-matched.
+    """
+    method = egrid_fbs_method_for_year(get_usa_config().usa_ghg_data_year)
     try:
-        return _load_cornerstone_ghg_fbs_from_gcs(base_name=_EGRID_FBS_METHOD)
+        return _load_cornerstone_ghg_fbs_from_gcs(base_name=method)
     except FileNotFoundError:
         logger.info(
             'eGRID FBS parquet not in transform/output_data; '
-            'loading via getFlowBySector'
+            'loading via getFlowBySector (%s)',
+            method,
         )
         return getFlowBySector(
-            methodname=_EGRID_FBS_METHOD,
+            methodname=method,
             download_FBS_if_missing=True,
         )
 

--- a/bedrock/transform/eeio/electricity_disaggregation.py
+++ b/bedrock/transform/eeio/electricity_disaggregation.py
@@ -35,7 +35,6 @@ ELECTRICITY_AGGREGATE = '221100'
 BALANCE_TOLERANCE = 1e6
 DISAGG_BALANCE_ATOL = 1.0
 IO_ACCOUNT_YEAR = 2017
-EGRID_FBS_METHOD_NAME = 'GHG_national_Cornerstone_2023_egrid'
 
 TABLE_8_3_DESCRIPTION = (
     'Table 8.3 Revenue and expense statistics for major U.S. '

--- a/bedrock/transform/ghg/GHG_national_Cornerstone_2024_egrid.yaml
+++ b/bedrock/transform/ghg/GHG_national_Cornerstone_2024_egrid.yaml
@@ -1,0 +1,50 @@
+# Cornerstone 2024 national GHG FBS inheriting GHG_national_Cornerstone_2024.
+# electric_power emissions come from stewi eGRID (plant-level) instead of
+# UMD_GHGIA_T_2_S1 / UMD_GHGIA_T_3_7 electric_power activity sets.
+
+!include:GHG_national_Cornerstone_2024.yaml
+  industry_spec:
+    !include:Cornerstone_2025_target.yaml:industry_spec
+      NAICS_6:
+        !include:Cornerstone_2025_target.yaml:industry_spec:NAICS_6
+        - '221111'
+        - '221112'
+        - '221113'
+        - '221114'
+        - '221115'
+        - '221116'
+        - '221117'
+        - '221118'
+        - '221121'
+        - '221122'
+  source_names: !include:GHG_national_Cornerstone_2024.yaml:source_names
+    UMD_GHGIA_T_2_S1:
+      !include:GHG_national_Cornerstone_2024.yaml:source_names:UMD_GHGIA_T_2_S1
+      activity_sets:
+        !include:GHG_national_Cornerstone_2024.yaml:source_names:UMD_GHGIA_T_2_S1:activity_sets
+        electric_power:
+          selection_fields:
+            PrimaryActivity: __handled_by_EPA_eGRID__
+          attribution_method: direct
+
+    UMD_GHGIA_T_3_7:
+      !include:GHG_national_Cornerstone_2024.yaml:source_names:UMD_GHGIA_T_3_7
+      activity_sets:
+        !include:GHG_national_Cornerstone_2024.yaml:source_names:UMD_GHGIA_T_3_7:activity_sets
+        electric_power:
+          selection_fields:
+            PrimaryActivity: __handled_by_EPA_eGRID__
+          attribution_method: direct
+
+    EPA_eGRID_electric:
+      data_format: FBS_outside_flowsa
+      activity_schema: NAICS_2017_Code
+      activity_to_sector_mapping: EPA_eGRID
+      FBS_datapull_fxn: !script_function:stewiFBS egrid_to_sector
+      inventory_dict:
+        eGRID: 2024
+      year: 2024
+      include_flow_names:
+        - Carbon dioxide
+        - Methane
+        - Nitrous oxide

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = "==3.11.*"
 
 [[package]]
@@ -2366,8 +2366,8 @@ wheels = [
 
 [[package]]
 name = "stewi"
-version = "1.2.1"
-source = { git = "https://github.com/cornerstone-data/standardizedinventories.git#bbb8147c0de1fb5531027dce9f67d97bec755f06" }
+version = "1.2.2"
+source = { git = "https://github.com/cornerstone-data/standardizedinventories.git#eb27446893fa503961f80fdb62e2a44621421c30" }
 dependencies = [
     { name = "esupy" },
     { name = "numpy" },


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

The eGRID FBS method name for electricity disaggregation was previously hardcoded to the 2023 variant (`GHG_national_Cornerstone_2023_egrid`). This change replaces that hardcoded value with a year-keyed lookup (`_EGRID_FBS_METHOD_BY_YEAR`) driven by `usa_ghg_data_year` from `USAConfig`, so that v0.2 (2023) and v0.3 (2024) electricity configurations automatically use their corresponding eGRID FBS method.

A new `GHG_national_Cornerstone_2024_egrid.yaml` config was added that inherits from `GHG_national_Cornerstone_2024.yaml` and replaces the `electric_power` activity sets in `UMD_GHGIA_T_2_S1` and `UMD_GHGIA_T_3_7` with plant-level emissions from stewi eGRID 2024, mirroring the pattern already established for 2023.

`stewi` was bumped from `1.2.1` to `1.2.2`.

## Testing

Unit tests were added covering:
- `egrid_fbs_method_for_year` returns the correct method name for supported years (2023, 2024) and raises `ValueError` for unsupported years.
- `_load_egrid_fbs_for_electricity_disagg` selects the correct GCS method name based on `usa_ghg_data_year`.
- `_load_egrid_fbs_for_electricity_disagg` falls back to `getFlowBySector` with the correct year-matched method name when the GCS file is not found.