### PR TITLE
Step 4c-1: derive the 2017 margin rates and the three receiving sets (#610)

### DIFF
--- a/bedrock/analysis/nowcasting/README.md
+++ b/bedrock/analysis/nowcasting/README.md
@@ -13,6 +13,9 @@ uv run python -m bedrock.analysis.nowcasting.plots
 # one block, screen resolution
 uv run python -m bedrock.analysis.nowcasting.plots --section use_fd_detail_sut
 
+# the Step 4c margin anchor against the published Supply columns
+uv run python -m bedrock.analysis.nowcasting.margins_2017_baseline --check
+
 # the copies embedded in the progress report
 uv run python -m bedrock.analysis.nowcasting.plots \
     --dpi 110 --out-dir <report images dir> --no-report
@@ -54,6 +57,12 @@ Blocks with no candidate yet are skipped with a message rather than failing.
   published 2017 detail Use table and against the PCE/PEQ bridges. Writes the
   cell-wise CSV exports in `output/` that `sections.py` reads as the Step 1
   candidate.
+- `margins_2017_baseline.py` — the Step 4c phase-1 check ([#610](https://github.com/cornerstone-data/bedrock/issues/610)):
+  aggregates [`transform/iot/nowcast_margins.py`](../../transform/iot/nowcast_margins.py)'s
+  transaction-level rates back to the published Supply table's `TRADE`/`TRANS`
+  columns, commodity by commodity, and reports what each residual is. `--check`
+  exits non-zero if a count regresses. Writes the per-commodity comparison and
+  the rate table to `output/`.
 - [`trade_data/`](trade_data/README.md) — Step 1d/4b source evaluation for the
   trade columns (#527): three 2017 probes scoring a Census goods + BEA services
   extract against the SUT targets — Use `F04000` for exports, Supply `MCIF` /

--- a/bedrock/analysis/nowcasting/margins_2017_baseline.py
+++ b/bedrock/analysis/nowcasting/margins_2017_baseline.py
@@ -1,0 +1,566 @@
+"""Check the 2017 margin anchor against the published Supply table.
+
+The validation half of Step 4c phase 1
+([#610](https://github.com/cornerstone-data/bedrock/issues/610)):
+``bedrock/transform/iot/nowcast_margins.py`` derives the receiving sets and the
+per-(buyer, commodity, margin type) rates from the transaction-level Margins
+table, and this checks that aggregating them reproduces the Supply table's
+margin columns **commodity by commodity**.
+
+Per commodity, never in aggregate. ``T014`` nets to about 1 economy-wide against
+7.4 trillion of gross mass - a trade margin is added to the good and subtracted
+from the trade commodity that earned it - so a totals check does not merely risk
+passing on broken data, it passes on anything.
+
+The two identities, and what closes them:
+
+```
+sum_buyers ( Wholesale + Retail )  =  TRADE[c] + TOP[c]
+sum_buyers   Transportation        =  TRANS[c]
+```
+
+The trade identity carries the tax term because the two tables sit in different
+frameworks - the Margins table is make-use, the Supply table supply-use, and
+wholesale and retail trade commodity tax is inside the margin columns of the one
+and in taxes on products in the other (B. Jolliff, BEA, 2025-05-30). It still
+does not close exactly, and the residual is not noise: sales tax sits in the
+margin columns but excise sits in ``Producers' Value``, and both land in ``TOP``,
+so what is left over is the **producer-level** share of the tax. It lands where
+the tax law puts it - severance tax on oil, gas and coal at 80-90% of ``TOP``,
+federal excise on tobacco and alcohol at 35-37%, and motor fuel tax at
+essentially zero because it is collected at the pump and behaves like a sales
+tax.
+
+Both sides are before redefinitions: the published detail SUT is a
+before-redefinitions construct and the margins anchor is
+``load_2017_margins_before_redef_usa``. Pairing the after-redefinitions Margins
+table with this Supply table closes the trade identity for 226 commodities
+rather than 236 - a *redefinition* mismatch, not a framework one, and not a
+number to chase. Redefinition moves 6,007 million of trade margin across 111
+commodities, of which ``333914`` pump and pumping equipment is 4,139: it is
+redefined out of the after-redefinitions table altogether while the
+before-redefinitions Supply table still carries ``TRADE`` for it.
+
+Run from the repo root::
+
+    uv run python -m bedrock.analysis.nowcasting.margins_2017_baseline
+    uv run python -m bedrock.analysis.nowcasting.margins_2017_baseline --check
+
+``--check`` exits non-zero if any identity or bound check comes in below the
+counts measured when this landed, which is what makes it useful in a rebuild.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from bedrock.extract.iot.io_2017 import _load_2017_detail_supply_use_usa
+from bedrock.transform.iot.nowcast_margins import (
+    COMMODITY_LEVEL,
+    MARGIN_TYPE_LEVEL,
+    RATE_BASIS,
+    margin_rate_table,
+    margins_by_commodity,
+    rate_dispersion_by_commodity,
+    receiving_set_summary,
+)
+from bedrock.utils.economic.units import MILLION_CURRENCY_TO_CURRENCY
+from bedrock.utils.taxonomy.bea.v2017_commodity import (
+    USA_2017_COMMODITY_CODES,
+    USA_2017_COMMODITY_DESC,
+)
+
+logger = logging.getLogger(__name__)
+
+OUTPUT_DIR = Path(__file__).parent / 'output'
+IDENTITY_CSV_PATH = OUTPUT_DIR / 'margins_2017_identities_by_commodity.csv'
+RATE_TABLE_CSV_PATH = OUTPUT_DIR / 'margins_2017_rate_table.csv'
+
+#: The Supply table's bridge columns, in published order. ``TRADE`` carries a
+#: trailing space in the workbook header; :func:`load_supply_bridge_2017` strips
+#: it rather than propagating the surprise.
+SUPPLY_BRIDGE_COLUMNS = [
+    'T007',
+    'MCIF',
+    'MADJ',
+    'T013',
+    'TRADE',
+    'TRANS',
+    'T014',
+    'MDTY',
+    'TOP',
+    'SUB',
+    'T015',
+    'T016',
+]
+
+#: An identity "holds" for a commodity when the two sides agree within this,
+#: relative to the published side.
+IDENTITY_TOLERANCE = 0.01
+
+#: A commodity is margin-bearing for the tax decomposition only if it actually
+#: carries trade margin: with no wholesale or retail, both sides of the trade
+#: identity are zero and the residual degenerates to the whole of ``TOP``, which
+#: reads as a spurious 100% producer-level tax on restaurants, electric power,
+#: insurance and legal services.
+MIN_TOP_FOR_TAX_DECOMPOSITION = 100 * MILLION_CURRENCY_TO_CURRENCY
+
+#: Measured when #610 landed, on the before-redefinitions pair. ``--check``
+#: treats these as floors; a rebuild that comes in under one of them has changed
+#: something.
+BASELINE_TRANS_COMMODITIES_HOLDING = 180
+BASELINE_TRADE_COMMODITIES_HOLDING = 236
+
+
+def load_supply_bridge_2017() -> pd.DataFrame:
+    """
+    The published 2017 detail Supply table's bridge columns, per commodity. USD.
+
+    These are the commodity-level control on the transaction-level Margins
+    table: ``TRADE`` and ``TRANS`` are one value per commodity where the Margins
+    table is per (buyer, commodity), and they reconcile only by aggregation - the
+    reverse is impossible, since commodity totals cannot be split back across
+    buyers without reintroducing the assumption the Margins table exists to
+    carry.
+    """
+    supply = _load_2017_detail_supply_use_usa('Supply_detail').rename(
+        columns=lambda column: column.strip()
+    )
+    commodities = [code for code in USA_2017_COMMODITY_CODES if code in supply.index]
+    bridge = (
+        supply.loc[commodities, SUPPLY_BRIDGE_COLUMNS].astype(float)
+        * MILLION_CURRENCY_TO_CURRENCY
+    )
+    bridge.index.name = COMMODITY_LEVEL
+    return bridge
+
+
+#: Each identity as ``(name, derived column, published target, margin column)``.
+#: The trade identity's target carries the tax term where its margin column does
+#: not, which is why the two are named separately.
+IDENTITIES: tuple[tuple[str, str, str, str], ...] = (
+    ('trade', 'trade_margins', 'trade_target', 'TRADE'),
+    ('transport', 'transport_margins', 'TRANS', 'TRANS'),
+)
+
+
+def _relative_difference(derived: pd.Series, published: pd.Series) -> pd.Series:
+    """``derived / published - 1``, NaN where the published side is zero."""
+    return derived / published.replace(0.0, np.nan) - 1
+
+
+def verify_supply_margin_identities() -> pd.DataFrame:
+    """
+    Both identities, commodity by commodity.
+
+    Columns: the derived aggregates, the published columns they target, the
+    difference each way, and the producer-level tax the trade residual
+    decomposes into. ``*_holds`` is True where the two sides agree within
+    :data:`IDENTITY_TOLERANCE` **or** both are zero - 144 commodities bear no
+    transportation margin at all, and counting those as failures would be as
+    misleading as counting them as passes silently.
+    """
+    derived = margins_by_commodity()
+    published = load_supply_bridge_2017()
+    out = pd.concat([derived, published], axis=1).fillna(0.0)
+    out.insert(0, 'commodity_name', out.index.map(dict(USA_2017_COMMODITY_DESC)))
+
+    out['trade_target'] = out['TRADE'] + out['TOP']
+    for name, derived_column, published_column, _ in IDENTITIES:
+        difference = out[derived_column] - out[published_column]
+        relative = _relative_difference(out[derived_column], out[published_column])
+        out[f'{name}_diff'] = difference
+        out[f'{name}_rel_diff'] = relative
+        out[f'{name}_holds'] = relative.abs().le(IDENTITY_TOLERANCE) | (
+            (out[derived_column] == 0) & (out[published_column] == 0)
+        )
+
+    # The residual of the trade identity is the producer-level (excise) share of
+    # TOP; the rest is trade-level tax already inside the margin columns.
+    out['producer_level_tax'] = -out['trade_diff']
+    decomposable = (out['trade_margins'] != 0) & (
+        out['TOP'] > MIN_TOP_FOR_TAX_DECOMPOSITION
+    )
+    out['tax_decomposable'] = decomposable
+    out['producer_level_tax_share'] = (
+        out['producer_level_tax'] / out['TOP'].replace(0.0, np.nan)
+    ).where(decomposable)
+    return out
+
+
+def identity_summary(identities: pd.DataFrame | None = None) -> pd.DataFrame:
+    """
+    How each identity does, split by the sign of the Supply margin column.
+
+    The three populations answer different questions, and reporting only the
+    first is how a margin check flatters itself:
+
+    ``all commodities``
+        includes the 144 commodities with no transportation margin on either
+        side, which hold trivially. 320 of 402 sounds better than the
+        informative 180 of 258.
+    ``margin > 0``
+        the receiving side - the commodities this anchor is built to reproduce.
+    ``margin < 0``
+        the supplying side. The Margins table carries only the receiving half of
+        each margin, so the derived column is zero here **by construction** and
+        every commodity fails. Those are the 19 trade and 5 transport
+        commodities that give up 96.8% and 56.8% of their own output; rebuilding
+        them is Step 4a's job, not this one's.
+    """
+    frame = verify_supply_margin_identities() if identities is None else identities
+    rows = []
+    for name, derived_column, target_column, margin_column in IDENTITIES:
+        for population, selection in (
+            ('all commodities', pd.Series(True, index=frame.index)),
+            (f'{margin_column} > 0', frame[margin_column] > 0),
+            (f'{margin_column} < 0', frame[margin_column] < 0),
+        ):
+            subset = frame.loc[selection]
+            published = subset[target_column].sum()
+            rows.append(
+                {
+                    'identity': name,
+                    'population': population,
+                    'commodities': int(selection.sum()),
+                    'holds': int(subset[f'{name}_holds'].sum()),
+                    'derived': subset[derived_column].sum(),
+                    'published': published,
+                    'net_diff': subset[f'{name}_diff'].sum(),
+                    'net_rel_diff': (
+                        subset[f'{name}_diff'].sum() / published
+                        if published
+                        else np.nan
+                    ),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def give_up_check(identities: pd.DataFrame | None = None) -> pd.DataFrame:
+    """
+    The supplying side: the 24 commodities whose Supply margin column is
+    negative, against what the Margins table says they gave up.
+
+    The negative side was scoped as Step 4a's problem - a trade or transport
+    commodity gives up nearly all of its own output, so it was to be rebuilt
+    from 4a's output vector. It does not have to be: the published
+    ``Purchasers' Value`` already carries it, because on a trade commodity's own
+    rows purchasers' value is *below* the sum of the components by exactly the
+    margin moved onto the goods (:func:`margins_by_commodity`).
+
+    Against the transport commodities it is a direct read - all five within
+    0.2%, 20 million out of 415,570. Against the trade commodities it runs high
+    by the trade-level tax the receiving side is short by, and the two sides
+    measure that tax independently to within 0.3%: 391,761 million given up
+    above the negative Supply columns here, against 391,162 million by which
+    ``sum(Wholesale + Retail)`` exceeds ``TRADE`` on the receiving side - 12.0%
+    of positive ``TRADE``, and 90% of the ``TOP`` those commodities carry.
+    Petroleum wholesalers are the extreme at 2.2x, and consistently so - motor
+    fuel tax is collected at the pump, so nearly all of petroleum's ``TOP`` is
+    trade-level.
+    """
+    frame = verify_supply_margin_identities() if identities is None else identities
+    supplying = frame.loc[(frame['TRADE'] < 0) | (frame['TRANS'] < 0)].copy()
+    supplying['supply_negative'] = -(
+        supplying['TRADE'].clip(upper=0) + supplying['TRANS'].clip(upper=0)
+    )
+    supplying['give_up_ratio'] = (
+        supplying['margin_given_up'] / supplying['supply_negative']
+    )
+    supplying['implied_trade_level_tax'] = (
+        supplying['margin_given_up'] - supplying['supply_negative']
+    )
+    columns = [
+        'commodity_name',
+        'margin_given_up',
+        'TRADE',
+        'TRANS',
+        'supply_negative',
+        'give_up_ratio',
+        'implied_trade_level_tax',
+    ]
+    return supplying[columns].sort_values('supply_negative', ascending=False)
+
+
+def trade_identity_misses(identities: pd.DataFrame | None = None) -> pd.DataFrame:
+    """
+    The commodities where the trade identity does not hold, and the tax that
+    accounts for them.
+
+    They are not a scatter of near misses: they are the excise and severance
+    goods, in order. What the identity's tax term corrects for is *trade-level*
+    tax, which sits inside the Wholesale and Retail columns; excise sits in
+    ``Producers' Value`` instead and never enters the left-hand side, so a
+    commodity misses by exactly its producer-level tax.
+    """
+    frame = verify_supply_margin_identities() if identities is None else identities
+    positive = frame['TRADE'] > 0
+    misses = frame.loc[positive & ~frame['trade_holds']]
+    columns = [
+        'commodity_name',
+        'trade_target',
+        'trade_margins',
+        'trade_diff',
+        'trade_rel_diff',
+        'TOP',
+        'producer_level_tax_share',
+    ]
+    return misses[columns].sort_values('trade_diff')
+
+
+def _margin_cell_profile(margin_type: str) -> pd.DataFrame:
+    """Per commodity, how many cells carry *margin_type* and how big they are."""
+    margins = margin_rate_table().xs(margin_type, level=MARGIN_TYPE_LEVEL)['margin']
+    grouped = margins.groupby(level=COMMODITY_LEVEL)
+    return pd.DataFrame({'cells': grouped.size(), 'median_cell': grouped.median()})
+
+
+def transport_rounding_profile(
+    identities: pd.DataFrame | None = None,
+) -> pd.DataFrame:
+    """
+    The transportation identity's misses, bucketed by how big the published
+    cells are.
+
+    The misses are a publication artifact rather than a method error, and this
+    is the evidence. BEA publishes the Margins table rounded to a million, and
+    the smallest non-zero transportation cell in it is exactly 1 million - so
+    every cell that would round below half a million is published as zero and
+    drops out of the commodity sum. The shortfall is therefore one-sided (195 of
+    258 commodities come in short, 22 over) and scales with how thinly a
+    commodity's margin is spread: commodities whose median cell is about a
+    million miss by ~3%, those above 20 million by 0.02%. Economy-wide it is
+    -0.25%, and the 78 missing commodities carry 7.6% of ``TRANS``.
+
+    Nothing to fix here - a nowcast rebuilt from these rates inherits the same
+    rounding, and the alternative is to invent cells BEA suppressed.
+    """
+    frame = verify_supply_margin_identities() if identities is None else identities
+    profile = _margin_cell_profile('Transportation').join(
+        frame[['TRANS', 'transport_diff', 'transport_rel_diff', 'transport_holds']]
+    )
+    profile = profile.loc[profile['TRANS'] > 0]
+    buckets = pd.cut(
+        profile['median_cell'] / MILLION_CURRENCY_TO_CURRENCY,
+        [0, 1, 2, 5, 20, np.inf],
+        labels=['<= 1M', '1-2M', '2-5M', '5-20M', '> 20M'],
+    )
+    return (
+        profile.groupby(buckets, observed=True)
+        .agg(
+            commodities=('TRANS', 'size'),
+            holds=('transport_holds', 'sum'),
+            median_cells=('cells', 'median'),
+            median_rel_diff=('transport_rel_diff', 'median'),
+        )
+        .rename_axis('median published cell')
+    )
+
+
+def rate_bound_check(identities: pd.DataFrame | None = None) -> pd.DataFrame:
+    """
+    Which denominator a margin rate is actually bounded by.
+
+    ``TRADE / T013`` exceeds 1 for 21 commodities carrying a fifth of all
+    positive ``TRADE`` - apparel at 1.84, ``S00402`` used and secondhand goods at
+    16.02 - and that is correct rather than broken: margin is added to basic
+    value, not carved out of it, so a rate on ``T013`` is unbounded. ``T013``
+    remains the right *allocation* base, per BEA's "margins are distributed based
+    on the value in column OR" and the manual's interim-supply weighting, but
+    "rate > 1" is not a validation rule. ``T016`` is where the bound is real.
+    """
+    frame = verify_supply_margin_identities() if identities is None else identities
+    rows = []
+    for numerator in ('TRADE', 'TRANS'):
+        for denominator in ('T013', 'T016'):
+            ratio = frame[numerator] / frame[denominator].replace(0.0, np.nan)
+            positive = frame[numerator] > 0
+            above = positive & ratio.gt(1)
+            rows.append(
+                {
+                    'ratio': f'{numerator} / {denominator}',
+                    'commodities_positive': int(positive.sum()),
+                    'above_1': int(above.sum()),
+                    'max': ratio[positive].max(),
+                    'share_of_value_above_1': (
+                        frame.loc[above, numerator].sum()
+                        / frame.loc[positive, numerator].sum()
+                    ),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def export_identities(path: Path = IDENTITY_CSV_PATH) -> Path:
+    """Write the per-commodity identity comparison to CSV."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    verify_supply_margin_identities().to_csv(path)
+    logger.info('Wrote per-commodity identity comparison to %s', path)
+    return path
+
+
+def export_rate_table(path: Path = RATE_TABLE_CSV_PATH) -> Path:
+    """Write the per-(buyer, commodity, margin type) rate table to CSV."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    margin_rate_table().to_csv(path)
+    logger.info('Wrote rate table to %s', path)
+    return path
+
+
+def _print_frame(frame: pd.DataFrame, float_format: str = '{:,.3f}') -> None:
+    with pd.option_context(
+        'display.width', 200, 'display.float_format', float_format.format
+    ):
+        print(frame.to_string())
+
+
+def main(check: bool = False) -> int:
+    """Print the phase-1 report; with *check*, fail if a count has regressed."""
+    logging.basicConfig(level=logging.INFO, format='%(message)s')
+    millions = 1 / MILLION_CURRENCY_TO_CURRENCY
+
+    summary = receiving_set_summary()
+    print('Receiving sets (margin in millions):')
+    shown = summary.assign(
+        margin=summary['margin'] * millions,
+        rate_margin=summary['rate_margin'] * millions,
+        level_margin=summary['level_margin'] * millions,
+    )
+    _print_frame(shown)
+
+    dispersion = rate_dispersion_by_commodity()
+    print('\nWithin-commodity rate dispersion (no commodity has a uniform rate):')
+    _print_frame(
+        dispersion.groupby(level=MARGIN_TYPE_LEVEL).agg(
+            commodities=('cv', 'size'),
+            median_cv=('cv', 'median'),
+            uniform=('cv', lambda cv: int((cv < 0.01).sum())),
+        )
+    )
+
+    identities = verify_supply_margin_identities()
+    print('\nSupply-column identities, per commodity (millions):')
+    summary_frame = identity_summary(identities)
+    _print_frame(
+        summary_frame.assign(
+            derived=summary_frame['derived'] * millions,
+            published=summary_frame['published'] * millions,
+            net_diff=summary_frame['net_diff'] * millions,
+        ),
+        '{:,.4f}',
+    )
+
+    print('\nWhich denominator bounds a margin rate:')
+    _print_frame(rate_bound_check(identities))
+
+    decomposable = identities.loc[identities['tax_decomposable']]
+    producer_share = (
+        decomposable['producer_level_tax'].sum() / decomposable['TOP'].sum()
+    )
+    print(
+        f'\nProducer-level tax on the {len(decomposable)} margin-bearing '
+        f'commodities with TOP > 100 million: '
+        f'{producer_share:.1%} of TOP '
+        f'({decomposable["producer_level_tax"].sum() * millions:,.0f} of '
+        f'{decomposable["TOP"].sum() * millions:,.0f} million)'
+    )
+
+    misses = trade_identity_misses(identities)
+    print(
+        f'\nTrade identity: the {len(misses)} misses are the excise and '
+        f'severance goods (millions):'
+    )
+    _print_frame(
+        misses.assign(
+            trade_target=misses['trade_target'] * millions,
+            trade_margins=misses['trade_margins'] * millions,
+            trade_diff=misses['trade_diff'] * millions,
+            TOP=misses['TOP'] * millions,
+        )
+    )
+
+    print(
+        '\nTransport identity: the misses are publication rounding - BEA '
+        'publishes no cell below 1 million, so thinly spread commodities lose '
+        'the suppressed ones:'
+    )
+    _print_frame(transport_rounding_profile(identities), '{:,.4f}')
+
+    give_up = give_up_check(identities)
+    transport_give_up = give_up.loc[give_up['TRANS'] < 0]
+    print(
+        f'\nSupplying side: the {len(give_up)} commodities with a negative '
+        f'Supply margin column, against what they give up in the Margins table '
+        f'(millions). Transport reads directly; trade runs high by the '
+        f'trade-level tax ({give_up["implied_trade_level_tax"].sum() * millions:,.0f} '
+        f'in total, {transport_give_up["implied_trade_level_tax"].sum() * millions:,.0f} '
+        f'of it on transport):'
+    )
+    _print_frame(
+        give_up.assign(
+            margin_given_up=give_up['margin_given_up'] * millions,
+            TRADE=give_up['TRADE'] * millions,
+            TRANS=give_up['TRANS'] * millions,
+            supply_negative=give_up['supply_negative'] * millions,
+            implied_trade_level_tax=give_up['implied_trade_level_tax'] * millions,
+        )
+    )
+
+    identity_path = export_identities()
+    rate_path = export_rate_table()
+    print(f'\nWrote {identity_path}\nWrote {rate_path}')
+
+    if not check:
+        return 0
+
+    failures = []
+    holding = (
+        summary_frame.set_index(['identity', 'population'])['holds']
+        .astype(int)
+        .to_dict()
+    )
+    for identity, population, floor in (
+        ('transport', 'TRANS > 0', BASELINE_TRANS_COMMODITIES_HOLDING),
+        ('trade', 'TRADE > 0', BASELINE_TRADE_COMMODITIES_HOLDING),
+    ):
+        got = holding[identity, population]
+        if got < floor:
+            failures.append(
+                f'{identity} identity holds for {got} commodities, below the '
+                f'{floor} measured when #610 landed'
+            )
+    above_one = (
+        rate_bound_check(identities).set_index('ratio')['above_1'].astype(int).to_dict()
+    )
+    for ratio in ('TRADE / T016', 'TRANS / T016'):
+        if above_one[ratio]:
+            failures.append(
+                f'{ratio} exceeds 1 for {above_one[ratio]} commodities; expected none'
+            )
+    rates = margin_rate_table()
+    unfitted = int(rates.loc[rates['basis'] == RATE_BASIS, 'rate'].isna().sum())
+    if unfitted:
+        failures.append(f'{unfitted} rate-basis transactions have no rate')
+
+    if failures:
+        for failure in failures:
+            print(f'FAIL: {failure}')
+        return 1
+    print('\nOK: identities, bounds and rate coverage all at or above baseline.')
+    return 0
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--check',
+        action='store_true',
+        help='exit non-zero if an identity or bound check has regressed',
+    )
+    raise SystemExit(main(**vars(parser.parse_args())))

--- a/bedrock/analysis/nowcasting/margins_estimation_plan.md
+++ b/bedrock/analysis/nowcasting/margins_estimation_plan.md
@@ -34,6 +34,14 @@ Measured on the 2017 table:
 | **Retail** | **1,933 (3.4%)** | 188 | **87.5%** | **0.364** | **0.164** |
 | Transportation | 12,252 (21.6%) | 257 | 20.4% | 0.020 | 0.039 |
 
+Two notes on reading that table, both settled by Phase 1. The rate columns are
+**margin ÷ purchasers' value** — a share of what the buyer pays, not the
+cascading rate BEA computes and the build carries. And the counts are off the
+*after*-redefinitions table; the anchor is now the **before**-redefinitions one
+(§Phase 1), where the same counts are 17,419 / 2,106 / 12,516 transactions over
+254 / 188 / 258 commodities. The structure the table describes is unchanged
+either way.
+
 Three consequences:
 
 - **The buyer dimension is essentially a retail phenomenon.** Retail's PCE rate
@@ -193,9 +201,15 @@ each commodity, on BEA's own cascading bases:
 | Wholesale / (Producers' + Transport) | 249 | **0.238** | 0 (0%) |
 | Retail / (Producers' + Transport + Wholesale) | 56 | **0.696** | 0 (0%) |
 
-Zero commodities are uniform. The reason is that BEA's "item" is **finer than
-the published commodity**, so several item rates mix inside every published
-commodity, and the item level is not recoverable from published data.
+Rebuilt in Phase 1 on the before-redefinitions anchor, over every commodity with
+more than one rate-bearing transaction: wholesale **0.218** over 253 commodities
+with **none** under 0.01, retail **0.776** over 131 with **one**, transportation
+**0.226** over 257 with **three**. Four commodities out of 641 are effectively
+uniform, which does not support a per-commodity rate anywhere else.
+
+The reason is that BEA's "item" is **finer than the published commodity**, so
+several item rates mix inside every published commodity, and the item level is
+not recoverable from published data.
 
 **Therefore: carry rates per (buyer, commodity, margin type) as
 [#571](https://github.com/cornerstone-data/bedrock/issues/571) already
@@ -256,17 +270,15 @@ the same shape as [`compensation_disaggregation_plan.md`](compensation_disaggreg
 
 | phase | issue | depends on |
 |---|---|---|
-| 1 | [#610](https://github.com/cornerstone-data/bedrock/issues/610) 2017 rates and receiving sets | **nothing — start here** |
+| 1 | ✅ [#610](https://github.com/cornerstone-data/bedrock/issues/610) 2017 rates and receiving sets — **built**, §Phase 1 below | — |
 | 2 | [#611](https://github.com/cornerstone-data/bedrock/issues/611) port the FAF transport chain | #601 (merged) |
 | 3 | [#612](https://github.com/cornerstone-data/bedrock/issues/612) AWTS/ARTS annual trade levels | — |
-| 4 | [#613](https://github.com/cornerstone-data/bedrock/issues/613) apply and derive `TRADE`/`TRANS` | #610–#612, **#570 (4a), #579 (4b)** |
+| 4 | [#613](https://github.com/cornerstone-data/bedrock/issues/613) apply and derive `TRADE`/`TRANS` | #610–#612, **#570 (4a), #579 (4b), #580 (4d)** |
 | 5 | [#614](https://github.com/cornerstone-data/bedrock/issues/614) validate per commodity | #613 |
 | — | [#615](https://github.com/cornerstone-data/bedrock/issues/615) re-run BEA's product-line method | **deferred, candidate for a Phase 3 of the project** |
 
-**Phase 1 — 2017 rates and the receiving sets.** Depends on nothing; start here.
-Derive per-(buyer, commodity, margin type) rates on BEA's cascading bases, and
-the three receiving sets from non-zero values. Prove both identities reproduce
-the published Supply columns commodity by commodity.
+**Phase 1 — 2017 rates and the receiving sets.** Built; see §Phase 1 below for
+what it produced and what it settled.
 
 **Phase 2 — port the transport chain.** flowsa `margins` `BTS_FAF` +
 `Transport_Margins_2017.yaml`. Extend `Crosswalk_SCTGtoBEA.csv` to 2017 detail.
@@ -285,11 +297,15 @@ the 2022 `ecnnapcsprd` vintage, and build the one missing NAPCS → I-O commodit
 concordance. **Do Phase 1 first and see whether that is needed** — it is a large
 piece of work whose output the 2017 Margins file already approximates.
 
-**Phase 4 — apply.** Rates from Phase 1 onto nowcast `T013`, levels controlled
-to Phases 2–3. **`T013` = `T007` + `MCIF` + `MADJ`, so this needs 4a *and* 4b.**
-Applying rates to `T007` alone is the tempting shortcut and drops the margin on
-imports — three independent statements confirm the base: Jolliff's "column OR",
-the wholesale method's "interim supply", and the transport method's table 8.2.
+**Phase 4 — apply.** Rates from Phase 1 onto the nowcast base, levels controlled
+to Phases 2–3. **The base needs 4a, 4b *and* 4d** — it is producer value less
+the trade-level tax, `T013 + MDTY + SUB + producer-level TOP`, measured in
+§Phase 1 against the published column at −0.003%. Two shortcuts to avoid, in
+opposite directions: applying rates to `T007` alone drops the margin on imports
+(three independent statements confirm imports are in the base — Jolliff's
+"column OR", the wholesale method's "interim supply", and the transport method's
+table 8.2), while applying them to full producer value double-counts the
+trade-level tax already inside the rates.
 
 **Phase 5 — validate per commodity, never in aggregate.** `T014` nets to **1**
 against **7,361,003** of gross mass, so a totals check passes on *anything*. Use
@@ -301,6 +317,211 @@ Budget the effort on the **positive side**: the −3.68T negative side is 24
 commodities giving up nearly all their own output (19 trade at 96.8%, eight
 retail sectors at exactly −100%; 5 transport at 56.8%), which 4a produces
 anyway. The work is allocating across the 255 receiving commodities.
+
+## Phase 1 — built
+
+[`bedrock/transform/iot/nowcast_margins.py`](../../transform/iot/nowcast_margins.py)
+carries the structure;
+[`margins_2017_baseline.py`](margins_2017_baseline.py) is the proof against the
+published Supply columns, commodity by commodity, and `--check` fails if a count
+regresses.
+
+**Settled: the anchor is the *before*-redefinitions Margins table.** It matches
+the MUT before-redefinitions tables and therefore the SUT — everything upstream
+of Step 7 stays before redefinitions — and the published Supply table it
+aggregates against is a before-redefinitions construct too.
+
+Measured both ways, the after-redefinitions table closes the **trade identity**
+— `Σ_buyers (Wholesale + Retail) = TRADE + TOP`, §The object — for 226 of the
+255 commodities with positive `TRADE`, against 236. **That gap is redefinition, not framework**
+— the SUT/MUT difference is what the `+ TOP` term handles, and it applies to
+both redefinition states equally. Redefinition moves 6,007 million of trade
+margin gross across 111 commodities, −5,879 net, and **`333914` pump and pumping
+equipment is 4,139 of it on its own**: it is redefined out of the
+after-redefinitions Margins table entirely, as a buyer and as a commodity, while
+the before-redefinitions Supply table still carries `TRADE` = 3,965 for it. The
+rest are small proportional shifts — the largest, `326190`, is 654 on 41,158 —
+that push commodities across the 1% line. So the two tables do not disagree
+about margins; they are indexed on different commodity content, and pairing
+either one with the Supply table of the other state asks them to reconcile
+anyway.
+
+Note `derive_PRO_to_PUR_ratio` reaches for the after-redefinitions table via
+`USAConfig`; these are different objects for different purposes.
+
+**What it produces**, all keyed on the published `(buyer, commodity)` index:
+
+| | transactions | commodities | buyers | margin, $M | carried as a rate | as a level |
+|---|---:|---:|---:|---:|---:|---:|
+| Wholesale | 17,419 (30.6%) | 254 | 413 | 1,894,329 | 17,168 | 251 |
+| Retail | 2,106 (3.7%) | 188 | 336 | 1,761,765 | 2,098 | 8 |
+| Transportation | 12,516 (22.0%) | 258 | 413 | 414,559 | 12,286 | 230 |
+
+Rates are per (buyer, commodity, margin type) on BEA's cascading bases, and the
+table carries a `base_share` and a `margin_share` alongside each — a nowcast
+base arrives per commodity (`T013`) and has to be split across that commodity's
+receiving transactions before a per-transaction rate can be applied, so keeping
+both splits is what lets #613 use this without going back to the published
+table.
+
+**Two treatments, not one.** 489 of the (transaction × margin type) entries
+carry a *level* instead of a rate: 470 `F03000` inventory entries (§Negative
+margins below), and 19 across 13 transactions whose cascading base is zero or
+negative — seven retail cells of exactly 1 million over a zero base, and six
+over a negative one, of which `F02E00` buying `S00402` is essentially all the
+value. A margin over a change-in-inventories base is a timing correction, not a
+rate, and a rate over a negative base is not a number.
+
+### Both identities, per commodity
+
+| identity | population | commodities | holds within 1% | derived, $M | published, $M | net |
+|---|---|---:|---:|---:|---:|---:|
+| trade | `TRADE` > 0 | 255 | **236** | 3,656,094 | 3,697,260 | −1.11% |
+| trade | all | 402 | 279 | | | |
+| transport | `TRANS` > 0 | 258 | **180** | 414,559 | 415,580 | −0.25% |
+| transport | all | 402 | 319 | | | |
+
+⚠️ The two rows per identity are the same check on different populations, and
+the difference is not small: 144 commodities bear no transportation margin on
+either side and hold trivially, which is what turns 180 of 258 into 319 of 402.
+Quote the positive population.
+
+### Every residual, accounted for
+
+**The 19 trade misses are the excise and severance goods, in order** — tobacco
+−18%, oil and gas −33%, distilleries −12%, motion picture −35%, breweries −6%,
+coal −57%, wineries −2%. Each misses by exactly its producer-level tax, which is
+the decomposition above seen from the other end: the identity's tax term
+corrects for *trade-level* tax, sitting inside Wholesale and Retail, while
+excise sits in `Producers' Value` and never enters the left-hand side.
+Producer-level tax is **9.6% of `TOP`** over the 203 margin-bearing commodities
+with `TOP` > 100 million.
+
+**The 78 transport misses are publication rounding, not method.** BEA publishes
+the Margins table to the million and the smallest non-zero transportation cell
+in it is exactly 1 million, so every cell that would round below half a million
+is published as zero and drops out of the commodity sum. The shortfall is
+therefore one-sided — 195 of 258 commodities short against 22 over — and scales
+with how thinly the margin is spread:
+
+| median published cell | commodities | holds | median relative difference |
+|---|---:|---:|---:|
+| ≤ 1M | 21 | 3 | −3.0% |
+| 1–2M | 60 | 23 | −1.3% |
+| 2–5M | 86 | 67 | −0.3% |
+| 5–20M | 72 | 69 | −0.1% |
+| > 20M | 19 | 18 | −0.02% |
+
+The misses carry 7.6% of `TRANS`. Nothing to fix: a nowcast built from these
+rates inherits the same rounding, and the alternative is inventing cells BEA
+suppressed.
+
+**The supplying side is in the Margins table after all** — this changes the
+Phase 4 scoping. The 24 commodities with a negative Supply margin column were
+written off above as "close to a function of trade/transport output, which 4a
+produces anyway". They do not need 4a: the published `Purchasers' Value` is
+**not** the sum of the four components on a trade or transport commodity's own
+rows. PCE buys 254 billion of `441000` motor vehicle dealers at producers' value
+and **zero** at purchasers' value, because that margin has been moved onto the
+goods. `Σ_b (Producers' + Transportation + Wholesale + Retail − Purchasers')`
+per commodity lands entirely on those 24, and:
+
+- against `−TRANS` it is a **direct read** — all five transport commodities
+  within 0.2%, 20 million out of 415,570;
+- against `−TRADE` it runs 1.0× to 2.2× high, and the excess is the trade-level
+  tax the receiving side is short by. The two sides measure that tax
+  independently to within 0.3% — 391,761 million here against 391,162 million by
+  which `Σ(Wholesale + Retail)` exceeds `TRADE` on the receiving side, 12.0% of
+  positive `TRADE`. Petroleum wholesalers are the extreme at 2.2×, exactly as
+  the motor-fuel-tax finding predicts.
+
+⚠️ The same fact is a trap for Step 6b: **do not reconstruct `Purchasers' Value`
+by summing the components** — on 14,655 rows the published table does not, and
+the difference is the whole 4.07 trillion of margin.
+
+### What the rates apply to — and why 4d comes first
+
+The cascade starts from `Producers' Value`, so "what is the nowcast base" is a
+question about *valuation*, and it has a measurable answer. Summing the Margins
+table over buyers per commodity — **excluding `F05000`**, which carries
+−2,626,305 of producers' value, no margin at all, and is a MUT-only negative
+column — gives 37,093,944 against a derived producer value (`T013` + `T015`) of
+37,094,432: **−0.0013%**. Basic `T013` is 36,398,867, off by 695,565. The
+Margins table is a **producer**-value object, not a basic-value one.
+
+Per commodity it is producer value **less the trade-level tax**, because that
+tax is booked inside the margin columns of the commodity receiving the margin
+and inside the `Producers' Value` of the trade commodity that collected it —
+`424700` petroleum wholesalers carry 161,945 of producers' value against a
+`T013` of 72,970. So the base a nowcast has to rebuild is:
+
+```
+base[c] = T013[c] + MDTY[c] + SUB[c] + producer_level_tax[c]
+```
+
+(`SUB` is stored negative in the Supply table, so it subtracts; a negative
+producer-level residual is treated as zero.) Scored against the published
+`Σ_buyers Producers' Value` over the 378 margin-receiving commodities:
+
+| candidate base | within 1% | within 0.1% | net |
+|---|---:|---:|---:|
+| `T013` basic | 293 / 378 | 164 | +0.88% |
+| full producer, `T013 + T015` | 201 / 378 | 125 | −1.19% |
+| **producer less trade-level tax** | **377 / 378** | **364** | **−0.003%** |
+
+**So the tax columns are a hard prerequisite of Phase 4, and only part of `TOP`
+belongs in the base.** Adding all of `TOP` double-counts the trade-level share,
+which is already inside the rates' numerators: 19% too high on petroleum
+refineries, 36% on tobacco. The split that says how much to add is the
+producer-level decomposition Phase 1 produced, which is the third use that
+decomposition has now earned.
+
+| the excise commodities, $M | published `Σ PV` | basic | full producer | the rule |
+|---|---:|---:|---:|---:|
+| Petroleum refineries | 530,433 | 530,094 | 629,277 | 530,435 |
+| Tobacco manufacturing | 62,153 | 48,809 | 84,820 | 62,154 |
+| Distilleries | 25,456 | 21,341 | 32,441 | 25,453 |
+| Oil and gas extraction | 359,408 | 351,108 | 360,281 | 359,410 |
+
+**What Phase 4 therefore depends on:**
+
+| input | from | why |
+|---|---|---|
+| `T007` domestic output, basic | 4a [#570](https://github.com/cornerstone-data/bedrock/issues/570) | `T013` |
+| `MCIF`, `MADJ` | 4b [#579](https://github.com/cornerstone-data/bedrock/issues/579) | `T013` — imported goods carry domestic margin |
+| `MDTY` | 4b [#579](https://github.com/cornerstone-data/bedrock/issues/579) | in the base directly |
+| `TOP`, `SUB` | **4d [#580](https://github.com/cornerstone-data/bedrock/issues/580)** | the producer-level slice of `TOP`, and `SUB` |
+| `F03000` by commodity | 1e [#529](https://github.com/cornerstone-data/bedrock/issues/529) | moves the 470 inventory **level** rows, which no rate covers |
+| buyer split | Phase 1's `base_share` | see below |
+
+**Not** dependencies, and worth stating because both look like they should be.
+Trade and transport commodity output is a *check* on the negative side, not an
+input — the give-up derives from the positive side. And the Use table is
+deliberately not one: distributing the commodity base across buyers uses the
+2017 `base_share` rather than a nowcast Use matrix, because getting producer
+value per Use cell is what Step 6b uses the margins *for*. Freezing the buyer
+structure at 2017 is the price of breaking that circle; if Step 3 lands first,
+the nowcast Use row is available to inform the split, but nothing here requires
+it.
+
+One limitation this makes explicit: the rate numerators contain trade-level
+sales tax, so carrying 2017 rates forward carries 2017's effective sales-tax
+rates with them. A statutory rate change in a nowcast year does not reach the
+margins except through the Phase 3 control totals.
+
+### The bound check, and one correction
+
+| ratio | commodities > 0 | above 1 | max | share of value above 1 |
+|---|---:|---:|---:|---:|
+| `TRADE` / `T013` | 255 | 21 | 16.02 | 21.1% |
+| `TRADE` / `T016` | 255 | **0** | 0.715 | — |
+| `TRANS` / `T013` | 258 | 1 | 3.25 | 5.7% |
+| `TRANS` / `T016` | 258 | **0** | 0.315 | — |
+
+The warning above was written for the trade margin; it applies to
+transportation too. `S00402` used and secondhand goods carries `TRANS`/`T013` of
+3.25 — the same mechanism, a commodity with almost no basic value of its own.
+Bound-check on `T016` for both.
 
 ## Negative margins are inventory timing — never clip them
 

--- a/bedrock/analysis/nowcasting/plan.md
+++ b/bedrock/analysis/nowcasting/plan.md
@@ -702,12 +702,21 @@ not introduce a step 10.
   **Five method points, all from BEA correspondence (B. Jolliff, 2025-05/06) and verified against 2017
   detail in [#571](https://github.com/cornerstone-data/bedrock/issues/571):**
 
-  1. **Apply rates to `T013`, not domestic output.** *"Total product supply (column OR) includes total
-     commodity output plus imports; margins are distributed based on the value in column OR."* Imported
-     goods carry domestic margin, so a rate carried on `T007` alone is biased — and the 2009 manual
-     says the same twice independently, using "interim supply (output + imports)" as the weight in both
-     the wholesale step (4) and the transport step (2). **This is a real sequencing constraint — see
-     below.**
+  1. **Apply rates to supply including imports, not to domestic output.** *"Total product supply
+     (column OR) includes total commodity output plus imports; margins are distributed based on the
+     value in column OR."* Imported goods carry domestic margin, so a rate carried on `T007` alone is
+     biased — and the 2009 manual says the same twice independently, using "interim supply (output +
+     imports)" as the weight in both the wholesale step (4) and the transport step (2). **This is a
+     real sequencing constraint — see below.**
+     ⚠️ **`T013` is the wrong base by a hair, and 4d is a prerequisite.** Measured in
+     [`margins_estimation_plan.md`](margins_estimation_plan.md) §Phase 1: the Margins table's
+     `Producers' Value` is a **producer**-value object (`Σ_buyers` = `T013` + `T015` to −0.0013%,
+     against `T013` alone at +1.9%), and per commodity it is producer value *less* the trade-level tax
+     that rides inside the margin columns. The base to rebuild is
+     `T013 + MDTY + SUB + producer-level TOP` — 377 of 378 receiving commodities within 1% against
+     293 for `T013` and 201 for full producer value. So **4c's application phase needs `TOP`/`SUB`
+     from 4d**, and only the producer-level slice of `TOP`: adding all of it double-counts the
+     trade-level share already inside the rates, by 19% on petroleum refineries and 36% on tobacco.
      ⚠️ Note `TRADE`/`T013` is **not** bounded by 1 and a ratio above 1 is not evidence of an error:
      margin is *added to* basic value (`T016 = T013 + T014 + T015`), not carved out of it. 21
      commodities exceed 1 legitimately — apparel is 1.84 — while `TRADE`/`T016` exceeds 1 for none.
@@ -740,6 +749,11 @@ not introduce a step 10.
   which is what the transaction-level rates are for.
 - 4d. **Tax/subsidy columns** (`TOP`, `SUB`) — NIPA T30500/T31300 totals split by 2017 commodity
   shares. Remember `SUB` is negative here and positive in the Use table.
+  ⚠️ **Not last, and not optional to 4c**: 4c's application phase needs `TOP` and `SUB` for its base
+  (point 1 above), so 4d runs before 4c's second half rather than after the margin columns. It also
+  needs to carry `TOP`'s **producer-level vs trade-level split**, not just the total — #610 measured
+  the 2017 split per commodity (9.6% producer-level over the 203 margin-bearing commodities with
+  `TOP` > 100 million), and only the producer-level part belongs in the margin base.
 - 4e. **Verify the four Supply identities per commodity** (`T013`/`T014`/`T015`/`T016` above), 402/402,
   before declaring the Supply table done.
 
@@ -947,16 +961,17 @@ replaced by #572. **Every item on the board is now a trackable issue.**
   the Supply margin columns, Step 6b's PUR→PRO conversion, and the Step 6d Margins deliverable.
 
   **4c splits into two halves with different dependencies, and only the first is truly parallel.**
-  BEA distributes margins on `T013` = `T007` + `MCIF` + `MADJ` (§Step 4c point 1), so:
+  BEA distributes margins on supply including imports (§Step 4c point 1), so:
 
   | half | needs | when |
   |---|---|---|
-  | **Derive 2017 rates** per (buyer, commodity, margin type) from the published Margins table, and prove the two identities reproduce the 2017 Supply columns | nothing — the 2017 tables are already loaded | **start now, genuinely parallel** |
-  | **Apply those rates** to a nowcast year | `T007` from **4a** (#570) *and* `MCIF`/`MADJ` from **4b** (#579) | after both |
+  | ✅ **Derive 2017 rates** per (buyer, commodity, margin type) from the published Margins table, and prove the two identities reproduce the 2017 Supply columns | nothing — the 2017 tables are already loaded | **done, #610** |
+  | **Apply those rates** to a nowcast year | `T007` from **4a** (#570), `MCIF`/`MADJ`/`MDTY` from **4b** (#579) *and* `TOP`/`SUB` from **4d** (#580) | after all three |
 
-  Doing the first half now is what de-risks the other three consumers, because it settles the rate
-  structure and the identities without waiting on any other step. Applying rates to `T007` alone to
-  avoid the 4b dependency is the tempting shortcut and is **wrong** — it drops the margin on imports.
+  Doing the first half first is what de-risked the other three consumers, and it also **settled what
+  the second half depends on**: the rate base is producer value less trade-level tax, not `T013`, so
+  4d joins 4a and 4b as a prerequisite (§Step 4c point 1). Applying rates to `T007` alone to avoid the
+  4b dependency is the tempting shortcut and is **wrong** — it drops the margin on imports.
 - **P1** — code-space Phase 2 (retarget `FD_Gov`/`FD_Structures`/`FD_IP`, drop
   `map_fbs_sectors_to_model_schema`, roll out 2018-2024), which unblocks #576, Step 2 and Step 3.
   #574 may fall out of this rather than needing its own attribution work — diagnose first. Then #579,

--- a/bedrock/transform/iot/__tests__/test_nowcast_margins.py
+++ b/bedrock/transform/iot/__tests__/test_nowcast_margins.py
@@ -1,0 +1,189 @@
+"""Tests for the 2017 margin anchor (Step 4c phase 1, #610).
+
+All synthetic: the rate structure is arithmetic over a published table, and the
+published table is checked against the Supply columns by
+``bedrock/analysis/nowcasting/margins_2017_baseline.py`` instead.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from bedrock.transform.iot.nowcast_margins import (
+    BUYER_LEVEL,
+    COMMODITY_LEVEL,
+    INVENTORY_BUYER_CODE,
+    LEVEL_BASIS,
+    MARGIN_TYPE_LEVEL,
+    RATE_BASIS,
+    margin_bases,
+    margin_levels,
+    margin_rate_table,
+    margin_receiving_sets,
+    margins_by_commodity,
+    rate_dispersion_by_commodity,
+    receiving_set_summary,
+)
+
+MARGIN_COLUMNS = [
+    "Producers' Value",
+    'Transportation',
+    'Wholesale',
+    'Retail',
+    "Purchasers' Value",
+]
+
+
+def margins_frame(
+    rows: list[tuple[str, str, float, float, float, float]],
+) -> pd.DataFrame:
+    """``(buyer, commodity, producers, transport, wholesale, retail)`` rows."""
+    frame = pd.DataFrame(
+        [row[2:] for row in rows],
+        columns=MARGIN_COLUMNS[:4],
+        index=pd.MultiIndex.from_tuples(
+            [row[:2] for row in rows], names=[BUYER_LEVEL, COMMODITY_LEVEL]
+        ),
+    )
+    frame["Purchasers' Value"] = frame.sum(axis=1)
+    return frame
+
+
+def test_bases_cascade() -> None:
+    margins = margins_frame([('111100', '325412', 100.0, 10.0, 20.0, 5.0)])
+    bases = margin_bases(margins)
+    assert bases['Transportation'].iloc[0] == 100.0
+    assert bases['Wholesale'].iloc[0] == 110.0
+    assert bases['Retail'].iloc[0] == 130.0
+
+
+def test_rates_are_margin_over_the_cascading_base() -> None:
+    margins = margins_frame([('111100', '325412', 100.0, 10.0, 22.0, 26.4)])
+    table = margin_rate_table(margins)
+    rates = table.xs(('111100', '325412'))['rate']
+    assert rates['Transportation'] == pytest.approx(0.1)  # 10 / 100
+    assert rates['Wholesale'] == pytest.approx(0.2)  # 22 / 110
+    assert rates['Retail'] == pytest.approx(0.2)  # 26.4 / 132
+    assert (table['basis'] == RATE_BASIS).all()
+
+
+def test_receiving_sets_are_the_non_zero_transactions() -> None:
+    margins = margins_frame(
+        [
+            ('111100', '325412', 100.0, 10.0, 20.0, 0.0),
+            ('F01000', '325412', 100.0, 0.0, 20.0, 30.0),
+            ('112100', '325412', 100.0, 0.0, 0.0, 0.0),
+        ]
+    )
+    sets = margin_receiving_sets(margins)
+    assert list(sets['Transportation']) == [('111100', '325412')]
+    assert list(sets['Wholesale']) == [('111100', '325412'), ('F01000', '325412')]
+    assert list(sets['Retail']) == [('F01000', '325412')]
+    # a transaction with no margin of any kind is in no receiving set
+    assert not any(('112100', '325412') in index for index in sets.values())
+
+
+def test_inventories_are_carried_as_a_level_not_a_rate() -> None:
+    margins = margins_frame(
+        [
+            ('111100', '325412', 100.0, 10.0, 20.0, 0.0),
+            (INVENTORY_BUYER_CODE, '325412', 400.0, -8.0, 12.0, 0.0),
+        ]
+    )
+    table = margin_rate_table(margins)
+    inventory = table.xs(INVENTORY_BUYER_CODE, level=BUYER_LEVEL)
+    assert (inventory['basis'] == LEVEL_BASIS).all()
+    assert inventory['rate'].isna().all()
+    # the negative margin survives untouched - it is a timing correction
+    assert inventory.loc[('325412', 'Transportation'), 'margin'] == -8.0
+    assert set(margin_levels(margins).index.get_level_values(BUYER_LEVEL)) == {
+        INVENTORY_BUYER_CODE
+    }
+
+
+def test_non_positive_base_is_carried_as_a_level() -> None:
+    margins = margins_frame(
+        [
+            ('F02E00', 'S00402', -1000.0, 40.0, 0.0, 0.0),
+            ('111100', '335110', 0.0, 0.0, 0.0, 1.0),
+            ('111100', '325412', 100.0, 10.0, 0.0, 0.0),
+        ]
+    )
+    table = margin_rate_table(margins)
+    assert table.loc[('F02E00', 'S00402', 'Transportation'), 'basis'] == LEVEL_BASIS
+    assert table.loc[('111100', '335110', 'Retail'), 'basis'] == LEVEL_BASIS
+    assert table.loc[('111100', '325412', 'Transportation'), 'basis'] == RATE_BASIS
+    assert table['rate'].isna().sum() == 2
+
+
+def test_shares_split_a_commodity_across_its_rate_rows() -> None:
+    margins = margins_frame(
+        [
+            ('111100', '325412', 300.0, 0.0, 30.0, 0.0),
+            ('F01000', '325412', 100.0, 0.0, 20.0, 0.0),
+            (INVENTORY_BUYER_CODE, '325412', 400.0, 0.0, 40.0, 0.0),
+        ]
+    )
+    wholesale = margin_rate_table(margins).xs('Wholesale', level=MARGIN_TYPE_LEVEL)
+    rate_rows = wholesale['basis'] == RATE_BASIS
+    assert wholesale.loc[rate_rows, 'base_share'].sum() == 1.0
+    assert wholesale.loc[rate_rows, 'margin_share'].sum() == 1.0
+    # the level row is excluded from both, so its 400 does not dilute the split
+    assert wholesale.loc[('111100', '325412'), 'base_share'] == 0.75
+    assert wholesale.loc[('F01000', '325412'), 'margin_share'] == 0.4
+    assert (
+        wholesale.xs(INVENTORY_BUYER_CODE, level=BUYER_LEVEL)['base_share'].isna().all()
+    )
+
+
+def test_margins_by_commodity_sums_trade_and_transport_separately() -> None:
+    margins = margins_frame(
+        [
+            ('111100', '325412', 100.0, 10.0, 20.0, 0.0),
+            ('F01000', '325412', 100.0, 5.0, 15.0, 40.0),
+            ('111100', '311111', 100.0, 7.0, 0.0, 0.0),
+        ]
+    )
+    by_commodity = margins_by_commodity(margins)
+    assert by_commodity.loc['325412', 'trade_margins'] == 75.0
+    assert by_commodity.loc['325412', 'transport_margins'] == 15.0
+    assert by_commodity.loc['311111', 'trade_margins'] == 0.0
+    # every commodity is present, so a margin-free one reads zero rather than
+    # dropping out of a per-commodity check
+    assert len(by_commodity) == 402
+    assert by_commodity.loc['221100', 'trade_margins'] == 0.0
+
+
+def test_receiving_set_summary_counts_both_treatments() -> None:
+    margins = margins_frame(
+        [
+            ('111100', '325412', 100.0, 10.0, 20.0, 0.0),
+            ('F01000', '325412', 100.0, 0.0, 20.0, 40.0),
+            (INVENTORY_BUYER_CODE, '325412', 400.0, -8.0, 0.0, 0.0),
+            ('112100', '311111', 50.0, 0.0, 0.0, 0.0),
+        ]
+    )
+    summary = receiving_set_summary(margins)
+    transportation = summary.loc['Transportation']
+    assert transportation['transactions'] == 2
+    assert transportation['transaction_share'] == 0.5
+    assert transportation['rate_transactions'] == 1
+    assert transportation['level_transactions'] == 1
+    assert transportation['margin'] == 2.0
+    assert summary.loc['Retail', 'transactions'] == 1
+    assert summary.loc['Wholesale', 'buyers'] == 2
+
+
+def test_dispersion_needs_more_than_one_transaction() -> None:
+    margins = margins_frame(
+        [
+            ('111100', '325412', 100.0, 0.0, 10.0, 0.0),
+            ('F01000', '325412', 100.0, 0.0, 30.0, 0.0),
+            ('111100', '311111', 100.0, 0.0, 20.0, 0.0),
+        ]
+    )
+    dispersion = rate_dispersion_by_commodity(margins)
+    assert list(dispersion.index) == [('Wholesale', '325412')]
+    assert dispersion['mean'].iloc[0] == pytest.approx(0.2)  # (0.1 + 0.3) / 2
+    assert dispersion['cv'].iloc[0] == pytest.approx(0.5)  # std 0.1 over mean 0.2

--- a/bedrock/transform/iot/nowcast_margins.py
+++ b/bedrock/transform/iot/nowcast_margins.py
@@ -1,0 +1,338 @@
+"""2017-anchored margin structure for the nowcast Margins dataset.
+
+Step 4c of the nowcast build
+(``bedrock/analysis/nowcasting/margins_estimation_plan.md``), phase 1
+(`#610 <https://github.com/cornerstone-data/bedrock/issues/610>`_). What this
+module produces is the *structure* the later phases carry forward: the three
+receiving sets, a rate per (buyer, commodity, margin type), and the aggregation
+back to the Supply table's margin columns. It sources nothing annual - phases 2
+and 3 supply the annual levels, and phase 4 (#613) applies these rates to a
+nowcast base.
+
+**The object.** BEA's published Margins table is one row per (buyer, commodity)
+with columns ``Producers' Value``, ``Transportation``, ``Wholesale``,
+``Retail``, ``Purchasers' Value``. The buyer side spans industries *and*
+final-demand codes, so a good bought by a household and the same good bought as
+an intermediate input are separate rows - which is the point, since their retail
+rates differ by more than 2x.
+
+**Before redefinitions.** The margins anchor is the before-redefinitions table,
+matching the MUT before-redefinitions tables and therefore the SUT: everything
+upstream of Step 7 stays before redefinitions, and the published Supply table
+this aggregates against is a before-redefinitions construct too. The
+after-redefinitions table is the one ``derive_PRO_to_PUR_ratio`` reaches for via
+``USAConfig`` - a different object for a different purpose.
+
+**Cascading bases.** The margin rates are not shares of one common denominator.
+Per the BEA IO manual (2009) chapter 8, margins stack: transportation applies to
+producers' value, wholesale to producers' value plus transportation, retail to
+all three. :data:`MARGIN_BASE_COLUMNS` encodes that order.
+
+**A rate above 1 is not an error.** Margin is *added* to basic value
+(``T016 = T013 + T014 + T015``), not carved out of it, so a rate on any of these
+bases is unbounded - ``S00402`` used and secondhand goods runs to 16x its basic
+value because used goods have no production. Bound-check against ``T016``
+instead; see ``margins_2017_baseline.py``.
+
+**Two treatments, not one.** Most receiving transactions carry a *rate*. Two
+kinds carry a *level* instead (:data:`LEVEL_BASIS`):
+
+- ``F03000`` change in private inventories. Every negative margin in the 2017
+  table is an ``F03000`` row: margin is booked when inventories build, so a
+  drawdown carries the offsetting negative. That is a timing correction, not a
+  rate, and dividing it by a change-in-inventories base produces a number that
+  means nothing. Note this is the signal ``_margin_negatives_treatment``'s
+  ``abs_negative_margin_columns`` flag destroys - do not route this table
+  through it.
+- Transactions whose cascading base is zero or negative, where a rate is
+  undefined. 13 of them in 2017 - seven retail cells of exactly 1 million over a
+  zero base, and six over a negative one, of which ``F02E00`` buying ``S00402``
+  is 18.5 billion of the 18.5 billion involved.
+"""
+
+from __future__ import annotations
+
+import functools
+
+import numpy as np
+import pandas as pd
+
+from bedrock.extract.iot.io_2017 import load_2017_margins_before_redef_usa
+from bedrock.utils.taxonomy.bea.v2017_commodity import USA_2017_COMMODITY_CODES
+
+#: The three margin types, in the order they cascade.
+MARGIN_TYPES: tuple[str, ...] = ('Transportation', 'Wholesale', 'Retail')
+
+#: The base each margin type's rate is expressed on (BEA IO manual 2009, ch. 8).
+#: Margins stack, so each type's base includes the ones applied before it.
+MARGIN_BASE_COLUMNS: dict[str, tuple[str, ...]] = {
+    'Transportation': ("Producers' Value",),
+    'Wholesale': ("Producers' Value", 'Transportation'),
+    'Retail': ("Producers' Value", 'Transportation', 'Wholesale'),
+}
+
+#: Index level names of the published Margins table.
+BUYER_LEVEL = 'Industry Code'
+COMMODITY_LEVEL = 'Commodity Code'
+MARGIN_TYPE_LEVEL = 'margin_type'
+
+#: Change in private inventories - carried as a level, never fitted as a rate.
+INVENTORY_BUYER_CODE = 'F03000'
+
+RATE_BASIS = 'rate'
+LEVEL_BASIS = 'level'
+
+
+@functools.cache
+def load_margins_transactions_2017() -> pd.DataFrame:
+    """
+    Published 2017 detail Margins table, before redefinitions, restricted to
+    real commodities. USD.
+
+    The workbook carries the value-added rows (``V00100``, ``V00200``,
+    ``V00300``) in the commodity column as well, which the transaction object
+    has no use for - they hold producers' value only and never any margin.
+    """
+    df = load_2017_margins_before_redef_usa()
+    commodities = df.index.get_level_values(COMMODITY_LEVEL)
+    return df.loc[commodities.isin(USA_2017_COMMODITY_CODES)]
+
+
+def _margins_or_default(margins: pd.DataFrame | None) -> pd.DataFrame:
+    return load_margins_transactions_2017() if margins is None else margins
+
+
+def margin_bases(margins: pd.DataFrame | None = None) -> pd.DataFrame:
+    """
+    The cascading base of each margin type, per transaction. USD.
+
+    One column per :data:`MARGIN_TYPES`, on the same index as *margins*.
+    """
+    df = _margins_or_default(margins)
+    return pd.DataFrame(
+        {
+            margin_type: df[list(base_columns)].sum(axis=1)
+            for margin_type, base_columns in MARGIN_BASE_COLUMNS.items()
+        },
+        index=df.index,
+    )
+
+
+def margin_receiving_sets(
+    margins: pd.DataFrame | None = None,
+) -> dict[str, pd.MultiIndex]:
+    """
+    The (buyer, commodity) transactions that bear each margin, per margin type.
+
+    A transaction receives a margin exactly when the published value is
+    non-zero, which is BEA's own definition of the receiving set - the wholesale
+    and retail steps distribute to a hand-selected set of transactions, and the
+    zeros are that selection, not missing data. Retail's set is 8x sparser than
+    wholesale's, as the manual's "only those transactions that move through
+    retail establishments" implies.
+    """
+    df = _margins_or_default(margins)
+    return {
+        margin_type: pd.MultiIndex.from_frame(
+            df.index[df[margin_type] != 0].to_frame(index=False)
+        )
+        for margin_type in MARGIN_TYPES
+    }
+
+
+def margin_rate_table(margins: pd.DataFrame | None = None) -> pd.DataFrame:
+    """
+    One row per (buyer, commodity, margin type) that receives margin, with the
+    rate or the level to carry it forward by.
+
+    Index: ``Industry Code`` x ``Commodity Code`` x ``margin_type``. Columns:
+
+    ``margin``
+        the published margin, USD.
+    ``base``
+        its cascading base (:data:`MARGIN_BASE_COLUMNS`), USD.
+    ``rate``
+        ``margin / base``, or NaN where the row is carried as a level.
+    ``basis``
+        :data:`RATE_BASIS` or :data:`LEVEL_BASIS` - see the module docstring for
+        why two treatments are needed.
+    ``base_share``, ``margin_share``
+        the row's share of its (commodity, margin type) group, over the
+        rate-basis rows only, so each sums to 1 within a group. A nowcast base
+        arrives per commodity (``T013``, from 4a and 4b) and has to be split
+        across that commodity's receiving transactions before a per-transaction
+        rate can be applied; these are the two candidate splits, and keeping
+        both here is what makes the rate structure usable by #613 without going
+        back to the published table.
+
+    Rates are deliberately *not* collapsed to one per commodity. BEA computes
+    one rate per *item*, uniform across the transactions receiving it, but the
+    item is finer than the published commodity and is not recoverable: zero of
+    the published commodities have a uniform rate on either trade margin.
+    """
+    df = _margins_or_default(margins)
+    bases = margin_bases(df)
+    buyers = df.index.get_level_values(BUYER_LEVEL)
+
+    frames = []
+    for margin_type in MARGIN_TYPES:
+        receiving = df[margin_type] != 0
+        frame = pd.DataFrame(
+            {
+                'margin': df.loc[receiving, margin_type],
+                'base': bases.loc[receiving, margin_type],
+            }
+        )
+        frame[MARGIN_TYPE_LEVEL] = margin_type
+        frame['basis'] = np.where(
+            (buyers[receiving] == INVENTORY_BUYER_CODE) | (frame['base'] <= 0),
+            LEVEL_BASIS,
+            RATE_BASIS,
+        )
+        frames.append(frame.set_index(MARGIN_TYPE_LEVEL, append=True))
+
+    out = pd.concat(frames).sort_index()
+    is_rate = out['basis'] == RATE_BASIS
+    out['rate'] = (out['margin'] / out['base']).where(is_rate)
+
+    group = [COMMODITY_LEVEL, MARGIN_TYPE_LEVEL]
+    for column, share in (('base', 'base_share'), ('margin', 'margin_share')):
+        totals = out[column].where(is_rate).groupby(level=group).transform('sum')
+        out[share] = (out[column] / totals.replace(0.0, np.nan)).where(is_rate)
+
+    return out[['margin', 'base', 'rate', 'basis', 'base_share', 'margin_share']]
+
+
+def margin_levels(margins: pd.DataFrame | None = None) -> pd.DataFrame:
+    """
+    The receiving transactions carried as levels rather than rates.
+
+    The ``F03000`` inventory rows and the handful with a non-positive base, in
+    the same shape as :func:`margin_rate_table`. Their margin moves with a
+    price index, not with a base.
+    """
+    table = margin_rate_table(margins)
+    return table.loc[table['basis'] == LEVEL_BASIS]
+
+
+def margins_by_commodity(margins: pd.DataFrame | None = None) -> pd.DataFrame:
+    """
+    The two Supply-table margin aggregates, per commodity. USD.
+
+    ``trade_margins``
+        ``sum_buyers (Wholesale + Retail)``, which equals Supply
+        ``TRADE + TOP`` - **not** ``TRADE``. The Margins table is on the
+        make-use framework and the Supply table on supply-use; wholesale and
+        retail trade commodity tax sits inside the margin columns of the former
+        and in the taxes-on-products column of the latter (B. Jolliff, BEA,
+        2025-05-30). Dropping the tax term overstates ``TRADE`` by 11.8%.
+    ``transport_margins``
+        ``sum_buyers Transportation``, which equals Supply ``TRANS`` directly -
+        no tax term, since transportation is not a trade margin.
+    ``margin_given_up``
+        the other side of the same money:
+        ``sum_buyers (Producers' + Transportation + Wholesale + Retail -
+        Purchasers')``. The published ``Purchasers' Value`` is *not* the sum of
+        the four components on a trade or transport commodity's own rows - PCE
+        buys 254 billion of ``441000`` motor vehicle dealers at producers' value
+        and zero at purchasers' value, because that margin has been moved onto
+        the goods. The difference is what the commodity gave up, and it lands
+        entirely on the 24 commodities whose Supply margin column is negative:
+        19 trade and 5 transport. Against ``-TRANS`` it reproduces all five
+        transport commodities within 0.2%; against ``-TRADE`` it runs 1.0x to
+        2.2x high, and the excess is trade-level tax, the same term the trade
+        identity carries on the receiving side with the opposite sign.
+
+    Reindexed to all 402 commodities, so a commodity that bears no margin
+    appears as zero rather than dropping out.
+
+    Validate these per commodity and never in aggregate: ``T014`` nets to about
+    1 economy-wide against 7.4 trillion of gross mass, because a trade margin is
+    added to the good and subtracted from the trade commodity that earned it. A
+    totals check here passes on anything.
+    """
+    df = _margins_or_default(margins)
+    given_up = (
+        df[list(MARGIN_TYPES) + ["Producers' Value"]].sum(axis=1)
+        - df["Purchasers' Value"]
+    )
+    by_commodity = (
+        df.assign(margin_given_up=given_up)
+        .groupby(level=COMMODITY_LEVEL)[list(MARGIN_TYPES) + ['margin_given_up']]
+        .sum()
+        .reindex(list(USA_2017_COMMODITY_CODES), fill_value=0.0)
+    )
+    out = pd.DataFrame(
+        {
+            'trade_margins': by_commodity['Wholesale'] + by_commodity['Retail'],
+            'transport_margins': by_commodity['Transportation'],
+            'margin_given_up': by_commodity['margin_given_up'],
+        }
+    )
+    out.index.name = COMMODITY_LEVEL
+    return out
+
+
+def receiving_set_summary(margins: pd.DataFrame | None = None) -> pd.DataFrame:
+    """
+    Shape of each receiving set: how many transactions, buyers and commodities
+    bear the margin, how much value it carries, and how it splits between the
+    two treatments.
+
+    ``transaction_share`` is against every row of the table, receiving or not,
+    which is the figure that says how differently the three margins behave -
+    wholesale reaches 30% of transactions, retail 4%.
+    """
+    df = _margins_or_default(margins)
+    table = margin_rate_table(df)
+    rows = []
+    for margin_type in MARGIN_TYPES:
+        received = table.xs(margin_type, level=MARGIN_TYPE_LEVEL)
+        is_rate = received['basis'] == RATE_BASIS
+        rows.append(
+            {
+                MARGIN_TYPE_LEVEL: margin_type,
+                'transactions': len(received),
+                'transaction_share': len(received) / len(df),
+                'commodities': received.index.get_level_values(
+                    COMMODITY_LEVEL
+                ).nunique(),
+                'buyers': received.index.get_level_values(BUYER_LEVEL).nunique(),
+                'margin': received['margin'].sum(),
+                'rate_transactions': int(is_rate.sum()),
+                'rate_margin': received.loc[is_rate, 'margin'].sum(),
+                'level_transactions': int((~is_rate).sum()),
+                'level_margin': received.loc[~is_rate, 'margin'].sum(),
+                'median_rate': received['rate'].median(),
+            }
+        )
+    return pd.DataFrame(rows).set_index(MARGIN_TYPE_LEVEL)
+
+
+def rate_dispersion_by_commodity(
+    margins: pd.DataFrame | None = None,
+) -> pd.DataFrame:
+    """
+    Within-commodity dispersion of the rates, per margin type and commodity.
+
+    The evidence against collapsing to one rate per commodity, and the reason
+    :func:`margin_rate_table` keeps the buyer dimension: BEA's uniform rate is
+    at the item level, finer than the published commodity, so several item rates
+    mix inside every commodity here. Restricted to commodities with more than
+    one rate-basis transaction, since a single-transaction commodity has no
+    dispersion to measure.
+
+    Columns: ``transactions``, ``mean``, ``std``, ``cv``.
+    """
+    table = margin_rate_table(margins)
+    rates = table.loc[table['basis'] == RATE_BASIS, 'rate']
+    grouped = rates.groupby(level=[MARGIN_TYPE_LEVEL, COMMODITY_LEVEL])
+    out = pd.DataFrame(
+        {
+            'transactions': grouped.size(),
+            'mean': grouped.mean(),
+            'std': grouped.std(ddof=0),
+        }
+    )
+    out['cv'] = out['std'] / out['mean'].replace(0.0, np.nan)
+    return out.loc[out['transactions'] > 1]


### PR DESCRIPTION
cc:
Related: #571, #610

**Stack 1 of 3** for Step 4c margins. Base `nowcast`.
→ #611 transport chain → #612 trade levels.

## What changed? Why?

Phase 1 of [`margins_estimation_plan.md`](https://github.com/cornerstone-data/bedrock/blob/nowcast/bedrock/analysis/nowcasting/margins_estimation_plan.md): the 2017 anchor every later phase moves forward. `bedrock/transform/iot/nowcast_margins.py` carries the structure; `margins_2017_baseline.py` is the proof against the published Supply columns, commodity by commodity, with `--check` failing if a count regresses.

**The anchor is the *before*-redefinitions Margins table.** It matches the MUT before-redefinitions tables and therefore the SUT — everything upstream of Step 7 stays before redefinitions — and the published Supply table it aggregates against is a before-redefinitions construct too. Note `derive_PRO_to_PUR_ratio` reaches for the *after*-redefinitions table via `USAConfig`; these are different objects for different purposes.

**What it produces**, keyed on the published `(buyer, commodity)` index:

| | transactions | commodities | buyers | margin, $M | as a rate | as a level |
|---|---:|---:|---:|---:|---:|---:|
| Wholesale | 17,419 (30.6%) | 254 | 413 | 1,894,329 | 17,168 | 251 |
| Retail | 2,106 (3.7%) | 188 | 336 | 1,761,765 | 2,098 | 8 |
| Transportation | 12,516 (22.0%) | 258 | 413 | 414,559 | 12,286 | 230 |

Rates are per (buyer, commodity, margin type) on BEA's cascading bases, with a `base_share` and `margin_share` alongside each, so #613 can split a per-commodity nowcast base across receiving transactions without going back to the published table.

**Two treatments, not one.** 489 entries carry a *level* rather than a rate: 470 `F03000` inventory entries, and 19 whose cascading base is zero or negative. A margin over a change-in-inventories base is a timing correction, and a rate over a negative base is not a number.

## Findings that shape the later phases

**A per-commodity rate is not supportable.** BEA computes one rate per *item*, and the item is finer than the published commodity. Rate dispersion within commodities: wholesale median CV **0.218** over 253 commodities with **none** under 0.01, retail **0.776**, transportation **0.226**. Four commodities out of 641 are effectively uniform. So rates are carried per (buyer, commodity, margin type) as #571 specifies.

**Both identities hold, per commodity:**

| identity | population | commodities | within 1% | derived $M | published $M | net |
|---|---|---:|---:|---:|---:|---:|
| trade | `TRADE` > 0 | 255 | **236** | 3,656,094 | 3,697,260 | −1.11% |
| transport | `TRANS` > 0 | 258 | **180** | 414,559 | 415,580 | −0.25% |

Every residual is accounted for. The 19 trade misses are the excise and severance goods in order (tobacco −18%, oil and gas −33%, coal −57%) — each misses by exactly its producer-level tax, which sits in `Producers' Value` and never enters the left-hand side. The 78 transport misses are **publication rounding**, not method: the smallest non-zero cell is 1 million, so cells rounding below half a million publish as zero, and the shortfall is one-sided (195 short against 22 over) and scales with how thinly the margin is spread.

**The base for Phase 4 is producer value less trade-level tax** — measured, not assumed:

| candidate base | within 1% of published `Σ PV` | within 0.1% | net |
|---|---:|---:|---:|
| `T013` basic | 293 / 378 | 164 | +0.88% |
| full producer, `T013 + T015` | 201 / 378 | 125 | −1.19% |
| **producer less trade-level tax** | **377 / 378** | **364** | **−0.003%** |

This is why 4d (#580) is a hard prerequisite of #613: only *part* of `TOP` belongs in the base, and adding all of it double-counts the trade-level share already inside the rates' numerators.

## Two traps recorded

⚠️ **Do not reconstruct `Purchasers' Value` by summing the components.** On 14,655 rows the published table does not — PCE buys 254 billion of `441000` at producers' value and **zero** at purchasers' value, because that margin has been moved onto the goods. This is a trap for Step 6b.

⚠️ **Never clip the negative margins.** All 31 negative rows are buyer `F03000`, −8,076 million, and they are inventory timing (BEA correspondence quoted in the plan). `_margin_negatives_treatment`'s `abs_negative_margin_columns` flag in `derive_PRO_to_PUR_ratio.py` would destroy exactly this signal. Expect the sign to flip in an inventory-build year.

## Testing

`bedrock/transform/iot/__tests__/test_nowcast_margins.py`. `margins_2017_baseline.py --check` is the regression gate, per the repo's convention of making analysis-script checks a CLI flag rather than a unit test.
