### PR TITLE
Match GHG model flag in electricity reallocation test config

### DIFF
--- a/bedrock/utils/config/configs/test_usa_config_waste_disagg_electricity.yaml
+++ b/bedrock/utils/config/configs/test_usa_config_waste_disagg_electricity.yaml
@@ -1,4 +1,11 @@
+# Electricity-reallocation config for
+# bedrock/transform/eeio/__tests__/test_electricity_reallocation.py.
+# Pair of test_usa_config_waste_disagg (same years / GHG model; reallocation on).
+# use_cornerstone_ghg_model must match its pair: test_e_unchanged_with_
+# electricity_reallocation compares derive_E_usa() across the two, and the flag
+# picks the GHG inventory (Cornerstone FBS vs GHG_national_CEDA_2023).
 model_base_year: 2023
 usa_ghg_data_year: 2023
+use_cornerstone_ghg_model: True
 implement_waste_disaggregation: True
 implement_electricity_reallocation: True


### PR DESCRIPTION
cc:
Closes:

## What changed? Why?

Adds `use_cornerstone_ghg_model: True` to `test_usa_config_waste_disagg_electricity.yaml`.

#608 added that flag to `test_usa_config_waste_disagg.yaml` but not to this file. `test_electricity_reallocation.py::TestElectricityReallocationIntegration::test_e_unchanged_with_electricity_reallocation` asserts `derive_E_usa()` is identical across the two configs, and the flag selects the GHG inventory in `load_E_from_flowsa()` — the pre-built Cornerstone FBS vs `GHG_national_CEDA_2023`. The test was therefore comparing two different inventories and failed on N2O for `1111A0` (31.72e9 vs 28.43e9, the UMD GHGIA vs EPA GHGI agricultural-soils difference).

This broke nightly `test_integration` run #493 on `672c37c`; run #492 on the parent commit was green.

Also carries #608's intended speedup to this config: the CEDA path no longer regenerates `GHG_national_CEDA_2023` (~4-5 min).

A header comment records that the flag must track its pair, so the coupling is visible next time either file is edited.

## Testing

`uv run pytest -v -m eeio_integration` on the two affected files: 9 passed (previously-failing test green). Full `uv run pytest`: 394 passed, 2 skipped, 1 xfailed. `black`, `ruff`, `mypy` clean.
