### PR TITLE
feat(extract): add national Census and BEA trade FBAs

### DIFF
--- a/bedrock/analysis/nowcasting/trade_data/probe_2017_trade_totals.py
+++ b/bedrock/analysis/nowcasting/trade_data/probe_2017_trade_totals.py
@@ -1,20 +1,9 @@
 """
-2017 trade totals probe for bedrock#527.
+2017 trade totals probe for bedrock#528.
 
-Pulls national goods + services trade totals the same way the flowsa
-``imports`` branch FBAs do in spirit:
-
-* Census USA Trade NAICS-6, MONTH=12 YTD — imports ``GEN_CIF_YR``, exports
-  ``ALL_VAL_YR`` (no partner-country loop; national aggregate).
-* BEA ``IntlServTrade`` for ``AllCountries`` — uses the ``AllTypesOfService``
-  row only (summing all TypeOfService rows double-counts the hierarchy).
-
-Compares those extracts to the 2017 SUT targets - Use F04000 and Supply
-MCIF/MADJ/MDTY - already in
-bedrock, plus published ITA goods+services calendar-year totals.
-
-API keys: ``bedrock/extract/API_Keys.env`` via ``load_env_file_key``
-(``Census``, ``BEA``). Never prints key values.
+Loads national goods + services from Census_USATrade and BEA_IEA FBAs
+(USD) and compares to 2017 SUT targets — Use F04000 and Supply
+MCIF/MADJ/MDTY — plus ITA goods+services control totals from BEA_ITA.
 
 Run from repo root::
 
@@ -25,25 +14,18 @@ Writes ``bedrock/analysis/nowcasting/trade_data/output/probe_2017_trade_totals.c
 
 from __future__ import annotations
 
-import json
-import urllib.parse
-import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
 
 import pandas as pd
 
 from bedrock.analysis.nowcasting.compare_NIPA_to_IOT.loaders import bea_matrix_column
-from bedrock.utils.config.common import load_env_file_key
+from bedrock.extract.bea.BEA_ITA import ita_gs_totals_usd
+from bedrock.extract.flowbyactivity import getFlowByActivity
 
 YEAR = 2017
 OUT_DIR = Path(__file__).resolve().parent / "output"
 OUT_CSV = OUT_DIR / "probe_2017_trade_totals.csv"
-
-# Published ITA Table 1.1 calendar-year goods+services (million USD).
-# Source: BEA international transactions tables (2017 release vintage).
-ITA_2017_EXPORTS_GS_MUSD = 2_263_907.0
-ITA_2017_IMPORTS_GS_MUSD = 2_764_352.0
 
 
 @dataclass(frozen=True)
@@ -64,95 +46,36 @@ class ExtractTotals:
         return self.census_goods_exports_fas_musd + self.bea_services_exports_musd
 
 
-def _census_json(flow: str, get_fields: str, api_key: str) -> list[list[str]]:
-    params = urllib.parse.urlencode(
-        {
-            "get": get_fields,
-            "COMM_LVL": "NA6",
-            "YEAR": str(YEAR),
-            "MONTH": "12",
-            "key": api_key,
-        }
-    )
-    url = f"https://api.census.gov/data/timeseries/intltrade/{flow}/naics?{params}"
-    with urllib.request.urlopen(url, timeout=180) as resp:
-        payload = resp.read().decode("utf-8")
-    if payload.lstrip().startswith("<"):
-        raise RuntimeError(
-            f"Census API returned HTML (likely missing/invalid key) for {flow}"
-        )
-    return json.loads(payload)
-
-
-def _sum_census_column(table: list[list[str]], column: str) -> tuple[float, int]:
-    header, *rows = table
-    idx = header.index(column)
-    total = sum(float(row[idx] or 0.0) for row in rows)
-    return total / 1e6, len(rows)  # API values are USD → million USD
-
-
-def fetch_census_goods(api_key: str) -> tuple[float, float, int, int]:
-    imports_tbl = _census_json("imports", "NAICS,GEN_CIF_YR", api_key)
-    exports_tbl = _census_json("exports", "NAICS,ALL_VAL_YR", api_key)
-    imp_m, n_imp = _sum_census_column(imports_tbl, "GEN_CIF_YR")
-    exp_m, n_exp = _sum_census_column(exports_tbl, "ALL_VAL_YR")
-    return imp_m, exp_m, n_imp, n_exp
-
-
-def _bea_intl_serv(direction: str, api_key: str) -> pd.DataFrame:
-    params = urllib.parse.urlencode(
-        {
-            "UserID": api_key,
-            "method": "GetData",
-            "DataSetName": "IntlServTrade",
-            "TradeDirection": direction,
-            "Affiliation": "AllAffiliations",
-            "AreaOrCountry": "AllCountries",
-            "Year": str(YEAR),
-            "ResultFormat": "json",
-        }
-    )
-    url = f"https://apps.bea.gov/api/data/?{params}"
-    with urllib.request.urlopen(url, timeout=180) as resp:
-        raw = json.loads(resp.read().decode("utf-8"))
-    results = raw.get("BEAAPI", {}).get("Results", {})
-    if isinstance(results, dict) and results.get("Error"):
-        raise RuntimeError(f"BEA API error for {direction}: {results['Error']}")
-    data = results.get("Data") if isinstance(results, dict) else None
-    if not data:
-        raise RuntimeError(f"BEA IntlServTrade returned no Data for {direction}")
-    df = pd.DataFrame(data)
-    df["DataValue"] = pd.to_numeric(df["DataValue"], errors="coerce").fillna(0.0)
-    return df
-
-
-def fetch_bea_services(api_key: str) -> tuple[float, float]:
-    """Return (imports, exports) in million USD from AllTypesOfService."""
-    out: dict[str, float] = {}
-    for direction in ("Imports", "Exports"):
-        df = _bea_intl_serv(direction, api_key)
-        row = df.loc[df["TypeOfService"] == "AllTypesOfService"]
-        if row.empty:
-            raise RuntimeError(
-                f"BEA IntlServTrade missing AllTypesOfService for {direction}"
-            )
-        # UNIT_MULT=6 → DataValue is already million USD.
-        out[direction] = float(row["DataValue"].iloc[0])
-    return out["Imports"], out["Exports"]
+def _usd_to_musd(amount: float) -> float:
+    return float(amount) / 1e6
 
 
 def fetch_extracts() -> ExtractTotals:
-    census_key = load_env_file_key("API_Key", "Census")
-    bea_key = load_env_file_key("API_Key", "BEA")
-    g_imp, g_exp, n_imp, n_exp = fetch_census_goods(census_key)
-    s_imp, s_exp = fetch_bea_services(bea_key)
+    census = getFlowByActivity("Census_USATrade", YEAR)
+    bea = getFlowByActivity("BEA_IEA", YEAR)
+
+    census_imp = census.loc[census["FlowName"] == "GEN_CIF_YR"]
+    census_exp = census.loc[census["FlowName"] == "ALL_VAL_YR"]
+    bea_imp = bea.loc[
+        (bea["FlowName"] == "Imports")
+        & (bea["ActivityProducedBy"] == "AllTypesOfService")
+    ]
+    bea_exp = bea.loc[
+        (bea["FlowName"] == "Exports")
+        & (bea["ActivityProducedBy"] == "AllTypesOfService")
+    ]
+    if census_imp.empty or census_exp.empty:
+        raise RuntimeError("Census_USATrade FBA missing GEN_CIF_YR or ALL_VAL_YR rows")
+    if bea_imp.empty or bea_exp.empty:
+        raise RuntimeError("BEA_IEA FBA missing AllTypesOfService Imports/Exports rows")
+
     return ExtractTotals(
-        census_goods_imports_cif_musd=g_imp,
-        census_goods_exports_fas_musd=g_exp,
-        bea_services_imports_musd=s_imp,
-        bea_services_exports_musd=s_exp,
-        census_import_naics_rows=n_imp,
-        census_export_naics_rows=n_exp,
+        census_goods_imports_cif_musd=_usd_to_musd(census_imp["FlowAmount"].sum()),
+        census_goods_exports_fas_musd=_usd_to_musd(census_exp["FlowAmount"].sum()),
+        bea_services_imports_musd=_usd_to_musd(bea_imp["FlowAmount"].sum()),
+        bea_services_exports_musd=_usd_to_musd(bea_exp["FlowAmount"].sum()),
+        census_import_naics_rows=int(census_imp["ActivityProducedBy"].nunique()),
+        census_export_naics_rows=int(census_exp["ActivityProducedBy"].nunique()),
     )
 
 
@@ -169,14 +92,15 @@ def fetch_benchmarks() -> dict[str, float]:
     madj = bea_matrix_column("MADJ", matrix="Supply_SUT_detail")
     mdty = bea_matrix_column("MDTY", matrix="Supply_SUT_detail")
     f050_mut = bea_matrix_column("F05000", matrix="Use_MUT_detail_after_redef")
+    ita = ita_gs_totals_usd(YEAR)
     return {
         "use_F04000_exports_musd": float(f040_sut.total),
         "supply_MCIF_musd": float(mcif.total),
         "supply_MADJ_musd": float(madj.total),
         "supply_MDTY_musd": float(mdty.total),
         "mut_F05000_imports_abs_musd": abs(float(f050_mut.total)),
-        "ita_exports_gs_musd": ITA_2017_EXPORTS_GS_MUSD,
-        "ita_imports_gs_musd": ITA_2017_IMPORTS_GS_MUSD,
+        "ita_exports_gs_musd": ita["exports"] / 1e6,
+        "ita_imports_gs_musd": ita["imports"] / 1e6,
     }
 
 
@@ -250,14 +174,13 @@ def build_comparison(extract: ExtractTotals, bench: dict[str, float]) -> pd.Data
     ]
     df = pd.DataFrame(rows)
     df["year"] = YEAR
-    # Ratios against the SUT targets the nowcast has to reproduce.
     df["ratio_to_supply_MCIF"] = df["million_usd"] / bench["supply_MCIF_musd"]
     df["ratio_to_use_F040"] = df["million_usd"] / bench["use_F04000_exports_musd"]
     return df
 
 
 def main() -> None:
-    print(f"Fetching Census + BEA extracts for {YEAR}...")
+    print(f"Loading Census_USATrade + BEA_IEA FBAs for {YEAR}...")
     extract = fetch_extracts()
     print("Loading SUT benchmarks: Use F04000, Supply MCIF/MADJ/MDTY...")
     bench = fetch_benchmarks()

--- a/bedrock/extract/bea/BEA_IEA.py
+++ b/bedrock/extract/bea/BEA_IEA.py
@@ -1,0 +1,101 @@
+"""BEA IntlServTrade national services trade (AllCountries)."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import pandas as pd
+from requests import Response
+
+from bedrock.transform.flowbyfunctions import assign_fips_location_system
+from bedrock.utils.io.gcp import load_from_gcs
+from bedrock.utils.io.gcp_paths import gcs_extract_input_sub_bucket_from_kwargs
+from bedrock.utils.io.local_extract_input_data import load_local_extract_input_dir
+from bedrock.utils.mapping.location import US_FIPS
+
+_MILLION_TO_USD = 1_000_000.0
+
+
+def _bea_iea_direction(url: str) -> str:
+    query = parse_qs(urlparse(url).query)
+    direction = (query.get('TradeDirection') or query.get('tradedirection') or [''])[0]
+    if direction not in {'Imports', 'Exports'}:
+        raise ValueError(f'BEA IntlServTrade url missing TradeDirection: {url}')
+    return direction
+
+
+def _bea_iea_filename(url: str, year: str | int) -> str:
+    return f"BEA_IEA_{year}_{_bea_iea_direction(url)}.csv"
+
+
+def bea_iea_url_helper(
+    *, build_url: str, config: dict[str, Any], **_kwargs: Any
+) -> list[str]:
+    """National AllCountries urls for each TradeDirection (no partner loop)."""
+    return [
+        build_url.replace('__direction__', direction)
+        for direction in config.get('trade_directions', ['Imports', 'Exports'])
+    ]
+
+
+def bea_iea_call(*, resp: Response, **kwargs: Any) -> pd.DataFrame:
+    """Parse BEA JSON Results.Data and write the raw table under extract/input_data/."""
+    raw = json.loads(resp.text)
+    results = raw.get('BEAAPI', {}).get('Results', {})
+    if isinstance(results, dict) and results.get('Error'):
+        raise RuntimeError(f"BEA IntlServTrade error: {results['Error']}")
+    data = results.get('Data') if isinstance(results, dict) else None
+    if not data:
+        raise ValueError(f'BEA IntlServTrade returned no Data for {resp.url}')
+    df = pd.DataFrame(data)
+    filename = _bea_iea_filename(resp.url, kwargs['year'])
+    out_dir = load_local_extract_input_dir(kwargs)
+    df.to_csv(os.path.join(out_dir, filename), index=False)
+    return df
+
+
+def bea_iea_load_gcs(**kwargs: Any) -> pd.DataFrame:
+    """Load a cached IntlServTrade dump from local input_data (GCS later, if staged)."""
+    filename = _bea_iea_filename(str(kwargs['url']), kwargs['year'])
+    return load_from_gcs(
+        name=filename,
+        sub_bucket=gcs_extract_input_sub_bucket_from_kwargs(kwargs),
+        local_dir=load_local_extract_input_dir(kwargs),
+        loader=pd.read_csv,
+    )
+
+
+def bea_iea_parse(
+    *, df_list: list[pd.DataFrame], year: str, **_kwargs: Any
+) -> pd.DataFrame:
+    """Format TypeOfService rows; convert million-USD DataValue to USD."""
+    df = pd.concat(df_list, ignore_index=True)
+    if 'TypeOfService' not in df.columns or 'DataValue' not in df.columns:
+        raise ValueError('BEA IntlServTrade dump missing TypeOfService or DataValue')
+    direction_col = 'TradeDirection' if 'TradeDirection' in df.columns else None
+    if direction_col is None:
+        raise ValueError('BEA IntlServTrade dump missing TradeDirection')
+
+    out = pd.DataFrame(
+        {
+            'ActivityProducedBy': df['TypeOfService'].astype(str),
+            'FlowName': df[direction_col].astype(str),
+            'FlowAmount': pd.to_numeric(df['DataValue'], errors='coerce').fillna(0.0)
+            * _MILLION_TO_USD,
+            'Description': df[direction_col].astype(str).str.lower(),
+        }
+    )
+    out['ActivityConsumedBy'] = ''
+    out['SourceName'] = 'BEA_IEA'
+    out['Class'] = 'Money'
+    out['FlowType'] = 'TECHNOSPHERE_FLOW'
+    out['Compartment'] = ''
+    out['Unit'] = 'USD'
+    out['Year'] = int(year)
+    out['Location'] = US_FIPS
+    out['DataReliability'] = 5  # tmp
+    out['DataCollection'] = 5  # tmp
+    return assign_fips_location_system(out, year)

--- a/bedrock/extract/bea/BEA_IEA.yaml
+++ b/bedrock/extract/bea/BEA_IEA.yaml
@@ -1,0 +1,37 @@
+author: US Bureau of Economic Analysis
+source_name: International Services Trade (IntlServTrade)
+source_url: https://www.bea.gov/data/intl-trade-investment/international-services
+bib_id: BEA_IEA
+api_name: BEA
+api_key_required: true
+format: json
+url:
+  base_url: https://apps.bea.gov/api/data/?
+  api_path: ''
+  url_params:
+    UserID: __apiKey__
+    method: GetData
+    DataSetName: IntlServTrade
+    TradeDirection: __direction__
+    Affiliation: AllAffiliations
+    AreaOrCountry: AllCountries
+    Year: __year__
+    ResultFormat: json
+url_replace_fxn: !script_function:BEA_IEA bea_iea_url_helper
+call_response_fxn: !script_function:BEA_IEA bea_iea_call
+parse_response_fxn: !script_function:BEA_IEA bea_iea_parse
+gcs_fxn: !script_function:BEA_IEA bea_iea_load_gcs
+extract_data_from_raw_sources: False
+time_delay: 1
+years:
+  - 2017
+  - 2018
+  - 2019
+  - 2020
+  - 2021
+  - 2022
+  - 2023
+  - 2024
+trade_directions:
+  - Imports
+  - Exports

--- a/bedrock/extract/bea/BEA_ITA.py
+++ b/bedrock/extract/bea/BEA_ITA.py
@@ -40,16 +40,16 @@ def ita_gs_totals_usd(year: int | str) -> dict[Literal['exports', 'imports'], fl
     from bedrock.extract.flowbyactivity import getFlowByActivity  # noqa: PLC0415
 
     fba = getFlowByActivity(_ITA_SOURCE, int(year))
-    out: dict[Literal['exports', 'imports'], float] = {}
-    for direction, flow_name in (
-        ('exports', 'exports_gs'),
-        ('imports', 'imports_gs'),
-    ):
-        rows = fba.loc[fba['FlowName'] == flow_name]
-        if rows.empty:
-            raise ValueError(f'BEA_ITA FBA missing {flow_name} for {year}')
-        out[direction] = float(pd.to_numeric(rows['FlowAmount'], errors='coerce').sum())
-    return out
+    exports = fba.loc[fba['FlowName'] == 'exports_gs']
+    imports = fba.loc[fba['FlowName'] == 'imports_gs']
+    if exports.empty:
+        raise ValueError(f'BEA_ITA FBA missing exports_gs for {year}')
+    if imports.empty:
+        raise ValueError(f'BEA_ITA FBA missing imports_gs for {year}')
+    return {
+        'exports': float(pd.to_numeric(exports['FlowAmount'], errors='coerce').sum()),
+        'imports': float(pd.to_numeric(imports['FlowAmount'], errors='coerce').sum()),
+    }
 
 
 def bea_ita_load(**_kwargs: Any) -> pd.DataFrame:

--- a/bedrock/extract/bea/BEA_ITA.py
+++ b/bedrock/extract/bea/BEA_ITA.py
@@ -1,0 +1,95 @@
+"""BEA ITA goods+services national control totals (Tables 2.1 / 3.1 family)."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import pandas as pd
+
+from bedrock.transform.flowbyfunctions import assign_fips_location_system
+from bedrock.utils.io.gcp import load_from_gcs
+from bedrock.utils.io.gcp_paths import gcs_extract_input_path
+from bedrock.utils.io.local_extract_input_data import local_extract_input_dir
+from bedrock.utils.mapping.location import US_FIPS
+
+_MILLION_TO_USD = 1_000_000.0
+_ITA_INPUT_FILENAME = 'ita_gs_totals.csv'
+_ITA_SOURCE = 'BEA_ITA'
+
+
+def load_ita_gs_table() -> pd.DataFrame:
+    """Year-indexed ITA G+S export/import totals in million USD."""
+    df = load_from_gcs(
+        name=_ITA_INPUT_FILENAME,
+        sub_bucket=gcs_extract_input_path(_ITA_SOURCE, year=None),
+        local_dir=local_extract_input_dir(_ITA_SOURCE, year=None),
+        loader=pd.read_csv,
+    )
+    required = {'year', 'exports_gs_million_usd', 'imports_gs_million_usd'}
+    missing = required - set(df.columns)
+    if missing:
+        raise ValueError(f'ITA totals CSV missing columns: {sorted(missing)}')
+    df['year'] = df['year'].astype(int)
+    for col in ('exports_gs_million_usd', 'imports_gs_million_usd'):
+        df[col] = pd.to_numeric(df[col], errors='coerce')
+    return df
+
+
+def ita_gs_totals_usd(year: int | str) -> dict[Literal['exports', 'imports'], float]:
+    """Calendar-year ITA goods+services totals in USD, from the BEA_ITA FBA."""
+    from bedrock.extract.flowbyactivity import getFlowByActivity  # noqa: PLC0415
+
+    fba = getFlowByActivity(_ITA_SOURCE, int(year))
+    out: dict[Literal['exports', 'imports'], float] = {}
+    for direction, flow_name in (
+        ('exports', 'exports_gs'),
+        ('imports', 'imports_gs'),
+    ):
+        rows = fba.loc[fba['FlowName'] == flow_name]
+        if rows.empty:
+            raise ValueError(f'BEA_ITA FBA missing {flow_name} for {year}')
+        out[direction] = float(pd.to_numeric(rows['FlowAmount'], errors='coerce').sum())
+    return out
+
+
+def bea_ita_load(**_kwargs: Any) -> pd.DataFrame:
+    """Load staged ITA totals from extract/input_data/BEA_ITA/ (GCS later, if staged)."""
+    return load_ita_gs_table()
+
+
+def bea_ita_parse(
+    *, df_list: list[pd.DataFrame], year: str, **_kwargs: Any
+) -> pd.DataFrame:
+    """One exports_gs row and one imports_gs row for the requested year, in USD."""
+    table = pd.concat(df_list, ignore_index=True) if df_list else load_ita_gs_table()
+    year_i = int(year)
+    row = table.loc[table['year'].astype(int) == year_i]
+    if row.empty:
+        raise ValueError(f'ITA G+S totals missing year {year_i}')
+    records = [
+        {
+            'FlowName': 'exports_gs',
+            'FlowAmount': float(row['exports_gs_million_usd'].iloc[0])
+            * _MILLION_TO_USD,
+            'Description': 'ITA goods+services exports',
+        },
+        {
+            'FlowName': 'imports_gs',
+            'FlowAmount': float(row['imports_gs_million_usd'].iloc[0])
+            * _MILLION_TO_USD,
+            'Description': 'ITA goods+services imports',
+        },
+    ]
+    df = pd.DataFrame(records)
+    df['ActivityProducedBy'] = 'All'
+    df['ActivityConsumedBy'] = ''
+    df['SourceName'] = _ITA_SOURCE
+    df['Class'] = 'Money'
+    df['FlowType'] = 'TECHNOSPHERE_FLOW'
+    df['Compartment'] = ''
+    df['Unit'] = 'USD'
+    df['Year'] = year_i
+    df['Location'] = US_FIPS
+    df['DataReliability'] = 5  # tmp
+    df['DataCollection'] = 5  # tmp
+    return assign_fips_location_system(df, year)

--- a/bedrock/extract/bea/BEA_ITA.yaml
+++ b/bedrock/extract/bea/BEA_ITA.yaml
@@ -1,0 +1,12 @@
+author: US Bureau of Economic Analysis
+source_name: International Transactions Accounts goods and services totals
+source_url: https://www.bea.gov/data/intl-trade-investment/international-transactions
+bib_id: BEA_ITA
+format: csv
+url:
+  base_url: https://apps.bea.gov/itable/
+parse_response_fxn: !script_function:BEA_ITA bea_ita_parse
+gcs_fxn: !script_function:BEA_ITA bea_ita_load
+extract_data_from_raw_sources: False
+years:
+  - 2017

--- a/bedrock/extract/census/Census_USATrade.py
+++ b/bedrock/extract/census/Census_USATrade.py
@@ -1,0 +1,139 @@
+"""Census USA Trade NAICS-6 merchandise trade (national annual YTD)."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+from urllib.parse import urlparse
+
+import pandas as pd
+from requests import Response
+
+from bedrock.transform.flowbyfunctions import assign_fips_location_system
+from bedrock.utils.io.gcp import load_from_gcs
+from bedrock.utils.io.gcp_paths import gcs_extract_input_sub_bucket_from_kwargs
+from bedrock.utils.io.local_extract_input_data import load_local_extract_input_dir
+from bedrock.utils.mapping.location import US_FIPS
+
+_IMPORT_FLOW = 'imports'
+_EXPORT_FLOW = 'exports'
+
+
+def _census_flow_from_url(url: str) -> str:
+    path = urlparse(url).path.lower()
+    if f'/{_IMPORT_FLOW}/' in path:
+        return _IMPORT_FLOW
+    if f'/{_EXPORT_FLOW}/' in path:
+        return _EXPORT_FLOW
+    raise ValueError(f'Census USA Trade url missing imports/exports path: {url}')
+
+
+def _census_usatrade_filename(url: str, year: str | int) -> str:
+    return f"Census_USATrade_{year}_{_census_flow_from_url(url)}.csv"
+
+
+def census_usatrade_url_helper(
+    *, build_url: str, config: dict[str, Any], **_kwargs: Any
+) -> list[str]:
+    """National NAICS-6 import and export urls (no partner-country loop)."""
+    urls = []
+    for flow, get_key in (
+        (_IMPORT_FLOW, 'import_get_fields'),
+        (_EXPORT_FLOW, 'export_get_fields'),
+    ):
+        url = build_url.replace('__flow__', flow).replace(
+            '__get_fields__', str(config[get_key])
+        )
+        urls.append(url)
+    return urls
+
+
+def census_usatrade_call(*, resp: Response, **kwargs: Any) -> pd.DataFrame:
+    """Parse Census JSON and write the raw table under extract/input_data/."""
+    payload = json.loads(resp.text)
+    if not isinstance(payload, list) or len(payload) < 2:
+        raise ValueError(f'Census USA Trade returned no data rows for {resp.url}')
+    df = pd.DataFrame(payload[1:], columns=payload[0])
+    filename = _census_usatrade_filename(resp.url, kwargs['year'])
+    out_dir = load_local_extract_input_dir(kwargs)
+    df.to_csv(os.path.join(out_dir, filename), index=False)
+    return df
+
+
+def census_usatrade_load_gcs(**kwargs: Any) -> pd.DataFrame:
+    """Load a cached Census dump from local input_data (GCS later, if staged)."""
+    filename = _census_usatrade_filename(str(kwargs['url']), kwargs['year'])
+    return load_from_gcs(
+        name=filename,
+        sub_bucket=gcs_extract_input_sub_bucket_from_kwargs(kwargs),
+        local_dir=load_local_extract_input_dir(kwargs),
+        loader=pd.read_csv,
+    )
+
+
+def census_usatrade_parse(
+    *, df_list: list[pd.DataFrame], year: str, config: dict[str, Any], **_kwargs: Any
+) -> pd.DataFrame:
+    """Melt Census value fields to FlowName / FlowAmount in USD."""
+    frames = []
+    for raw in df_list:
+        df = raw.copy()
+        cols = {str(c).upper(): c for c in df.columns}
+        if 'NAICS' not in cols:
+            raise ValueError('Census USA Trade dump missing NAICS column')
+        naics_col = cols['NAICS']
+        present = [name for name in _flow_names_in_frame(df, config) if name in cols]
+        if not present:
+            continue
+        keep = df[[naics_col, *[cols[n] for n in present]]].copy()
+        keep = keep.rename(
+            columns={naics_col: 'NAICS', **{cols[n]: n for n in present}}
+        )
+        keep['NAICS'] = (
+            keep['NAICS']
+            .astype(str)
+            .str.replace(r'\.0$', '', regex=True)
+            .str.strip()
+            .str.zfill(6)
+        )
+        keep = keep.loc[keep['NAICS'].str.fullmatch(r'\d{6}', na=False)]
+        melted = keep.melt(
+            id_vars=['NAICS'],
+            value_vars=present,
+            var_name='FlowName',
+            value_name='FlowAmount',
+        )
+        melted['FlowAmount'] = pd.to_numeric(
+            melted['FlowAmount'], errors='coerce'
+        ).fillna(0.0)
+        melted['Description'] = melted['FlowName'].map(
+            lambda n: 'imports' if n != 'ALL_VAL_YR' else 'exports'
+        )
+        frames.append(melted)
+
+    if not frames:
+        raise ValueError(f'Census USA Trade parse produced no rows for {year}')
+
+    df = pd.concat(frames, ignore_index=True)
+    df['ActivityProducedBy'] = df['NAICS']
+    df['ActivityConsumedBy'] = ''
+    df['SourceName'] = 'Census_USATrade'
+    df['Class'] = 'Money'
+    df['FlowType'] = 'TECHNOSPHERE_FLOW'
+    df['Compartment'] = ''
+    df['Unit'] = 'USD'
+    df['Year'] = int(year)
+    df['Location'] = US_FIPS
+    df['DataReliability'] = 5  # tmp
+    df['DataCollection'] = 5  # tmp
+    df = assign_fips_location_system(df, year)
+    return df.drop(columns=['NAICS'])
+
+
+def _flow_names_in_frame(df: pd.DataFrame, config: dict[str, Any]) -> list[str]:
+    names = list(config.get('import_flow_names') or []) + list(
+        config.get('export_flow_names') or []
+    )
+    upper_cols = {str(c).upper() for c in df.columns}
+    return [n for n in names if n in upper_cols]

--- a/bedrock/extract/census/Census_USATrade.yaml
+++ b/bedrock/extract/census/Census_USATrade.yaml
@@ -1,0 +1,47 @@
+author: US Census Bureau
+source_name: USA Trade Online international merchandise trade (NAICS)
+source_url: https://www.census.gov/foreign-trade/data/index.html
+bib_id: Census_USATrade
+api_name: Census
+api_key_required: true
+format: json
+url:
+  base_url: https://api.census.gov/data/timeseries/intltrade/
+  api_path: __flow__/naics?
+  url_params:
+    get: __get_fields__
+    COMM_LVL: NA6
+    YEAR: __year__
+    MONTH: "12"
+    key: __apiKey__
+url_replace_fxn: !script_function:Census_USATrade census_usatrade_url_helper
+call_response_fxn: !script_function:Census_USATrade census_usatrade_call
+parse_response_fxn: !script_function:Census_USATrade census_usatrade_parse
+gcs_fxn: !script_function:Census_USATrade census_usatrade_load_gcs
+extract_data_from_raw_sources: False
+time_delay: 0.2
+years:
+  - 2017
+  - 2018
+  - 2019
+  - 2020
+  - 2021
+  - 2022
+  - 2023
+  - 2024
+# Census intltrade NAICS value fields (MONTH=12 = calendar YTD). Parse melts each
+# field to FlowName / FlowAmount in USD.
+#   GEN_CIF_YR  general imports, c.i.f. value (cost + insurance + freight)
+#   GEN_VAL_YR  general imports, customs value (landed, excluding duty)
+#   CAL_DUT_YR  calculated import duties
+#   GEN_CHA_YR  general imports, c.i.f. charges (freight/insurance wedge vs customs)
+#   ALL_VAL_YR  exports, FAS-family total value (free alongside ship)
+import_get_fields: NAICS,GEN_CIF_YR,GEN_VAL_YR,CAL_DUT_YR,GEN_CHA_YR
+export_get_fields: NAICS,ALL_VAL_YR
+import_flow_names:
+  - GEN_CIF_YR
+  - GEN_VAL_YR
+  - CAL_DUT_YR
+  - GEN_CHA_YR
+export_flow_names:
+  - ALL_VAL_YR

--- a/bedrock/utils/config/source_catalog.yaml
+++ b/bedrock/utils/config/source_catalog.yaml
@@ -82,6 +82,18 @@ BEA_NIPA:
     - Money
   activity_schema: None
   sector_hierarchy: "flat"
+BEA_IEA:
+  data_format: FBA
+  class:
+    - Money
+  activity_schema: None
+  sector_hierarchy: "flat"
+BEA_ITA:
+  data_format: FBA
+  class:
+    - Money
+  activity_schema: None
+  sector_hierarchy: "flat"
 BEA_Marine_Bunker_Fuel:
   data_format: FBA
   class:
@@ -187,6 +199,12 @@ Census_QWI:
 Census_VIP:
   data_format: FBA
   class: Money
+  activity_schema: None
+  sector_hierarchy: "flat"
+Census_USATrade:
+  data_format: FBA
+  class:
+    - Money
   activity_schema: None
   sector_hierarchy: "flat"
 EIA_AEO:


### PR DESCRIPTION
cc:
Related: #528

## What changed? Why?

Adds national trade Flow-By-Activity extracts so nowcast work can load Census goods, BEA services, and ITA G+S control totals through `generateflowbyactivity` / `getFlowByActivity` instead of ad-hoc API calls in analysis scripts.

**Census_USATrade** (`bedrock/extract/census/`) follows the CoA API→CSV pattern: `*_call` writes year dumps under `extract/input_data/Census_USATrade/{year}/`; default generate (`extract_data_from_raw_sources: False`) reloads via `gcs_fxn` from that local cache (GCS objects are optional later). National NAICS-6 only (MONTH=12 YTD; no partner-country loop). Import request fields melt to `FlowName` ∈ `{GEN_CIF_YR, GEN_VAL_YR, CAL_DUT_YR, GEN_CHA_YR}`; exports use `ALL_VAL_YR`. 
Field meanings (also in the yaml):

- `GEN_CIF_YR` general imports c.i.f.;
- `GEN_VAL_YR` general imports customs value;
- `CAL_DUT_YR` calculated duties;
- `GEN_CHA_YR` c.i.f. charges (freight/insurance wedge);
- `ALL_VAL_YR` exports FAS-family total. 

`Unit` is USD. `api_name: Census`, `api_key_required: true`.

**BEA_IEA** (`bedrock/extract/bea/`) is the same CoA pattern against BEA `IntlServTrade` (`AllCountries`, `AllAffiliations`, Imports and Exports). `ActivityProducedBy` is `TypeOfService`; `FlowName` is `Imports` / `Exports`. API million-USD values are converted ×1e6 to USD at parse. `api_name: BEA`, `time_delay: 1`.

**BEA_ITA** is a file-style FBA for calendar-year goods+services control totals. Parse emits `exports_gs` / `imports_gs` rows in USD. Downstream scale (`ita_gs_totals_usd`) reads the FBA via `getFlowByActivity`.

Sources are registered in `source_catalog.yaml` (`activity_schema: None`, Money, flat). `probe_2017_trade_totals` loads these FBAs and the ITA table (no live Census/BEA calls).

## Testing

Generate once from the APIs into local `input_data/`, then reload with the yaml flag False:

```powershell
uv run python -c "from bedrock.extract.generateflowbyactivity import load_fba_config, process_fba_config; src, year, cfg = load_fba_config('Census_USATrade', 2017); cfg['extract_data_from_raw_sources'] = True; process_fba_config(src, year, cfg, call_only=False)"
uv run python -c "from bedrock.extract.generateflowbyactivity import load_fba_config, process_fba_config; src, year, cfg = load_fba_config('BEA_IEA', 2017); cfg['extract_data_from_raw_sources'] = True; process_fba_config(src, year, cfg, call_only=False)"
uv run python -m bedrock.extract.generateflowbyactivity --year 2017 --source Census_USATrade
uv run python -m bedrock.extract.generateflowbyactivity --year 2017 --source BEA_IEA
uv run python -m bedrock.extract.generateflowbyactivity --year 2017 --source BEA_ITA
uv run python -m bedrock.analysis.nowcasting.trade_data.probe_2017_trade_totals
```

2017 smoke: Census `FlowName` set as above, Unit USD; BEA_IEA AllTypesOfService imports 534,852 / exports 836,352 million USD; combined extract / Supply MCIF ≈ 1.105; combined extract / Use F040 ≈ 1.084; ITA G+S FBA 2,263,907 / 2,764,352 million USD.