### PR TITLE
Step 4c-2: port the FAF transport margin chain, annual TRANS 2017-2024 (#611)

### DIFF
--- a/bedrock/analysis/nowcasting/margins_estimation_plan.md
+++ b/bedrock/analysis/nowcasting/margins_estimation_plan.md
@@ -140,7 +140,107 @@ approximated, and the commodity cost structure a volume weighting discards is
 kept — furniture stays eight times dearer per ton-mile than coal because the
 2017 table says so, not because a model inferred it.
 
-Three things that follow, all of which shrink the work:
+### The control total is not decoration — it is most of the movement
+
+⚠️ **Ton-miles are a volume index and `TRANS` is nominal.** Moving 2017 by
+ton-mile growth alone holds 2017 freight *rates* fixed, and 2017 freight rates
+are not a small thing to get wrong: the volume index reaches only 1.036 by 2022
+while the nominal level reaches 1.483. Nearly all of the movement in the
+transport margin over the nowcast window is repricing, not more freight.
+
+**Built** in
+[`nowcast_transport_margins.py`](../../transform/iot/nowcast_transport_margins.py)
+as the transport industries' own gross output, held at each mode's 2017 ratio of
+margin given up to output:
+
+```
+control[t]   = Σ_m GO_m[t] × (given_up_m[2017] ÷ GO_m[2017]),  rescaled so control[2017] = TRANS_2017
+TRANS[c, t]  = shape[c, t] × control[t] ÷ Σ_c shape[c, t]
+```
+
+Two reasons for that source over a freight price index. It is **the same number
+the negative side of the column carries** — `Σ_m given_up_m` *is* `−TRANS`, so
+the two sides cannot drift apart — and it is per mode, so it reprices truck
+freight with truck output rather than with an economy-wide deflator. The
+rescaling is 0.24%: the 2017 composite is 415,548 against 414,559 received, the
+gap being the negative `F03000` rows on the receiving side.
+
+| | 2018 | 2019 | 2020 | 2021 | 2022 | 2023 | 2024 |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| volume (ton-miles) | 1.066 | 1.052 | 0.997 | 1.025 | 1.036 | 1.029 | 1.032 |
+| level (control) | 1.099 | 1.127 | 1.089 | 1.266 | 1.483 | 1.393 | 1.399 |
+| **repricing** | 1.031 | 1.072 | 1.092 | 1.236 | **1.431** | 1.354 | 1.356 |
+
+Truck is 68% of `TRANS` and its output runs 1.572x its 2017 level in 2022 — the
+freight-rate surge, which the volume index cannot see at all.
+
+Three limitations, recorded rather than corrected:
+
+- **The 2017/2018 seam is partly methodological.** FAF's 2017 is anchored on the
+  CFS and 2018 onward are modelled. Aggregate ton-miles move 1.9% across it, but
+  the composition moves more: 21% of 2017 `TRANS` sits in SCTG groups jumping
+  more than 25% in that one year, and the `TRANS`-weighted mean step is 1.124
+  against the aggregate's 1.019. The control total absorbs the level, so what
+  survives is a shape shift.
+- **Air and rail output are not freight-only.** Air's 2017 give-up ratio is
+  0.026 against rail's 0.862 — the rest of air output is passengers — so air
+  freight margin follows passenger air. Air is 1.5% of `TRANS`; truck, the mode
+  that matters, is close to freight-pure.
+- **Pipeline gives up 1.033 of its own gross output.** Carried as an index, but
+  it means pipeline margin tracks the crude-price component of pipeline output.
+  `211000` crude petroleum is on that account the largest single movement in the
+  whole column, +34,289 million from 2017 to 2024.
+
+External validation of the annual trend — BTS Transportation Satellite Accounts,
+which give **for-hire** output by mode, and Freight Facts and Figures — is
+[#620](https://github.com/cornerstone-data/bedrock/issues/620), medium priority.
+`BTS_TSA` is already half-built as an FBA (2012–2019, NAICS 2012).
+
+### ⚠️ Agreed refinement, designed and not yet built
+
+The frozen give-up ratio is the weak point above, and there is a better
+construction that removes it for most of the column. **Decided 2026-08-09; the
+code still carries the ratio version.**
+
+The Supply table closes the identity exactly — `T016`, all direct non-margin
+uses, equals `T013 + TRANS + TOP + SUB` — so the margin *is* a residual:
+
+```
+direct_uses[t] = T016[2017] × final_use_index[t]      # intermediate:final frozen at 2017
+margin[t]      = (T013 + TOP + SUB)[t] − direct_uses[t]
+```
+
+Whether that residual is usable is entirely a question of conditioning, and it
+splits the modes cleanly:
+
+| 2017, $M | `T013` | `TRANS` | `T016` direct uses | leverage¹ | share of `TRANS` |
+|---|---:|---:|---:|---:|---:|
+| truck | 333,879 | −281,589 | 52,658 | **0.19** | 67.8% |
+| rail | 79,793 | −68,590 | 9,666 | **0.14** | 16.5% |
+| pipeline | 50,119 | −49,660 | 536 | **0.01** | 11.9% |
+| water | 40,058 | −9,506 | 30,710 | 3.2 | 2.3% |
+| air | 255,374 | −6,225 | 270,780 | 43.5 | 1.5% |
+
+¹ percent error in the margin per 1% error in direct uses.
+
+So **residual for truck, rail and pipeline — 96.2% of `TRANS`** — and
+`|TRANS[2017]| × ton-miles[t] × price[t]` for air and water, where the margin is
+too small a slice of output for a residual to survive (a 1% error in air's
+direct uses throws its margin by 43%). Truck's `T016` of 52,658 matches the SUT
+use row, 39,330 + 11,700 + 1,629, to the dollar.
+
+⚠️ **Blocked on the final-use index, and not by a little.** `NIPA_FD` works for
+2017 only: `NIPA_FD_2018`–`2024` are stale copies carrying 2017 NIPA **line
+numbers**, which shift by vintage, so seven activity sets come back empty and the
+method drops most of its output — 314 rows and no PCE at all against 2017's
+1,322. That is #539-area work. The fallback is the raw `U20405` PCE lines as an
+*index* with the level anchored on 2017, which needs no bridge; note the clean
+lines exist for air, rail and water — the three that mostly do **not** use the
+residual — while truck's 11,700 of PCE arrives through the bridge with no 1:1
+line. At truck's leverage that is tolerable (a 10% index error moves truck margin
+1.9%, rail 1.4%, pipeline 0.01%), but the truck index will be a proxy.
+
+Three more things that follow, all of which shrink the work:
 
 - **No balancing step.** An earlier draft fitted `margin_2017[c,m]` per commodity
   *and mode* biproportionally, which needs a RAS. The mode dimension never
@@ -311,7 +411,7 @@ variation, and it cannot be justified from the source method.
 | Piece | Where | State |
 |---|---|---|
 | `BTS_FAF` extractor | **bedrock** `extract/bts/` | ✅ **Ported** (FAF5.7.1, 2017-2024). Emits tons, ton-miles and value |
-| `Transport_Margins_2017.yaml` | flowsa **`margins`** branch | Not yet ported. Selects `Unit: ton-miles` and redistributes the non-primary modes proportionally |
+| `Margins_Transport_<year>.yaml` | **bedrock** `transform/margins/` | ✅ **Ported**, 2017–2024, off flowsa's `Transport_Margins_2017.yaml`. Shares one `Margins_Transport_source.yaml`, so a year is eight lines |
 | `NAICS_Crosswalk_FAF_Mode_and_SCTG.csv` | **bedrock** `utils/mapping/` | ✅ **Ported**, two stale BEA codes fixed, re-keyed on FAF's published names |
 | `Crosswalk_SCTGtoBEA.csv`, mode→BEA crosswalks, `FAFData.R` | `cornerstone-data/stateior` | **Not needed** — the flowsa crosswalk already reaches 2017 detail. Its air mode code is also wrong (`48100`, five digits) |
 | CFS 2017 public use file | Census | **Ruled out** — 55% of FAF's ton-miles and *zero* coverage of crude petroleum, the largest `TRANS` commodity |
@@ -363,7 +463,7 @@ the same shape as [`compensation_disaggregation_plan.md`](compensation_disaggreg
 | phase | issue | depends on |
 |---|---|---|
 | 1 | ✅ [#610](https://github.com/cornerstone-data/bedrock/issues/610) 2017 rates and receiving sets — **built**, §Phase 1 below | — |
-| 2 | [#611](https://github.com/cornerstone-data/bedrock/issues/611) port the FAF transport chain | #601 (merged) |
+| 2 | ✅ [#611](https://github.com/cornerstone-data/bedrock/issues/611) port the FAF transport chain — **built**, §Phase 2 below | #601 (merged) |
 | 3 | [#612](https://github.com/cornerstone-data/bedrock/issues/612) AWTS/ARTS annual trade levels | — |
 | 4 | [#613](https://github.com/cornerstone-data/bedrock/issues/613) apply and derive `TRADE`/`TRANS` | #610–#612, **#570 (4a), #579 (4b), #580 (4d)** |
 | 5 | [#614](https://github.com/cornerstone-data/bedrock/issues/614) validate per commodity | #613 |
@@ -372,7 +472,10 @@ the same shape as [`compensation_disaggregation_plan.md`](compensation_disaggreg
 **Phase 1 — 2017 rates and the receiving sets.** Built; see §Phase 1 below for
 what it produced and what it settled.
 
-**Phase 2 — port the transport chain.** In progress on `faf_transport_margins`.
+**Phase 2 — port the transport chain.** ✅ **Built** on `faf_transport_margins`;
+[`nowcast_transport_margins.py`](../../transform/iot/nowcast_transport_margins.py)
+produces the annual `TRANS` column, 2017–2024, and reproduces the published 2017
+column to the dollar.
 
 ✅ **Done.** `BTS_FAF` is ported (FAF5.7.1, the 2017-base version, 2017-2024 in
 one archive) with two departures from the flowsa original: no `tabula`/PDF
@@ -386,17 +489,41 @@ re-keyed on the names FAF publishes.
 ✅ **Settled.** Ton-miles over tons, FAF over CFS, and the anchor-and-move
 construction rather than direct allocation — §Transportation.
 
-❌ **Remaining**, and less than the issue scoped. Per-SCTG ton-mile growth
-factors from the FBA, applied to the published 2017 `TRANS` per commodity; the
-annual control total; and the FBS method that gets ton-miles from the FBA to
-commodity groups. No balancing step, no interim-supply split, no
+✅ **Also built.** `Margins_Transport_<year>` for 2017–2024, in
+`bedrock/transform/margins/`, carrying FAF ton-miles by mode and commodity
+moved; the per-SCTG growth factors; and the gross-output control total —
+§The control total above. No balancing step, no interim-supply split, no
 `Crosswalk_SCTGtoBEA.csv` extension — the ported crosswalk already covers all
 258 `TRANS`-receiving commodities.
+
+⚠️ **The FBS cannot express BEA codes, so the growth factors do not read its
+sector column.** `SectorConsumedBy` resolves to NAICS (`31212`, `11111`), which
+is the [#546](https://github.com/cornerstone-data/bedrock/issues/546) limitation:
+an SCTG mapped to a 3-digit NAICS group would be spread across everything in it.
+The module therefore aggregates the FBS back over its sector columns to the SCTG
+that survives in `Flowable`, and joins to BEA detail on the crosswalk's `Note`
+column in Python. When #546 lands a BEA-code target the join moves into the FBS
+and the module reads sectors instead — the same "column swap, not new work" as
+open question 2. For the same reason flowsa's `move_SCB_to_flow` is deliberately
+not ported: it overwrites `Flowable` with the NAICS sector and would silently
+coarsen every growth factor.
+
+Two things the port needed that the issue did not scope. `faf_parse` filtered on
+a year that `call_all_years: True` never passes it — the generator parses once
+with `year=None` and slices each year out itself, so **no FBA could be generated
+at all** until that was fixed. And `BTS_FAF` was missing from `source_catalog.yaml`,
+without which any FBS reading it fails on `data_format`.
+
+Note the FBS method name determines its folder: `return_folder_path` walks the
+name backwards on `_`, so `Margins_Transport_<year>` requires
+`transform/margins/` — which is where Phase 3's `Margins_Trade_<year>` belongs
+too.
+
 ⚠️ The FBS method uses `attribute_on: [Flowable, PrimarySector]`, which needs the
 `retain_activity_columns` plumbing restored in
 [#601](https://github.com/cornerstone-data/bedrock/pull/601) — it will raise
 `KeyError: ['ActivityProducedBy']` without it. #601 is merged on `nowcast` and
-present.
+confirmed present: the proportional activity set attributes without error.
 
 **Phase 3 — trade levels, and optionally BEA's own allocation.** Port
 `Gross_Margins_2017.yaml` (AWTS/ARTS) as the annual wholesale and retail control

--- a/bedrock/analysis/nowcasting/margins_estimation_plan.md
+++ b/bedrock/analysis/nowcasting/margins_estimation_plan.md
@@ -231,7 +231,7 @@ use row, 39,330 + 11,700 + 1,629, to the dollar.
 
 ⚠️ **Blocked on the final-use index.** `NIPA_FD` produces PCE for 2017 only.
 `NIPA_FD_2018`–`2024` are an earlier generation of the method — all seven are
-byte-identical to each other at 352 lines against 2017's 521, and they **do not
+identical apart from the year line, at 352 lines against 2017's 521, and **do not
 contain the PCE activity sets at all**: no `FD_PCE`, none of its six variants,
 no `FD_IP_equipment`. The #539 work landed on the 2017 file and was never
 carried forward. So 2018 returns 314 rows and no PCE against 2017's 1,322.

--- a/bedrock/analysis/nowcasting/margins_estimation_plan.md
+++ b/bedrock/analysis/nowcasting/margins_estimation_plan.md
@@ -79,9 +79,63 @@ inverting that would swap coal and pharmaceuticals.
 
 **Reproducible, and improvable.** Use **FAF** rather than CFS: it is modelled to
 annual years where CFS is quinquennial, and it publishes **ton-miles**, a better
-freight-cost proxy than tons since cost scales with distance. Test tons vs
-ton-miles against the 2017 rates and keep the better fit — the 49%-to-0.04%
-spread makes that a sharp test.
+freight-cost proxy than tons since cost scales with distance.
+
+⚠️ **But volume does not predict the margin, and the fit test settles it against
+the method rather than for it.** Measured on 2017, allocating each mode's margin
+across commodities on that mode's share of the measure — BEA's own construction
+— and scored against the published `TRANS` at SCTG level:
+
+| source | measure | pearson | total abs share error |
+|---|---|---:|---:|
+| **FAF** | **ton-miles** | **0.370** | **68.2pp** |
+| FAF | value | 0.310 | 69.3pp |
+| FAF | tons | 0.099 | 92.9pp |
+| CFS PUF | ton-miles | 0.099 | 79.9pp |
+| CFS PUF | value | 0.122 | 76.7pp |
+| CFS PUF | tons | 0.011 | 99.8pp |
+
+Three findings, in order of how much they change the build:
+
+**Ton-miles beats tons decisively, so the manual's assumption is the weaker
+one.** Constant revenue per ton is a line-haul assumption, and `TRANS` is the
+delivered margin. The residuals say so plainly: weight-based allocation
+over-pays bulk (coal 35,609 predicted against 13,432 published, cereal grains
+34,666 against 13,604) and starves light high-value goods (furniture 2,502
+against 21,035, machinery 4,810 against 19,931, electronics 4,325 against
+16,049). Furniture really does cost roughly eight times more per ton-mile to
+deliver than coal.
+
+**The CFS public use file is disqualified on scope, not on measure.** It carries
+2,979 of FAF's 5,436 billion ton-miles, and the missing 45% is not spread
+evenly: **crude petroleum, the single largest `TRANS` commodity at 47,613, has
+zero CFS coverage**, live animals 8%, cereal grains 51%. CFS excludes farms,
+fisheries, most construction and the domestic legs of imports — which is exactly
+what FAF adds back. (This rules out the PUF for *our* use. BEA works from the
+confidential CFS microdata with its own adjustments, so it says nothing about
+BEA's method.)
+
+**So do not allocate margin *by* ton-miles — use ton-miles to *move* the 2017
+allocation.** This is the same anchor-and-move shape as everything else in this
+plan, and it makes the weak cross-sectional fit irrelevant rather than
+blocking:
+
+```
+margin_2017[c,m]  biproportional fit, seeded on FAF ton-miles, to the two
+                  published margins: Σ_m = TRANS[c] per commodity, Σ_c = the
+                  mode's own negative TRANS (truck -281,589, rail -68,590,
+                  water -9,506, air -6,225, pipeline -49,660)
+rate[c,m]       = margin_2017[c,m] ÷ ton-miles_2017[c,m]
+TRANS_year[c]   = Σ_m rate[c,m] × ton-miles_year[c,m], controlled to the annual
+                  total
+```
+
+The fit is exact in 2017 by construction, so BEA's own commodity allocation is
+inherited rather than approximated, and the commodity-specific cost structure a
+volume weighting discards is retained in `rate[c,m]`. FAF is then used only for
+what it is good at — annual movement. The seed is known at 42 SCTG groups
+against 258 commodities, so within an SCTG every commodity is assumed to share
+the same mode mix; that is the one assumption the construction adds.
 
 ### Wholesale
 
@@ -220,9 +274,11 @@ variation, and it cannot be justified from the source method.
 
 | Piece | Where | State |
 |---|---|---|
-| `BTS_FAF` extractor + `Transport_Margins_2017.yaml` | flowsa **`margins`** branch | Built. Already selects `Unit: ton-miles` and redistributes the non-primary modes proportionally |
-| `NAICS_Crosswalk_FAF_Mode_and_SCTG.csv` | flowsa `margins` | Built |
-| `Crosswalk_SCTGtoBEA.csv`, mode→BEA crosswalks, `FAFData.R` | `cornerstone-data/stateior` | Built, **R**, and SCTG maps to **BEA 2012 detail** — no 2017 detail column |
+| `BTS_FAF` extractor | **bedrock** `extract/bts/` | ✅ **Ported** (FAF5.7.1, 2017-2024). Emits tons, ton-miles and value |
+| `Transport_Margins_2017.yaml` | flowsa **`margins`** branch | Not yet ported. Selects `Unit: ton-miles` and redistributes the non-primary modes proportionally |
+| `NAICS_Crosswalk_FAF_Mode_and_SCTG.csv` | **bedrock** `utils/mapping/` | ✅ **Ported**, two stale BEA codes fixed, re-keyed on FAF's published names |
+| `Crosswalk_SCTGtoBEA.csv`, mode→BEA crosswalks, `FAFData.R` | `cornerstone-data/stateior` | **Not needed** — the flowsa crosswalk already reaches 2017 detail. Its air mode code is also wrong (`48100`, five digits) |
+| CFS 2017 public use file | Census | **Ruled out** — 55% of FAF's ton-miles and *zero* coverage of crude petroleum, the largest `TRANS` commodity |
 | `Gross_Margins_2017.yaml` (Census AWTS + ARTS) | flowsa `margins` | Built. Annual **2012–2022**. Gives margin **by trade sector** |
 | PCE / PEQ bridges | bedrock, `BEA_PCEBridge` | Same margin columns as the Margins table, but **benchmark years only** — workbook sheets are 2007, 2012, 2017 |
 | `Census_EC_PxI` — Economic Census, Products by Industry | flowsa `margins` | Built, **2017**. This *is* BEA's product-line-by-KB input |
@@ -280,13 +336,29 @@ the same shape as [`compensation_disaggregation_plan.md`](compensation_disaggreg
 **Phase 1 — 2017 rates and the receiving sets.** Built; see §Phase 1 below for
 what it produced and what it settled.
 
-**Phase 2 — port the transport chain.** flowsa `margins` `BTS_FAF` +
-`Transport_Margins_2017.yaml`. Extend `Crosswalk_SCTGtoBEA.csv` to 2017 detail.
-Decide tons vs ton-miles on the 2017 fit.
-⚠️ The method uses `attribute_on: [Flowable, PrimarySector]`, which needs the
+**Phase 2 — port the transport chain.** In progress on `faf_transport_margins`.
+
+✅ **Done.** `BTS_FAF` is ported (FAF5.7.1, the 2017-base version, 2017-2024 in
+one archive) with two departures from the flowsa original: no `tabula`/PDF
+scrape, since the SCTG and mode code tables ship inside the archive as
+`FAF5_metadata.xlsx`; and **all trade types**, since FAF's `dms_*` fields already
+describe only the domestic leg, so the `trade_type == 1` filter was discarding
+20% of ton-miles concentrated in imports rather than avoiding a double count.
+The mode and SCTG crosswalk is ported with its two stale BEA codes fixed and
+re-keyed on the names FAF publishes.
+
+✅ **Settled.** Ton-miles over tons, FAF over CFS, and the anchor-and-move
+construction rather than direct allocation — §Transportation.
+
+❌ **Remaining.** The biproportional fit of `margin_2017[c,m]` and the
+`rate[c,m]` it yields; the annual control totals; and the FBS method itself.
+`Crosswalk_SCTGtoBEA.csv` no longer needs extending — the ported crosswalk
+covers all 258 `TRANS`-receiving commodities.
+⚠️ The FBS method uses `attribute_on: [Flowable, PrimarySector]`, which needs the
 `retain_activity_columns` plumbing restored in
 [#601](https://github.com/cornerstone-data/bedrock/pull/601) — it will raise
-`KeyError: ['ActivityProducedBy']` without it.
+`KeyError: ['ActivityProducedBy']` without it. #601 is merged on `nowcast` and
+present.
 
 **Phase 3 — trade levels, and optionally BEA's own allocation.** Port
 `Gross_Margins_2017.yaml` (AWTS/ARTS) as the annual wholesale and retail control
@@ -560,10 +632,20 @@ Three consequences:
 
 ## Open questions
 
-1. **Tons or ton-miles** for the transport allocation — decide on the 2017 fit.
-2. **Extending `Crosswalk_SCTGtoBEA.csv` to BEA 2017 detail** — it currently
-   carries 2012 detail and 2017 *summary* only. This is the real porting work
-   on the transport chain, not the SCTG mapping itself.
+1. ~~**Tons or ton-miles** for the transport allocation~~ — **settled on the 2017
+   fit** (§Transportation): ton-miles, by a wide margin over tons, and FAF over
+   the CFS public use file, which has zero coverage of the largest `TRANS`
+   commodity. But neither measure *predicts* the margin, so ton-miles moves the
+   2017 allocation forward rather than generating it — the rate is fitted on the
+   benchmark and carried, as everywhere else in this plan.
+2. ~~**Extending `Crosswalk_SCTGtoBEA.csv` to BEA 2017 detail**~~ — **moot.**
+   That was the stateior route; the flowsa crosswalk ported in Phase 2 already
+   carried a BEA 2017 detail code on every SCTG row, and with two stale codes
+   fixed it covers all 258 `TRANS`-receiving commodities and 100% of `TRANS`
+   value. Note the codes sit in a `Note` column that the mapping machinery does
+   not read — it joins on `Sector`, which is NAICS — so they become operative
+   only when [#546](https://github.com/cornerstone-data/bedrock/issues/546)
+   lands a BEA-code target schema. That is a column swap, not new work.
 3. **Build the NAPCS → I-O commodity concordance?** Only needed to re-run BEA's
    actual method on 2022 product lines rather than carry 2017-anchored rates.
    Everything upstream of it now exists; this is the sole missing link.

--- a/bedrock/analysis/nowcasting/margins_estimation_plan.md
+++ b/bedrock/analysis/nowcasting/margins_estimation_plan.md
@@ -229,11 +229,17 @@ too small a slice of output for a residual to survive (a 1% error in air's
 direct uses throws its margin by 43%). Truck's `T016` of 52,658 matches the SUT
 use row, 39,330 + 11,700 + 1,629, to the dollar.
 
-⚠️ **Blocked on the final-use index, and not by a little.** `NIPA_FD` works for
-2017 only: `NIPA_FD_2018`–`2024` are stale copies carrying 2017 NIPA **line
-numbers**, which shift by vintage, so seven activity sets come back empty and the
-method drops most of its output — 314 rows and no PCE at all against 2017's
-1,322. That is #539-area work. The fallback is the raw `U20405` PCE lines as an
+⚠️ **Blocked on the final-use index.** `NIPA_FD` produces PCE for 2017 only.
+`NIPA_FD_2018`–`2024` are an earlier generation of the method — all seven are
+byte-identical to each other at 352 lines against 2017's 521, and they **do not
+contain the PCE activity sets at all**: no `FD_PCE`, none of its six variants,
+no `FD_IP_equipment`. The #539 work landed on the 2017 file and was never
+carried forward. So 2018 returns 314 rows and no PCE against 2017's 1,322.
+(Seven `FD_Gov_*` and `FD_Structures*` sets also come back empty on 2018 for a
+separate reason, NIPA line numbers shifting by vintage.) Carrying the 2017
+activity sets forward is the fix, and it is worth doing on its own account —
+without it the nowcast's Step 1 final demand is a 2017-only object. The fallback
+here is the raw `U20405` PCE lines as an
 *index* with the level anchored on 2017, which needs no bridge; note the clean
 lines exist for air, rail and water — the three that mostly do **not** use the
 residual — while truck's 11,700 of PCE arrives through the bridge with no 1:1

--- a/bedrock/analysis/nowcasting/margins_estimation_plan.md
+++ b/bedrock/analysis/nowcasting/margins_estimation_plan.md
@@ -149,27 +149,67 @@ while the nominal level reaches 1.483. Nearly all of the movement in the
 transport margin over the nowcast window is repricing, not more freight.
 
 **Built** in
-[`nowcast_transport_margins.py`](../../transform/iot/nowcast_transport_margins.py)
-as the transport industries' own gross output, held at each mode's 2017 ratio of
-margin given up to output:
+[`nowcast_transport_margins.py`](../../transform/iot/nowcast_transport_margins.py),
+and it is **not one construction but three, dispatched per mode** by
+`MODE_CONTROL`. A single treatment cannot serve all five, because the modes
+differ in how much of their output is margin at all — 0.026 for air against
+0.862 for rail:
+
+| mode | share of `TRANS` | 2017 margin ÷ output | leverage¹ | treatment |
+|---|---:|---:|---:|---|
+| truck | 67.8% | 0.767 | 0.30 | `residual` |
+| rail | 16.5% | 0.862 | 0.16 | `residual` |
+| pipeline | 11.9% | 1.033 | — | `output_ratio` |
+| water | 2.3% | 0.173 | 4.8 | `freight_volume` |
+| air | 1.5% | 0.026 | 36.9 | `freight_volume` |
+
+¹ % error in the margin per 1% error in direct uses — what decides whether a
+residual is usable.
 
 ```
-control[t]   = Σ_m GO_m[t] × (given_up_m[2017] ÷ GO_m[2017]),  rescaled so control[2017] = TRANS_2017
-TRANS[c, t]  = shape[c, t] × control[t] ÷ Σ_c shape[c, t]
+residual[m,t]        = GO_m[t] − direct_uses_m[2017] × pce_index_m[t]
+freight_volume[m,t]  = given_up_m[2017] × ton_miles_m[t] × price_m[t]     (both relative to 2017)
+output_ratio[m,t]    = GO_m[t] × (given_up_m ÷ GO_m)[2017]
+control[t]           = Σ_m …,  rescaled so control[2017] = TRANS_2017
+TRANS[c,t]           = shape[c,t] × control[t] ÷ Σ_c shape[c,t]
 ```
 
-Two reasons for that source over a freight price index. It is **the same number
-the negative side of the column carries** — `Σ_m given_up_m` *is* `−TRANS`, so
-the two sides cannot drift apart — and it is per mode, so it reprices truck
-freight with truck output rather than with an economy-wide deflator. The
-rescaling is 0.24%: the 2017 composite is 415,548 against 414,559 received, the
-gap being the negative `F03000` rows on the receiving side.
+Every treatment is an **identity in 2017**, so the choice changes movement only.
+The rescaling is 0.24%: the 2017 composite is 415,548 against 414,559 received,
+the gap being the negative `F03000` rows on the receiving side.
+
+**Why each.** The *residual* is what replaced a frozen give-up ratio for the two
+modes that are 84.3% of the column: their margin is most of their output, so
+direct uses are the small term and an error in them barely moves the answer. It
+lifts the pair 0.8% to 5.1% above the frozen ratio. *Freight volume × price* is
+forced for air and water — a residual there **goes negative** (air from 2019,
+reaching −121,719 million by 2024, because air PCE grows 1.96x against output's
+1.393x), and a frozen ratio makes air *freight* margin follow air *passenger*
+output, which would cut it 46% in 2020 when air freight ton-miles were 1.010.
+*Output ratio* is all that remains for pipeline: its output is less than the
+margin it gives up, so no residual exists, and it has no PCE to move direct uses
+by.
+
+⚠️ **The choice is the largest open uncertainty in this column.** All four
+constructions agree exactly in 2017 and spread **11.8% by 2022**:
+
+| $M | 2018 | 2020 | 2022 | 2024 |
+|---|---:|---:|---:|---:|
+| `freight_volume` (FAF ton-miles × price) | 448,449 | 435,773 | 575,587 | 568,801 |
+| `output_ratio` (gross output × frozen ratio) | 456,831 | 452,385 | 616,115 | 581,522 |
+| `residual` (all five modes — diagnostic only) | 454,310 | 493,585 | 584,554 | 446,921 |
+| **`mixed`** (per-mode, the default) | 458,567 | 465,486 | **643,443** | 594,847 |
+
+So the method is a **parameter**, not a decision baked in —
+`control_total_components(years, method=…)` and `control_total_comparison(years)`
+— and [#620](https://github.com/cornerstone-data/bedrock/issues/620) settles it
+against external sources rather than against itself.
 
 | | 2018 | 2019 | 2020 | 2021 | 2022 | 2023 | 2024 |
 |---|---:|---:|---:|---:|---:|---:|---:|
 | volume (ton-miles) | 1.066 | 1.052 | 0.997 | 1.025 | 1.036 | 1.029 | 1.032 |
-| level (control) | 1.099 | 1.127 | 1.089 | 1.266 | 1.483 | 1.393 | 1.399 |
-| **repricing** | 1.031 | 1.072 | 1.092 | 1.236 | **1.431** | 1.354 | 1.356 |
+| level (control, mixed) | 1.104 | 1.129 | 1.121 | 1.312 | 1.548 | 1.436 | 1.432 |
+| **repricing** | 1.036 | 1.073 | 1.124 | 1.280 | **1.494** | 1.396 | 1.388 |
 
 Truck is 68% of `TRANS` and its output runs 1.572x its 2017 level in 2022 — the
 freight-rate surge, which the volume index cannot see at all.
@@ -182,10 +222,16 @@ Three limitations, recorded rather than corrected:
   more than 25% in that one year, and the `TRANS`-weighted mean step is 1.124
   against the aggregate's 1.019. The control total absorbs the level, so what
   survives is a shape shift.
-- **Air and rail output are not freight-only.** Air's 2017 give-up ratio is
-  0.026 against rail's 0.862 — the rest of air output is passengers — so air
-  freight margin follows passenger air. Air is 1.5% of `TRANS`; truck, the mode
-  that matters, is close to freight-pure.
+- **The residual freezes the intermediate:final split at 2017.** Direct uses
+  move wholly by a *final*-use index, so intermediate direct purchases of
+  freight are assumed to move with household ones. They are 46% of truck's
+  direct uses and 62% of rail's. At those modes' leverage a 10% error in the
+  frozen part moves truck margin 1.4% and rail 1.0%. Taking them from a nowcast
+  Use matrix instead would be circular — Step 6b needs these margins to build
+  it.
+- **The air and water price index is the whole industry's**, passengers
+  included. Much less contaminated than their *level* was under a frozen ratio,
+  but not clean.
 - **Pipeline gives up 1.033 of its own gross output.** Carried as an index, but
   it means pipeline margin tracks the crude-price component of pipeline output.
   `211000` crude petroleum is on that account the largest single movement in the
@@ -196,90 +242,37 @@ which give **for-hire** output by mode, and Freight Facts and Figures — is
 [#620](https://github.com/cornerstone-data/bedrock/issues/620), medium priority.
 `BTS_TSA` is already half-built as an FBA (2012–2019, NAICS 2012).
 
-### ⚠️ Agreed refinement, designed and not yet built
+### ✅ Built — and one framework inconsistency to settle
 
-The frozen give-up ratio is the weak point above, and there is a better
-construction that removes it for most of the column. **Decided 2026-08-09; the
-code still carries the ratio version.**
+The refinement above is **implemented**; see the table of treatments. Two notes
+on how the built version differs from the design as first written.
 
-The Supply table closes the identity exactly — `T016`, all direct non-margin
-uses, equals `T013 + TRANS + TOP + SUB` — so the margin *is* a residual:
+**The leverage figures moved, because the denominator did.** The design measured
+direct uses as the Supply table's `T016` against commodity output `T013`; the
+build measures them as `BEA_Detail_GrossOutput_IO` less the published give-up.
+Those are not the same object, and for truck they differ by a third:
 
-```
-direct_uses[t] = T016[2017] × final_use_index[t]      # intermediate:final frozen at 2017
-margin[t]      = (T013 + TOP + SUB)[t] − direct_uses[t]
-```
+| truck, 2017, $M | design (`T013`, commodity) | build (`GO`, industry) |
+|---|---:|---:|
+| output | 333,879 | 367,154 |
+| direct uses | 52,658 | 85,568 |
+| leverage | 0.19 | 0.30 |
 
-Whether that residual is usable is entirely a question of conditioning, and it
-splits the modes cleanly:
+⚠️ **`BEA_Detail_GrossOutput_IO` is *industry* gross output; the margin given up
+is a *commodity* quantity.** Mixing them is a framework inconsistency, and the
+33,275 gap for truck is secondary production — trucking output produced by
+industries other than NAICS 484, and vice versa. The conclusion is unaffected
+(the residual is well conditioned for truck and rail on either measure, and
+hopeless for air on both), but the build should move to commodity output `T013`
+so the residual is one framework throughout. That is 4a's object, so it is
+natural to take once 4a lands rather than to duplicate here.
 
-| 2017, $M | `T013` | `TRANS` | `T016` direct uses | leverage¹ | share of `TRANS` |
-|---|---:|---:|---:|---:|---:|
-| truck | 333,879 | −281,589 | 52,658 | **0.19** | 67.8% |
-| rail | 79,793 | −68,590 | 9,666 | **0.14** | 16.5% |
-| pipeline | 50,119 | −49,660 | 536 | **0.01** | 11.9% |
-| water | 40,058 | −9,506 | 30,710 | 3.2 | 2.3% |
-| air | 255,374 | −6,225 | 270,780 | 43.5 | 1.5% |
-
-¹ percent error in the margin per 1% error in direct uses.
-
-So **residual for truck, rail and pipeline — 96.2% of `TRANS`** — and
-`|TRANS[2017]| × ton-miles[t] × price[t]` for air and water, where the margin is
-too small a slice of output for a residual to survive (a 1% error in air's
-direct uses throws its margin by 43%). Truck's `T016` of 52,658 matches the SUT
-use row, 39,330 + 11,700 + 1,629, to the dollar.
-
-⚠️ **Blocked on the final-use index —
-[#621](https://github.com/cornerstone-data/bedrock/issues/621).** `NIPA_FD`
-produces PCE for 2017 only.
-`NIPA_FD_2018`–`2024` are an earlier generation of the method — all seven are
-identical apart from the year line, at 352 lines against 2017's 521, and **do not
-contain the PCE activity sets at all**: no `FD_PCE`, none of its six variants,
-no `FD_IP_equipment`. The #539 work landed on the 2017 file and was never
-carried forward. So 2018 returns 314 rows and no PCE against 2017's 1,322.
-(Seven `FD_Gov_*` and `FD_Structures*` sets also come back empty on 2018 for a
-separate reason, NIPA line numbers shifting by vintage.) Carrying the 2017
-activity sets forward is the fix, and it is worth doing on its own account —
-without it the nowcast's Step 1 final demand is a 2017-only object. The fallback
-here is the raw `U20405` PCE lines as an
-*index* with the level anchored on 2017, which needs no bridge; note the clean
-lines exist for air, rail and water — the three that mostly do **not** use the
-residual — while truck's 11,700 of PCE arrives through the bridge with no 1:1
-line. At truck's leverage that is tolerable (a 10% index error moves truck margin
-1.9%, rail 1.4%, pipeline 0.01%), but the truck index will be a proxy.
-
-Three more things that follow, all of which shrink the work:
-
-- **No balancing step.** An earlier draft fitted `margin_2017[c,m]` per commodity
-  *and mode* biproportionally, which needs a RAS. The mode dimension never
-  appears in the output — only in the derivation — so it can go. The transport
-  column is an **input to** Step 5's RAS, not a product of one, and the choice of
-  RAS implementation reverts to [#588](https://github.com/cornerstone-data/bedrock/issues/588)
-  where it belongs.
-- **No SCTG → commodity allocation, and so no 4a/4b dependency here.** Fixed
-  within-SCTG shares cancel, so the interim-supply weighting BEA uses to split a
-  product line across commodities is not needed for *this* column. It is still
-  needed for the trade margins.
-- **What is given up is modal-shift sensitivity.** A per-commodity rate cannot
-  see freight moving from rail to truck, which raises cost per ton-mile. That is
-  second order, and the mode-level form is the natural refinement to revisit once
-  a balancer exists — the derivation is recorded above for that reason.
-
-📬 **Asked of BEA, 2026-08-09, reply outstanding.** Whether the weighting is
-tons or has moved to ton-miles or a commodity-varying revenue rate; whether the
-distribution runs within each mode separately; how local delivery and
-small-shipment cost are handled; and whether the commodity allocation still
-comes from CFS directly or FAF now plays a part. **Nothing is blocked on the
-answer** — the construction above anchors on the published `TRANS` rather than
-reconstructing it, so it stands whichever way the weighting question falls.
-What each answer would change: *tons confirmed* leaves ton-miles a deliberate,
-documented deviation affecting only the mode-level refinement; *a
-commodity-varying revenue rate* vindicates the anchor directly, since that
-variation is what the 2017 implied rates preserve and a volume weighting
-discards; *local delivery included in the margin* explains the 5-8x residual on
-light high-value goods and says whether modal shift is the right second-order
-correction; *FAF used as an input* would mean BEA moves with the same annual
-source we do.
+**Pipeline lost the residual.** The design put it on the residual at leverage
+0.01. On the build's measure its output is *less* than the margin it gives up —
+48,072 against 49,640 — so the residual is negative and it falls back to
+`output_ratio`. Under commodity output (50,119 against 49,660) it is positive
+but tiny, so the residual would be near-degenerate either way; this is the
+second reason to settle the framework question.
 
 ### Wholesale
 

--- a/bedrock/analysis/nowcasting/margins_estimation_plan.md
+++ b/bedrock/analysis/nowcasting/margins_estimation_plan.md
@@ -121,21 +121,41 @@ plan, and it makes the weak cross-sectional fit irrelevant rather than
 blocking:
 
 ```
-margin_2017[c,m]  biproportional fit, seeded on FAF ton-miles, to the two
-                  published margins: Σ_m = TRANS[c] per commodity, Σ_c = the
-                  mode's own negative TRANS (truck -281,589, rail -68,590,
-                  water -9,506, air -6,225, pipeline -49,660)
-rate[c,m]       = margin_2017[c,m] ÷ ton-miles_2017[c,m]
-TRANS_year[c]   = Σ_m rate[c,m] × ton-miles_year[c,m], controlled to the annual
-                  total
+rate[c]       = TRANS_2017[c] ÷ ton-miles_2017[c]
+TRANS_year[c] = rate[c] × ton-miles_year[c], controlled to the annual total
 ```
 
-The fit is exact in 2017 by construction, so BEA's own commodity allocation is
-inherited rather than approximated, and the commodity-specific cost structure a
-volume weighting discards is retained in `rate[c,m]`. FAF is then used only for
-what it is good at — annual movement. The seed is known at 42 SCTG groups
-against 258 commodities, so within an SCTG every commodity is assumed to share
-the same mode mix; that is the one assumption the construction adds.
+**And it reduces further than it looks.** Ton-miles are published per SCTG, not
+per commodity, so `ton-miles[c] = share[c] × ton-miles[sctg(c)]`. Hold `share[c]`
+constant — there is no annual source that would move it — and it cancels:
+
+```
+TRANS_year[c] = TRANS_2017[c] × ton-miles_year[sctg] ÷ ton-miles_2017[sctg]
+```
+
+So the whole construction is **each commodity's published 2017 `TRANS`, moved by
+the ton-mile growth of its SCTG group, controlled to the annual total**. Exact in
+2017 by construction, so BEA's own commodity allocation is inherited rather than
+approximated, and the commodity cost structure a volume weighting discards is
+kept — furniture stays eight times dearer per ton-mile than coal because the
+2017 table says so, not because a model inferred it.
+
+Three things that follow, all of which shrink the work:
+
+- **No balancing step.** An earlier draft fitted `margin_2017[c,m]` per commodity
+  *and mode* biproportionally, which needs a RAS. The mode dimension never
+  appears in the output — only in the derivation — so it can go. The transport
+  column is an **input to** Step 5's RAS, not a product of one, and the choice of
+  RAS implementation reverts to [#588](https://github.com/cornerstone-data/bedrock/issues/588)
+  where it belongs.
+- **No SCTG → commodity allocation, and so no 4a/4b dependency here.** Fixed
+  within-SCTG shares cancel, so the interim-supply weighting BEA uses to split a
+  product line across commodities is not needed for *this* column. It is still
+  needed for the trade margins.
+- **What is given up is modal-shift sensitivity.** A per-commodity rate cannot
+  see freight moving from rail to truck, which raises cost per ton-mile. That is
+  second order, and the mode-level form is the natural refinement to revisit once
+  a balancer exists — the derivation is recorded above for that reason.
 
 ### Wholesale
 
@@ -350,10 +370,12 @@ re-keyed on the names FAF publishes.
 ✅ **Settled.** Ton-miles over tons, FAF over CFS, and the anchor-and-move
 construction rather than direct allocation — §Transportation.
 
-❌ **Remaining.** The biproportional fit of `margin_2017[c,m]` and the
-`rate[c,m]` it yields; the annual control totals; and the FBS method itself.
-`Crosswalk_SCTGtoBEA.csv` no longer needs extending — the ported crosswalk
-covers all 258 `TRANS`-receiving commodities.
+❌ **Remaining**, and less than the issue scoped. Per-SCTG ton-mile growth
+factors from the FBA, applied to the published 2017 `TRANS` per commodity; the
+annual control total; and the FBS method that gets ton-miles from the FBA to
+commodity groups. No balancing step, no interim-supply split, no
+`Crosswalk_SCTGtoBEA.csv` extension — the ported crosswalk already covers all
+258 `TRANS`-receiving commodities.
 ⚠️ The FBS method uses `attribute_on: [Flowable, PrimarySector]`, which needs the
 `retain_activity_columns` plumbing restored in
 [#601](https://github.com/cornerstone-data/bedrock/pull/601) — it will raise
@@ -636,8 +658,9 @@ Three consequences:
    fit** (§Transportation): ton-miles, by a wide margin over tons, and FAF over
    the CFS public use file, which has zero coverage of the largest `TRANS`
    commodity. But neither measure *predicts* the margin, so ton-miles moves the
-   2017 allocation forward rather than generating it — the rate is fitted on the
-   benchmark and carried, as everywhere else in this plan.
+   2017 allocation forward rather than generating it: each commodity's published
+   2017 `TRANS` grows with its SCTG group's ton-miles, controlled to the annual
+   total. No balancing step and no interim-supply split are involved.
 2. ~~**Extending `Crosswalk_SCTGtoBEA.csv` to BEA 2017 detail**~~ — **moot.**
    That was the stateior route; the flowsa crosswalk ported in Phase 2 already
    carried a BEA 2017 detail code on every SCTG row, and with two stale codes

--- a/bedrock/analysis/nowcasting/margins_estimation_plan.md
+++ b/bedrock/analysis/nowcasting/margins_estimation_plan.md
@@ -267,6 +267,36 @@ hopeless for air on both), but the build should move to commodity output `T013`
 so the residual is one framework throughout. That is 4a's object, so it is
 natural to take once 4a lands rather than to duplicate here.
 
+**The industry price index needs no commodity conversion — measured.** The
+price index is an *industry* series (`UGO304-A`), and converting it to a
+commodity one needs the market-share matrix, which exists annually only at
+summary level and not at all at detail. That constraint is real, and it does not
+bind here: the transport block of the 2017 Make table is near-diagonal, so the
+two indices are the same series to within a rounding error.
+
+| own-industry share of the commodity | before redef | after redef |
+|---|---:|---:|
+| air | 0.9999 | 1.0000 |
+| rail | 0.9984 | 0.9984 |
+| truck | 0.9943 | 0.9987 |
+| water | 0.9855 | 0.9921 |
+| pipeline | 0.9480 | 1.0000 |
+
+Holding the 2017 mix fixed and re-weighting the industry indices moves them by at
+most **0.696%** anywhere (pipeline, before redefinitions) and by 0.055% for
+truck, 0.000% for air and rail. After redefinitions the largest deviation
+anywhere is 0.059%. Since the price index enters only the `freight_volume`
+treatment — air and water — the effect on the built control total is **0.000%
+and 0.084%**. So the industry index is used directly, and the missing annual
+commodity mix costs nothing measurable *for these five commodities*. It would not
+generalise: this holds because freight commodities are produced almost entirely
+by their own industry, which is not true of, say, the trade commodities.
+
+⚠️ The figures above are **before redefinitions**, matching the margins anchor.
+Redefinition makes the block *more* diagonal (it moves secondary production onto
+the primary producer), so the before-redefinitions figure is the conservative one
+and the choice cannot be hiding a larger error.
+
 **Pipeline lost the residual.** The design put it on the residual at leverage
 0.01. On the build's measure its output is *less* than the margin it gives up —
 48,072 against 49,640 — so the residual is negative and it falls back to

--- a/bedrock/analysis/nowcasting/margins_estimation_plan.md
+++ b/bedrock/analysis/nowcasting/margins_estimation_plan.md
@@ -157,6 +157,22 @@ Three things that follow, all of which shrink the work:
   second order, and the mode-level form is the natural refinement to revisit once
   a balancer exists — the derivation is recorded above for that reason.
 
+📬 **Asked of BEA, 2026-08-09, reply outstanding.** Whether the weighting is
+tons or has moved to ton-miles or a commodity-varying revenue rate; whether the
+distribution runs within each mode separately; how local delivery and
+small-shipment cost are handled; and whether the commodity allocation still
+comes from CFS directly or FAF now plays a part. **Nothing is blocked on the
+answer** — the construction above anchors on the published `TRANS` rather than
+reconstructing it, so it stands whichever way the weighting question falls.
+What each answer would change: *tons confirmed* leaves ton-miles a deliberate,
+documented deviation affecting only the mode-level refinement; *a
+commodity-varying revenue rate* vindicates the anchor directly, since that
+variation is what the 2017 implied rates preserve and a volume weighting
+discards; *local delivery included in the margin* explains the 5-8x residual on
+light high-value goods and says whether modal shift is the right second-order
+correction; *FAF used as an input* would mean BEA moves with the same annual
+source we do.
+
 ### Wholesale
 
 Economic Census **product-line sales by kind of business (KB)**; the margin rate

--- a/bedrock/analysis/nowcasting/margins_estimation_plan.md
+++ b/bedrock/analysis/nowcasting/margins_estimation_plan.md
@@ -229,7 +229,9 @@ too small a slice of output for a residual to survive (a 1% error in air's
 direct uses throws its margin by 43%). Truck's `T016` of 52,658 matches the SUT
 use row, 39,330 + 11,700 + 1,629, to the dollar.
 
-⚠️ **Blocked on the final-use index.** `NIPA_FD` produces PCE for 2017 only.
+⚠️ **Blocked on the final-use index —
+[#621](https://github.com/cornerstone-data/bedrock/issues/621).** `NIPA_FD`
+produces PCE for 2017 only.
 `NIPA_FD_2018`–`2024` are an earlier generation of the method — all seven are
 identical apart from the year line, at 352 lines against 2017's 521, and **do not
 contain the PCE activity sets at all**: no `FD_PCE`, none of its six variants,

--- a/bedrock/extract/bts/BTS_FAF.py
+++ b/bedrock/extract/bts/BTS_FAF.py
@@ -68,11 +68,23 @@ FAF_ZIP = 'FAF5.7.1_State.zip'
 _SCTG_SHEET = 'Commodity (SCTG2)'
 _MODE_SHEET = 'Mode'
 
-#: ``trade_type`` 1. Imports and exports are excluded because the margin wanted
-#: here is the domestic leg only: the foreign-port-to-domestic-port leg of an
-#: import is already inside the Supply table's ``MCIF``, so counting it again as
-#: transport margin would double it.
-_DOMESTIC_TRADE_TYPE = 1
+#: **All** trade types are kept, which is a deliberate departure from the flowsa
+#: version's ``trade_type == 1`` filter.
+#:
+#: The concern that filter answers is real - the foreign-port-to-domestic-port
+#: leg of an import is already inside the Supply table's ``MCIF``, and counting
+#: it again as transport margin would double it. But FAF does not report that
+#: leg here: on an import record the ``dms_mode``, ``dms_orig``/``dms_dest`` and
+#: ton-mile fields all describe the **domestic** portion of the move, from the
+#: entry region onward. That leg is exactly the domestic-port-to-user movement
+#: BEA counts in ``TRANS``, so dropping it discards margin-bearing freight
+#: rather than avoiding a double count.
+#:
+#: It is 20% of ton-miles, and it is not spread evenly: excluding it is what
+#: made the 2017 fit worst on precisely the import-heavy commodities. Keeping it
+#: lifts the ton-mile fit against published ``TRANS`` from 0.274 to 0.370 and
+#: cuts the share error from 75.7 to 68.2 percentage points.
+_KEEP_ALL_TRADE_TYPES = True
 
 #: Published unit -> (bedrock unit, factor). FAF reports tons in thousands, and
 #: dollars and ton-miles in millions.
@@ -170,16 +182,13 @@ def _read_faf_zip(zip_path: str, config: dict[str, Any]) -> list[pd.DataFrame]:
         with zip_file.open(data_file) as handle:
             raw = pd.read_csv(
                 handle,
-                usecols=[*keys, 'trade_type', *measures],
-                dtype={'sctg2': int, 'dms_mode': int, 'trade_type': int},
+                usecols=[*keys, *measures],
+                dtype={'sctg2': int, 'dms_mode': int},
             )
 
-    totals = (
-        raw.loc[raw['trade_type'] == _DOMESTIC_TRADE_TYPE]
-        .drop(columns='trade_type')
-        .groupby(keys, as_index=False)
-        .sum()
-    )
+    # every trade type, summed over origin-destination pairs - see
+    # _KEEP_ALL_TRADE_TYPES on why the import and export legs belong here
+    totals = raw.groupby(keys, as_index=False).sum()
 
     long = totals.melt(id_vars=keys, var_name='measure', value_name='FlowAmount')
     long['Unit'] = long['measure'].map(lambda m: measures[m][0])

--- a/bedrock/extract/bts/BTS_FAF.py
+++ b/bedrock/extract/bts/BTS_FAF.py
@@ -252,11 +252,17 @@ def faf_load_gcs(**kwargs: Any) -> list[pd.DataFrame]:
 
 
 def faf_parse(
-    *, df_list: list[pd.DataFrame], source: str, year: int, **_: Any
+    *, df_list: list[pd.DataFrame], source: str, year: int | None, **_: Any
 ) -> pd.DataFrame:
-    """Select *year* out of the archive-wide frame and complete the FBA columns."""
+    """Complete the FBA columns on the archive-wide frame.
+
+    ``call_all_years: True`` means the generator parses once with ``year=None``
+    and slices each year out of the result itself, so the whole frame is
+    returned in that case rather than one year of it.
+    """
     df = pd.concat(df_list, ignore_index=True)
-    df = df.loc[df['Year'] == str(year)].copy()
+    if year is not None:
+        df = df.loc[df['Year'] == str(year)].copy()
     if df.empty:
         raise ValueError(f'{source} has no rows for {year}')
     return (
@@ -287,6 +293,10 @@ def move_flow_to_ACB(fba: pd.DataFrame, **_: Any) -> pd.DataFrame:
     return fba.assign(ActivityConsumedBy=fba['FlowName'])
 
 
-def move_SCB_to_flow(fbs: pd.DataFrame, **_: Any) -> pd.DataFrame:
-    """``clean_fbs``: replace the SCTG flow name with the mapped commodity."""
-    return fbs.assign(Flowable=fbs['SectorConsumedBy'], SectorConsumedBy=None)
+# The flowsa original had a companion ``move_SCB_to_flow`` here, run as
+# ``clean_fbs``, which overwrote ``Flowable`` with the mapped sector and blanked
+# ``SectorConsumedBy``. It is deliberately not ported: the SCTG name in
+# ``Flowable`` is what ``nowcast_transport_margins`` groups ton-miles by, since
+# the sector column resolves to NAICS rather than to the BEA commodity that
+# receives the margin (#546). Overwriting it would silently coarsen the growth
+# factors to whatever NAICS group each SCTG happens to land in.

--- a/bedrock/extract/bts/BTS_FAF.py
+++ b/bedrock/extract/bts/BTS_FAF.py
@@ -1,0 +1,283 @@
+# BTS_FAF.py (bedrock)
+# !/usr/bin/env python3
+# coding=utf-8
+
+"""
+Freight Analysis Framework (FAF), ORNL / US Bureau of Transportation Statistics.
+
+FAF models freight movement between origin-destination pairs, by commodity
+(SCTG) and mode. This extractor keeps only what the transport margin needs -
+national totals per (commodity, mode) - and discards the origin-destination
+detail, which is the bulk of the file.
+
+**Why this source.** Transport is the one margin with an external source that
+gives both the level and the commodity allocation. BEA's own method distributes
+transport cost across commodities on the share of transport receipts from moving
+each one, taken from the Commodity Flow Survey; the manual assumes revenue per
+ton is constant across commodities because CFS reports tons and value but not
+revenue. FAF is modelled from the same CFS but published annually rather than
+every five years, and it adds **ton-miles**, which is the better freight-cost
+proxy since cost scales with distance. Both measures are emitted here so the
+choice can be settled on the 2017 fit rather than by assertion.
+
+**Version.** FAF5.7.1, whose base year is 2017 - the same CFS vintage the BEA
+method rests on, and the benchmark year the margin rates are anchored to. FAF6
+exists with a 2022 base year, but a 2022 base cannot be checked against a
+published 2017 ``TRANS`` column. One file carries 2017-2024 annually (plus
+2030-2050 forecasts, which are dropped), so the whole nowcast window and the
+benchmark come from a single download.
+
+**Sizes.** The archive is 145 MB and the CSV inside it 529 MB over 1.2 million
+rows, so it is cached under ``extract/input_data/BTS_FAF/`` and read with
+``usecols`` rather than re-downloaded or read whole.
+
+⚠️ **Two traps this deliberately avoids.**
+
+*No PDF scraping.* The SCTG and mode code tables are published inside the same
+archive as ``FAF5_metadata.xlsx``. The upstream flowsa version reads them out of
+the FAF User Guide PDF with ``tabula``, which needs a Java runtime to recover
+tables that ship in the download already.
+
+*Names are validated, not assumed.* FAF publishes numeric codes; the
+descriptions come from the metadata workbook and are what the activity-to-sector
+crosswalk joins on. A renamed description would otherwise drop a commodity
+silently - allocating transport margin across fewer commodities while every
+total still balances - so every activity name is checked against the crosswalk
+at extract time and a mismatch raises.
+"""
+
+from __future__ import annotations
+
+import os
+import zipfile
+from typing import Any
+
+import pandas as pd
+
+from bedrock.transform.flowbyfunctions import assign_fips_location_system
+from bedrock.utils.config.settings import crosswalkpath
+from bedrock.utils.io.gcp import download_extract_input_from_gcs_if_not_exists
+from bedrock.utils.io.local_extract_input_data import local_extract_input_dir
+from bedrock.utils.mapping.location import US_FIPS
+
+#: One archive holds every year, so there is one file to cache rather than one
+#: per year - the same shape as BEA's NIPA flat files.
+FAF_ZIP = 'FAF5.7.1_State.zip'
+
+#: Sheets of ``FAF5_metadata.xlsx`` that name the numeric codes.
+_SCTG_SHEET = 'Commodity (SCTG2)'
+_MODE_SHEET = 'Mode'
+
+#: ``trade_type`` 1. Imports and exports are excluded because the margin wanted
+#: here is the domestic leg only: the foreign-port-to-domestic-port leg of an
+#: import is already inside the Supply table's ``MCIF``, so counting it again as
+#: transport margin would double it.
+_DOMESTIC_TRADE_TYPE = 1
+
+#: Published unit -> (bedrock unit, factor). FAF reports tons in thousands, and
+#: dollars and ton-miles in millions.
+_MEASURES: dict[str, tuple[str, float]] = {
+    'tons': ('tons', 1_000.0),
+    'tmiles': ('ton-miles', 1_000_000.0),
+    'current_value': ('USD', 1_000_000.0),
+}
+
+#: The crosswalk both activity dimensions join on.
+_CROSSWALK = 'NAICS_Crosswalk_FAF_Mode_and_SCTG.csv'
+
+
+def faf_local_path(source: str = 'BTS_FAF') -> str:
+    """Where the archive is cached: ``extract/input_data/BTS_FAF/``."""
+    return os.path.join(local_extract_input_dir(source, year=None), FAF_ZIP)
+
+
+def _value_column(year: int) -> str:
+    """The nominal-dollar column for *year*.
+
+    FAF publishes ``value_*`` in constant base-year dollars for every year and
+    ``current_value_*`` in nominal dollars from 2018 on. 2017 is the base year,
+    so it has no ``current_value_2017`` - the two are the same number, and
+    ``value_2017`` is it.
+    """
+    return 'value_2017' if year == 2017 else f'current_value_{year}'
+
+
+def _measure_columns(years: list[int]) -> dict[str, tuple[str, int, float]]:
+    """Published column -> (bedrock unit, year, scaling factor)."""
+    columns = {}
+    for year in years:
+        for published, (unit, factor) in _MEASURES.items():
+            name = _value_column(year) if published == 'current_value' else (
+                f'{published}_{year}'
+            )
+            columns[name] = (unit, year, factor)
+    return columns
+
+
+def _code_names(zip_file: zipfile.ZipFile) -> tuple[dict[int, str], dict[int, str]]:
+    """SCTG and mode code -> description, from the metadata workbook."""
+    metadata = next(n for n in zip_file.namelist() if n.lower().endswith('.xlsx'))
+    with zip_file.open(metadata) as handle:
+        book = pd.read_excel(handle, sheet_name=[_SCTG_SHEET, _MODE_SHEET], header=0)
+
+    def as_map(sheet: pd.DataFrame) -> dict[int, str]:
+        frame = sheet.rename(
+            columns={'Numeric Label': 'code', 'Description': 'description'}
+        ).dropna(subset=['code', 'description'])
+        return {
+            int(code): str(description).strip()
+            for code, description in zip(frame['code'], frame['description'])
+        }
+
+    return as_map(book[_SCTG_SHEET]), as_map(book[_MODE_SHEET])
+
+
+def _validate_against_crosswalk(commodities: set[str], modes: set[str]) -> None:
+    """Raise if FAF names something the activity-to-sector crosswalk cannot join.
+
+    The failure this prevents is quiet: an unjoined commodity carries no
+    transport margin, the remaining commodities still absorb the whole control
+    total, and every total balances while the allocation is wrong.
+    """
+    crosswalk = pd.read_csv(crosswalkpath / _CROSSWALK, dtype=str).fillna('')
+    known = {
+        source: set(rows['Activity'])
+        for source, rows in crosswalk.groupby('ActivitySourceName')
+    }
+    missing = {
+        'commodity': sorted(commodities - known.get('FAF_SCTG', set())),
+        'mode': sorted(modes - known.get('FAF_Mode', set())),
+    }
+    unmatched = {kind: names for kind, names in missing.items() if names}
+    if unmatched:
+        raise ValueError(
+            f'FAF publishes activity names that {_CROSSWALK} cannot join, so '
+            f'they would be dropped silently: {unmatched}. FAF has most likely '
+            f'renamed them - reconcile the crosswalk Activity column against '
+            f'the metadata workbook rather than letting the rows fall out.'
+        )
+
+
+def _read_faf_zip(zip_path: str, config: dict[str, Any]) -> list[pd.DataFrame]:
+    """National (commodity, mode) totals per year and measure, long format."""
+    years = [int(year) for year in config['years']]
+    measures = _measure_columns(years)
+    keys = ['sctg2', 'dms_mode']
+
+    with zipfile.ZipFile(zip_path) as zip_file:
+        sctg_names, mode_names = _code_names(zip_file)
+        data_file = next(n for n in zip_file.namelist() if n.lower().endswith('.csv'))
+        with zip_file.open(data_file) as handle:
+            raw = pd.read_csv(
+                handle,
+                usecols=[*keys, 'trade_type', *measures],
+                dtype={'sctg2': int, 'dms_mode': int, 'trade_type': int},
+            )
+
+    totals = (
+        raw.loc[raw['trade_type'] == _DOMESTIC_TRADE_TYPE]
+        .drop(columns='trade_type')
+        .groupby(keys, as_index=False)
+        .sum()
+    )
+
+    long = totals.melt(id_vars=keys, var_name='measure', value_name='FlowAmount')
+    long['Unit'] = long['measure'].map(lambda m: measures[m][0])
+    long['Year'] = long['measure'].map(lambda m: str(measures[m][1]))
+    long['FlowAmount'] = long['FlowAmount'] * long['measure'].map(
+        lambda m: measures[m][2]
+    )
+    long['FlowName'] = long['sctg2'].map(sctg_names)
+    long['ActivityProducedBy'] = long['dms_mode'].map(mode_names)
+
+    unnamed = long['FlowName'].isna() | long['ActivityProducedBy'].isna()
+    if unnamed.any():
+        codes = long.loc[unnamed, keys].drop_duplicates()
+        raise ValueError(
+            f'FAF data carries codes the metadata workbook does not name: '
+            f'{codes.to_dict("records")}'
+        )
+    _validate_against_crosswalk(
+        set(long['FlowName']), set(long['ActivityProducedBy'])
+    )
+
+    return [long.drop(columns=['measure', *keys])]
+
+
+def faf_call(
+    *, resp: Any, source: str, config: dict[str, Any], **_: Any
+) -> list[pd.DataFrame]:
+    """Cache the downloaded archive under extract-input, then read it.
+
+    Only reached with ``extract_data_from_raw_sources: True``; writing it down
+    rather than parsing it in memory is what lets every later run go through
+    :func:`faf_load_gcs` instead of pulling 145 MB from ORNL again.
+    """
+    local_path = faf_local_path(source)
+    os.makedirs(os.path.dirname(local_path), exist_ok=True)
+    with open(local_path, 'wb') as f:
+        f.write(resp.content)
+    return _read_faf_zip(local_path, config)
+
+
+def faf_load_gcs(**kwargs: Any) -> list[pd.DataFrame]:
+    """Load the archive from the local cache, or GCS extract-input if missing."""
+    source = str(kwargs['source'])
+    local_path = faf_local_path(source)
+    if not os.path.exists(local_path):
+        download_extract_input_from_gcs_if_not_exists(
+            # the archive spans every year, so it sits directly under
+            # extract/input-data/BTS_FAF/ rather than in a year subfolder
+            {**kwargs, 'year': None},
+            local_dir=os.path.dirname(local_path),
+            object_name=FAF_ZIP,
+        )
+    if not os.path.exists(local_path):
+        raise FileNotFoundError(
+            f'{FAF_ZIP} is neither cached at {local_path} nor available from '
+            f'gs://cornerstone-default/extract/input-data/{source}/. Set '
+            f'extract_data_from_raw_sources: True in {source}.yaml to fetch it '
+            f'from ORNL and cache it, then upload it so others need not.'
+        )
+    return _read_faf_zip(local_path, kwargs['config'])
+
+
+def faf_parse(
+    *, df_list: list[pd.DataFrame], source: str, year: int, **_: Any
+) -> pd.DataFrame:
+    """Select *year* out of the archive-wide frame and complete the FBA columns."""
+    df = pd.concat(df_list, ignore_index=True)
+    df = df.loc[df['Year'] == str(year)].copy()
+    if df.empty:
+        raise ValueError(f'{source} has no rows for {year}')
+    return (
+        df.assign(
+            Class='Other',
+            SourceName=source,
+            Compartment=None,
+            FlowType='TECHNOSPHERE_FLOW',
+            Location=US_FIPS,
+            # provisional pending a source-specific assessment
+            DataReliability=5,
+            DataCollection=5,
+        )
+        .pipe(assign_fips_location_system, 2024)
+        .reset_index(drop=True)
+    )
+
+
+def move_flow_to_ACB(fba: pd.DataFrame, **_: Any) -> pd.DataFrame:
+    """``clean_fba_before_activity_sets``: the commodity moved is the consumer.
+
+    FAF's two dimensions are the mode (which produces the transport service) and
+    the commodity moved. Only the mode is an activity in the published data, so
+    the commodity rides in ``FlowName`` out of the extractor and is promoted to
+    ``ActivityConsumedBy`` here, which is what lets the crosswalk map it to the
+    commodity that receives the margin.
+    """
+    return fba.assign(ActivityConsumedBy=fba['FlowName'])
+
+
+def move_SCB_to_flow(fbs: pd.DataFrame, **_: Any) -> pd.DataFrame:
+    """``clean_fbs``: replace the SCTG flow name with the mapped commodity."""
+    return fbs.assign(Flowable=fbs['SectorConsumedBy'], SectorConsumedBy=None)

--- a/bedrock/extract/bts/BTS_FAF.yaml
+++ b/bedrock/extract/bts/BTS_FAF.yaml
@@ -1,0 +1,37 @@
+author: US Bureau of Transportation Statistics / Oak Ridge National Laboratory
+source_name: Freight Analysis Framework (FAF) 5.7.1
+source_url: https://faf.ornl.gov/faf5
+source_publication_date: 2025
+bib_id: BTS_FAF
+api_name: None
+api_key_required: false
+format: zip
+url:
+  base_url: https://faf.ornl.gov/faf5/data/download_files/FAF5.7.1_State.zip
+
+call_response_fxn: !script_function:BTS_FAF faf_call
+gcs_fxn: !script_function:BTS_FAF faf_load_gcs
+parse_response_fxn: !script_function:BTS_FAF faf_parse
+
+# Read FAF5.7.1_State.zip from extract/input_data/BTS_FAF/ (or GCS extract-input
+# if it is not cached yet) rather than re-downloading 145MB from ORNL every run.
+# Set to True to refresh the cache, e.g. when a new FAF version is released.
+extract_data_from_raw_sources: False
+
+# One archive carries every year, so it is read once and each year selected out
+# of it rather than fetched separately.
+call_all_years: True
+
+# FAF5.7.1 is the version whose base year is 2017 - the same Commodity Flow
+# Survey vintage BEA's own margin method rests on, and the benchmark year the
+# margin rates are anchored to. It carries 2017-2024 annually; the 2030-2050
+# forecast columns in the same file are deliberately not listed here.
+years:
+- 2017
+- 2018
+- 2019
+- 2020
+- 2021
+- 2022
+- 2023
+- 2024

--- a/bedrock/transform/iot/__tests__/test_nowcast_transport_margins.py
+++ b/bedrock/transform/iot/__tests__/test_nowcast_transport_margins.py
@@ -1,0 +1,165 @@
+"""Tests for the annual transport margin (Step 4c phase 2, #611).
+
+All synthetic. The three real inputs - the FBS ton-miles, the gross output FBA
+and the published 2017 anchor - are substituted, because what is worth testing
+here is the arithmetic that joins them: that the anchor year comes back
+untouched, that the level is the control total and the shape is ton-miles, and
+that a commodity which loses its ton-miles raises rather than silently carrying
+its 2017 margin forward.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from bedrock.transform.iot import nowcast_transport_margins as ntm
+from bedrock.transform.iot.nowcast_transport_margins import (
+    ANCHOR_YEAR,
+    TRANSPORT_MODE_COMMODITIES,
+    _as_years,
+    commodity_ton_miles,
+    control_total_components,
+    movement_summary,
+    ton_mile_growth,
+    transport_margin_control_total,
+    transport_margins,
+)
+
+YEARS = (2017, 2018)
+
+#: Two commodities in one SCTG, one commodity spanning two.
+CROSSWALK = pd.DataFrame(
+    {
+        'sctg': ['Coal', 'Coal', 'Gasoline', 'Fuel oils'],
+        'Commodity Code': ['212100', '221100', '324110', '324110'],
+    }
+)
+
+TON_MILES = pd.DataFrame(
+    {2017: [100.0, 40.0, 60.0], 2018: [50.0, 60.0, 60.0]},
+    index=pd.Index(['Coal', 'Gasoline', 'Fuel oils'], name='Flowable'),
+)
+
+ANCHOR = pd.Series(
+    {'212100': 800.0, '221100': 200.0, '324110': 1000.0},
+    name='transport_margins',
+)
+
+#: Mode output doubles, so the control total doubles too.
+MODE_OUTPUT = pd.DataFrame(
+    {2017: [1000.0] * 5, 2018: [2000.0] * 5},
+    index=list(TRANSPORT_MODE_COMMODITIES),
+)
+MODE_GIVEN_UP = pd.Series(
+    dict.fromkeys(TRANSPORT_MODE_COMMODITIES, 400.0), name='margin_given_up'
+)
+
+
+@pytest.fixture(autouse=True)
+def stub_sources(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Substitute the three pipeline inputs, and the 402-commodity index."""
+    monkeypatch.setattr(ntm, 'sctg_ton_miles', lambda years: TON_MILES)
+    monkeypatch.setattr(ntm, 'sctg_to_commodity', lambda: CROSSWALK)
+    monkeypatch.setattr(ntm, '_gross_output', lambda years: MODE_OUTPUT)
+    monkeypatch.setattr(ntm, '_anchor_margins', lambda: ANCHOR)
+    monkeypatch.setattr(
+        ntm,
+        'margins_by_commodity',
+        lambda: pd.DataFrame({'margin_given_up': MODE_GIVEN_UP}),
+    )
+    monkeypatch.setattr(
+        ntm,
+        'USA_2017_COMMODITY_CODES',
+        ('212100', '221100', '324110', '484000'),
+    )
+
+
+def test_as_years_always_carries_the_anchor() -> None:
+    assert _as_years([2020, 2018, 2018]) == (2017, 2018, 2020)
+    assert _as_years([2017]) == (2017,)
+
+
+def test_commodity_ton_miles_sums_the_groups_a_commodity_belongs_to() -> None:
+    ton_miles = commodity_ton_miles(YEARS)
+    # both coal commodities carry the whole SCTG, not a share of it
+    assert ton_miles.loc['212100', 2017] == 100.0
+    assert ton_miles.loc['221100', 2017] == 100.0
+    # the two-SCTG commodity takes the total of both
+    assert ton_miles.loc['324110', 2017] == 100.0
+    assert ton_miles.loc['324110', 2018] == 120.0
+
+
+def test_commodity_ton_miles_raises_on_an_sctg_the_fbs_lacks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        ntm,
+        'sctg_to_commodity',
+        lambda: pd.DataFrame({'sctg': ['Renamed'], 'Commodity Code': ['212100']}),
+    )
+    with pytest.raises(ValueError, match='SCTGs the FBS does not carry'):
+        commodity_ton_miles(YEARS)
+
+
+def test_growth_is_one_in_the_anchor_year() -> None:
+    growth = ton_mile_growth(YEARS)
+    assert (growth[ANCHOR_YEAR] == 1.0).all()
+    assert growth.loc['212100', 2018] == pytest.approx(0.5)
+    assert growth.loc['324110', 2018] == pytest.approx(1.2)
+
+
+def test_control_components_reproduce_the_anchor_give_up() -> None:
+    components = control_total_components(YEARS)
+    assert components[ANCHOR_YEAR].equals(MODE_GIVEN_UP.rename(None))
+    # output doubles at a fixed ratio, so the margin given up doubles
+    assert components[2018].sum() == pytest.approx(2 * components[2017].sum())
+
+
+def test_control_total_is_rescaled_onto_the_published_anchor() -> None:
+    control = transport_margin_control_total(YEARS)
+    assert control[ANCHOR_YEAR] == pytest.approx(ANCHOR.sum())
+    assert control[2018] == pytest.approx(2 * ANCHOR.sum())
+
+
+def test_anchor_year_reproduces_the_published_column_exactly() -> None:
+    margins = transport_margins(YEARS)
+    for commodity, published in ANCHOR.items():
+        assert margins.loc[commodity, ANCHOR_YEAR] == pytest.approx(published)
+
+
+def test_total_equals_the_control_total_and_shape_follows_ton_miles() -> None:
+    margins = transport_margins(YEARS)
+    control = transport_margin_control_total(YEARS)
+    assert margins[2018].sum() == pytest.approx(control[2018])
+    # shape: 800*0.5, 200*0.5, 1000*1.2 = 400, 100, 1200, scaled to 4000
+    assert margins.loc['212100', 2018] == pytest.approx(4000 * 400 / 1700)
+    assert margins.loc['324110', 2018] == pytest.approx(4000 * 1200 / 1700)
+
+
+def test_reindexed_to_every_commodity_with_zero_for_non_receivers() -> None:
+    margins = transport_margins(YEARS)
+    assert list(margins.index) == ['212100', '221100', '324110', '484000']
+    # a transport mode gives margin up rather than receiving it
+    assert (margins.loc['484000'] == 0.0).all()
+
+
+def test_a_receiving_commodity_without_ton_miles_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        ntm,
+        'sctg_to_commodity',
+        lambda: CROSSWALK[CROSSWALK['Commodity Code'] != '221100'],
+    )
+    with pytest.raises(ValueError, match='no ton-miles to move by'):
+        transport_margins(YEARS)
+
+
+def test_movement_summary_separates_repricing_from_volume() -> None:
+    summary = movement_summary(YEARS)
+    assert (summary.loc[ANCHOR_YEAR] == 1.0).all()
+    # ton-miles carry the total from 2000 to 1700, while the level doubles
+    assert summary.loc[2018, 'volume'] == pytest.approx(1700 / 2000)
+    assert summary.loc[2018, 'level'] == pytest.approx(2.0)
+    assert summary.loc[2018, 'repricing'] == pytest.approx(2.0 * 2000 / 1700)

--- a/bedrock/transform/iot/__tests__/test_nowcast_transport_margins.py
+++ b/bedrock/transform/iot/__tests__/test_nowcast_transport_margins.py
@@ -1,11 +1,17 @@
 """Tests for the annual transport margin (Step 4c phase 2, #611).
 
-All synthetic. The three real inputs - the FBS ton-miles, the gross output FBA
-and the published 2017 anchor - are substituted, because what is worth testing
-here is the arithmetic that joins them: that the anchor year comes back
-untouched, that the level is the control total and the shape is ton-miles, and
-that a commodity which loses its ton-miles raises rather than silently carrying
-its 2017 margin forward.
+All synthetic. The real inputs - the FBS ton-miles by SCTG and by mode, the
+gross output and price index tables, the NIPA final-use index and the published
+2017 anchor - are substituted, because what is worth testing here is the
+arithmetic that joins them: that the anchor year comes back untouched under
+*every* control method, that each method moves the level its own way and
+:data:`MODE_CONTROL` dispatches between them, that the level is the control
+total while the shape is ton-miles, and that a commodity which loses its
+ton-miles raises rather than silently carrying its 2017 margin forward.
+
+The two ``pce_final_use_index`` tests are the exception: they run the real
+function over a synthetic bridge and NIPA table, since the 2017-share-freezing
+join is the one piece of new arithmetic worth exercising directly.
 """
 
 from __future__ import annotations
@@ -28,6 +34,14 @@ from bedrock.transform.iot.nowcast_transport_margins import (
 
 YEARS = (2017, 2018)
 
+#: Captured before the autouse fixture replaces it, for the two tests that
+#: exercise the real join rather than stubbing it.
+_REAL_PCE_INDEX = ntm.pce_final_use_index
+
+#: The mixed control total in 2018, given the stubs below: air and water on
+#: freight volume at 1200 each, rail, truck and pipeline at 800.
+MIXED_2018 = 4800.0
+
 #: Two commodities in one SCTG, one commodity spanning two.
 CROSSWALK = pd.DataFrame(
     {
@@ -46,13 +60,29 @@ ANCHOR = pd.Series(
     name='transport_margins',
 )
 
-#: Mode output doubles, so the control total doubles too.
+#: Mode output doubles. Under output_ratio that doubles the give-up; under
+#: residual it does not, since direct uses move with PCE instead.
 MODE_OUTPUT = pd.DataFrame(
     {2017: [1000.0] * 5, 2018: [2000.0] * 5},
     index=list(TRANSPORT_MODE_COMMODITIES),
 )
 MODE_GIVEN_UP = pd.Series(
     dict.fromkeys(TRANSPORT_MODE_COMMODITIES, 400.0), name='margin_given_up'
+)
+
+#: Freight volume doubles and freight prices rise by half, so the
+#: freight_volume treatment reaches 400 x 2 x 1.5 = 1200 in 2018. Distinct from
+#: both other treatments' 800, which is what lets the dispatch be tested.
+MODE_TON_MILES = pd.DataFrame(
+    {2017: [100.0] * 5, 2018: [200.0] * 5}, index=list(TRANSPORT_MODE_COMMODITIES)
+)
+MODE_PRICES = pd.DataFrame(
+    {2017: [1.0] * 5, 2018: [1.5] * 5}, index=list(TRANSPORT_MODE_COMMODITIES)
+)
+#: PCE doubles, so residual direct uses go 600 -> 1200 and the residual is
+#: 2000 - 1200 = 800.
+MODE_PCE_INDEX = pd.DataFrame(
+    {2017: [1.0] * 5, 2018: [2.0] * 5}, index=list(TRANSPORT_MODE_COMMODITIES)
 )
 
 
@@ -62,6 +92,9 @@ def stub_sources(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(ntm, 'sctg_ton_miles', lambda years: TON_MILES)
     monkeypatch.setattr(ntm, 'sctg_to_commodity', lambda: CROSSWALK)
     monkeypatch.setattr(ntm, '_gross_output', lambda years: MODE_OUTPUT)
+    monkeypatch.setattr(ntm, 'mode_ton_miles', lambda years: MODE_TON_MILES)
+    monkeypatch.setattr(ntm, 'mode_price_index', lambda years: MODE_PRICES)
+    monkeypatch.setattr(ntm, 'pce_final_use_index', lambda years: MODE_PCE_INDEX)
     monkeypatch.setattr(ntm, '_anchor_margins', lambda: ANCHOR)
     monkeypatch.setattr(
         ntm,
@@ -112,14 +145,15 @@ def test_growth_is_one_in_the_anchor_year() -> None:
 def test_control_components_reproduce_the_anchor_give_up() -> None:
     components = control_total_components(YEARS)
     assert components[ANCHOR_YEAR].equals(MODE_GIVEN_UP.rename(None))
-    # output doubles at a fixed ratio, so the margin given up doubles
-    assert components[2018].sum() == pytest.approx(2 * components[2017].sum())
+    # the movement is per mode now, not one ratio - see MODE_CONTROL
+    assert components[2018].sum() == pytest.approx(MIXED_2018)
 
 
 def test_control_total_is_rescaled_onto_the_published_anchor() -> None:
     control = transport_margin_control_total(YEARS)
     assert control[ANCHOR_YEAR] == pytest.approx(ANCHOR.sum())
-    assert control[2018] == pytest.approx(2 * ANCHOR.sum())
+    # the composite is 2000 in the anchor year, so the rescaling is 1:1 here
+    assert control[2018] == pytest.approx(MIXED_2018)
 
 
 def test_anchor_year_reproduces_the_published_column_exactly() -> None:
@@ -132,9 +166,9 @@ def test_total_equals_the_control_total_and_shape_follows_ton_miles() -> None:
     margins = transport_margins(YEARS)
     control = transport_margin_control_total(YEARS)
     assert margins[2018].sum() == pytest.approx(control[2018])
-    # shape: 800*0.5, 200*0.5, 1000*1.2 = 400, 100, 1200, scaled to 4000
-    assert margins.loc['212100', 2018] == pytest.approx(4000 * 400 / 1700)
-    assert margins.loc['324110', 2018] == pytest.approx(4000 * 1200 / 1700)
+    # shape: 800*0.5, 200*0.5, 1000*1.2 = 400, 100, 1200, scaled to the control
+    assert margins.loc['212100', 2018] == pytest.approx(MIXED_2018 * 400 / 1700)
+    assert margins.loc['324110', 2018] == pytest.approx(MIXED_2018 * 1200 / 1700)
 
 
 def test_reindexed_to_every_commodity_with_zero_for_non_receivers() -> None:
@@ -159,7 +193,109 @@ def test_a_receiving_commodity_without_ton_miles_raises(
 def test_movement_summary_separates_repricing_from_volume() -> None:
     summary = movement_summary(YEARS)
     assert (summary.loc[ANCHOR_YEAR] == 1.0).all()
-    # ton-miles carry the total from 2000 to 1700, while the level doubles
+    # ton-miles carry the total from 2000 down to 1700 while the level rises
+    level = MIXED_2018 / 2000
     assert summary.loc[2018, 'volume'] == pytest.approx(1700 / 2000)
-    assert summary.loc[2018, 'level'] == pytest.approx(2.0)
-    assert summary.loc[2018, 'repricing'] == pytest.approx(2.0 * 2000 / 1700)
+    assert summary.loc[2018, 'level'] == pytest.approx(level)
+    assert summary.loc[2018, 'repricing'] == pytest.approx(level * 2000 / 1700)
+
+
+def test_every_treatment_is_an_identity_in_the_anchor_year() -> None:
+    """The point of anchoring: the choice of driver changes movement, not 2017."""
+    for method in (ntm.MIXED, ntm.RESIDUAL, ntm.FREIGHT_VOLUME, ntm.OUTPUT_RATIO):
+        components = control_total_components(YEARS, method=method)
+        assert components[ANCHOR_YEAR].tolist() == [400.0] * 5, method
+
+
+def test_each_treatment_moves_the_level_its_own_way() -> None:
+    """Residual 2000-600x2, freight 400x2x1.5, ratio 2000x0.4 - all distinct."""
+    by_method = {
+        method: control_total_components(YEARS, method=method)[2018]
+        for method in (ntm.RESIDUAL, ntm.FREIGHT_VOLUME, ntm.OUTPUT_RATIO)
+    }
+    assert by_method[ntm.RESIDUAL].tolist() == [800.0] * 5
+    assert by_method[ntm.FREIGHT_VOLUME].tolist() == [1200.0] * 5
+    assert by_method[ntm.OUTPUT_RATIO].tolist() == [800.0] * 5
+
+
+def test_mixed_gives_each_mode_the_treatment_mode_control_assigns() -> None:
+    """Air and water on freight volume, rail and truck residual, pipeline ratio."""
+    components = control_total_components(YEARS, method=ntm.MIXED)[2018]
+    expected = {
+        '481000': 1200.0,  # air, freight_volume
+        '482000': 800.0,  # rail, residual
+        '483000': 1200.0,  # water, freight_volume
+        '484000': 800.0,  # truck, residual
+        '486000': 800.0,  # pipeline, output_ratio
+    }
+    assert components.to_dict() == expected
+    assert ntm.MODE_CONTROL.keys() == set(TRANSPORT_MODE_COMMODITIES)
+
+
+def test_comparison_carries_every_method_and_agrees_with_each() -> None:
+    comparison = ntm.control_total_comparison(YEARS)
+    assert set(comparison.columns) == {
+        ntm.RESIDUAL,
+        ntm.FREIGHT_VOLUME,
+        ntm.OUTPUT_RATIO,
+        ntm.MIXED,
+    }
+    for method in comparison.columns:
+        expected = control_total_components(YEARS, method=method).sum()
+        pd.testing.assert_series_equal(comparison[method], expected, check_names=False)
+    # every method is the same total in the anchor year, and they diverge after
+    assert comparison.loc[ANCHOR_YEAR].nunique() == 1
+    assert comparison.loc[2018].nunique() > 1
+
+
+def test_an_unknown_control_method_raises_rather_than_silently_defaulting() -> None:
+    with pytest.raises(ValueError, match='unknown control method'):
+        control_total_components(YEARS, method='ton_miles_only')
+
+
+def test_pce_index_holds_a_split_lines_2017_share_and_is_one_at_the_anchor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """NIPA line 7 splits 75/25 across air and water; that split is frozen."""
+    bridge = pd.DataFrame(
+        {
+            'NIPA Line': [3, 7, 7],
+            'Commodity Code': ['484000', '481000', '483000'],
+            "Purchasers' Value": [100.0, 75.0, 25.0],
+        }
+    )
+    pce = {2017: pd.Series({3: 100.0, 7: 100.0}), 2018: pd.Series({3: 50.0, 7: 400.0})}
+    monkeypatch.setattr(ntm, 'load_2017_pce_bridge_detail_usa', lambda: bridge)
+    monkeypatch.setattr(ntm, '_pce_by_nipa_line', lambda year: pce[year])
+    monkeypatch.setattr(ntm, 'pce_final_use_index', _REAL_PCE_INDEX)
+    _REAL_PCE_INDEX.cache_clear()
+
+    index = ntm.pce_final_use_index(YEARS)
+    assert index[ANCHOR_YEAR].tolist() == [1.0] * 5
+    # line 7 quadruples, and both its commodities move with it, share intact
+    assert index.loc['481000', 2018] == 4.0
+    assert index.loc['483000', 2018] == 4.0
+    assert index.loc['484000', 2018] == 0.5
+    # rail and pipeline have no PCE at all: index 1, never NaN
+    assert index.loc['482000', 2018] == 1.0
+    assert index.loc['486000', 2018] == 1.0
+    _REAL_PCE_INDEX.cache_clear()
+
+
+def test_pce_index_raises_when_the_bridge_names_a_line_nipa_lacks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bridge = pd.DataFrame(
+        {
+            'NIPA Line': [999],
+            'Commodity Code': ['484000'],
+            "Purchasers' Value": [100.0],
+        }
+    )
+    monkeypatch.setattr(ntm, 'load_2017_pce_bridge_detail_usa', lambda: bridge)
+    monkeypatch.setattr(ntm, '_pce_by_nipa_line', lambda year: pd.Series({3: 1.0}))
+    monkeypatch.setattr(ntm, 'pce_final_use_index', _REAL_PCE_INDEX)
+    _REAL_PCE_INDEX.cache_clear()
+    with pytest.raises(ValueError, match='different vintages'):
+        ntm.pce_final_use_index(YEARS)
+    _REAL_PCE_INDEX.cache_clear()

--- a/bedrock/transform/iot/nowcast_transport_margins.py
+++ b/bedrock/transform/iot/nowcast_transport_margins.py
@@ -8,8 +8,8 @@ module moves the transport column of it to an annual year. Transport is the one
 margin with an external source that reaches every commodity, so it is settled
 here rather than waiting for the trade levels in phase 3.
 
-**Shape from ton-miles, level from output.** The construction is two independent
-movements of the same 2017 column:
+**Shape from ton-miles, level from a control total.** The construction is two
+independent movements of the same 2017 column:
 
 .. code-block:: text
 
@@ -32,22 +32,51 @@ line-haul assumption where ``TRANS`` is the delivered margin.
 **Why a control total is needed at all.** Ton-miles are a *volume* index and
 ``TRANS`` is nominal. Moving 2017 by ton-miles alone holds 2017 freight rates
 fixed, which misses the 2021-22 rate surge entirely: the volume index reaches
-1.04 by 2022 while the nominal control reaches 1.48. The level therefore comes
-from the transport industries' own gross output, held at each mode's 2017 ratio
-of margin given up to output - which is the same number the negative side of the
-``TRANS`` column carries, so the two sides stay consistent by construction.
+1.04 by 2022 while the nominal control reaches 1.55. The level therefore comes
+from a separate nominal source per mode - and that source is the whole of what
+:func:`control_total_components` decides. Whichever treatment supplies it, the
+result is also the *negative* side of the ``TRANS`` column, so the two sides stay
+consistent by construction.
 
-⚠️ **A better control total is designed and not yet built.** The give-up ratio
-here is frozen at 2017, which is the weak point the limitations below all come
-back to. The Supply table closes ``T016 = T013 + TRANS + TOP + SUB``, so the
-margin can instead be taken as a residual against direct uses moved by an annual
-final-use index - well conditioned for truck, rail and pipeline (leverage 0.19,
-0.14, 0.01; 96.2% of ``TRANS``) and hopeless for air and water (43.5 and 3.2),
-which would keep a freight-volume-times-price form. It is blocked on an annual
-final-use index: ``NIPA_FD`` works for 2017 only, since the later years carry
-2017 NIPA line numbers and drop most of their output. See
-``margins_estimation_plan.md`` §Agreed refinement, and #620 for the external
-validation of whichever driver wins.
+⚠️ **The choice of control total is the largest open uncertainty here.** The four
+constructions in :func:`control_total_comparison` agree exactly in 2017 and
+spread **12% by 2022**, from 575,587 million to 643,443 million. That is why
+*method* is a parameter rather than a decision baked in, and why
+`#620 <https://github.com/cornerstone-data/bedrock/issues/620>`_ exists to settle
+it against BTS_TSA and Freight Facts & Figures rather than against itself.
+
+**The level is not one construction but three, by mode.** A single treatment
+cannot serve all five, because the modes differ in what fraction of their output
+is margin at all - 0.026 for air against 0.862 for rail. :data:`MODE_CONTROL`
+assigns each mode the only treatment that is conditioned for it:
+
+*Residual, for truck and rail* - 84.3% of ``TRANS``. The mode's output less its
+direct (non-margin) uses, where 2017 direct uses are moved by an annual
+final-use index and the intermediate:final split is held at 2017. Margin is 77%
+and 86% of output for these two, so direct uses are the small term: a 1% error
+in them moves the margin 0.30% and 0.16%. This is what replaced a frozen give-up
+ratio, and it lifts the pair 0.8% to 5.1% above that ratio over 2018-2024.
+
+*Freight volume times price, for air and water* - 3.8%. Their margin is 2.6% and
+17.3% of output, so the residual amplifies any error in direct uses 37x and 4.8x
+and **goes negative** - air from 2019, reaching -121,719 million by 2024, because
+air PCE grows 1.96x against output's 1.393x and direct uses overtake output
+entirely. Neither can a frozen give-up ratio serve: it makes air *freight* margin
+follow air *passenger* output, which is why the 2020 collapse to 0.536 of 2017
+output would cut air freight margin 46% in a year when air freight ton-miles were
+1.010. So these two move by their own FAF freight ton-miles - freight-only by
+construction - repriced by their BEA mode price index.
+
+*Output ratio, for pipeline* - 11.9%. Neither of the above is available:
+pipeline's output is *less* than the margin it gives up (a 2017 ratio of 1.033),
+so no residual exists, and it has no PCE at all, so there is no final-use index
+to move direct uses by. Its output is very nearly all margin, which is what makes
+the frozen ratio harmless here.
+
+⚠️ The air and water price index is the whole industry's, passengers included, so
+their repricing is still contaminated - much less than their *level* was under
+the frozen ratio, but not cleanly. #620 covers validating all three drivers
+against BTS_TSA and Freight Facts & Figures.
 
 ⚠️ **Three limitations of the construction as built.**
 
@@ -58,12 +87,14 @@ only 1.9% across that seam, but the composition moves much more: 21% of 2017
 year, and the ``TRANS``-weighted mean step is 1.124 against the aggregate's
 1.019. The control total absorbs the level, so what survives is a shape shift.
 
-*Air and rail output are not freight-only.* :func:`control_total_components`
-scales each mode's whole gross output, and air's includes passengers - which is
-why air's 2017 give-up ratio is 0.026 where rail's is 0.862. Holding that ratio
-fixed makes air freight margin follow passenger air output. Air is 1.5% of
-``TRANS``, so the error is bounded; truck, at 68%, is the mode that matters and
-is close to freight-pure.
+*The residual freezes the intermediate:final split at 2017.* Direct uses are
+moved wholly by a *final*-use index, so intermediate direct purchases of freight
+are assumed to move with household ones. They are 46% of truck's direct uses and
+62% of rail's. At those modes' leverage the exposure is small - a 10% error in
+the frozen part moves truck margin 1.4% and rail 1.0% - but it is the reason the
+residual is not extended to modes with thinner margins. Intermediate direct
+purchases are a Use-table row, and taking them from a nowcast Use matrix would be
+circular: Step 6b needs these margins to produce it.
 
 *Pipeline gives up more margin than its gross output* - a 2017 ratio of 1.033.
 That is carried as an index rather than treated as an error, but it means
@@ -89,7 +120,10 @@ import functools
 
 import pandas as pd
 
+from bedrock.extract.bea.BEA import map_detail_table
 from bedrock.extract.flowbyactivity import getFlowByActivity
+from bedrock.extract.iot.gdp import load_pi_detail
+from bedrock.extract.iot.io_2017 import load_2017_pce_bridge_detail_usa
 from bedrock.transform.flowbysector import getFlowBySector
 from bedrock.transform.iot.nowcast_margins import (
     COMMODITY_LEVEL,
@@ -118,6 +152,41 @@ FBS_METHOD = 'Margins_Transport_{year}'
 
 #: Annual nominal level source - gross output per BEA detail industry.
 GROSS_OUTPUT_SOURCE = 'BEA_Detail_GrossOutput_IO'
+
+#: Annual final-use source - NIPA table 2.4.5U, PCE by type of product.
+FINAL_USE_SOURCE = 'BEA_NIPA'
+FINAL_USE_TABLE = 'U20405'
+
+#: The three treatments of a mode's give-up level; see the module docstring.
+RESIDUAL = 'residual'
+FREIGHT_VOLUME = 'freight_volume'
+OUTPUT_RATIO = 'output_ratio'
+
+#: Apply :data:`MODE_CONTROL` per mode rather than one treatment to all five.
+#: The default, and the only one of the four that is conditioned for every mode.
+MIXED = 'mixed'
+
+#: Which mode gets which, and why it is the only one conditioned for it. The
+#: ratio is each mode's 2017 margin-given-up over its gross output, and the
+#: leverage is how far a 1% error in direct uses moves the margin - the number
+#: that decides whether a residual is usable.
+#:
+#: ============ ====== ======== ================================================
+#: mode         ratio  leverage treatment
+#: ============ ====== ======== ================================================
+#: truck        0.767  0.30     :data:`RESIDUAL`
+#: rail         0.862  0.16     :data:`RESIDUAL`
+#: water        0.173  4.8      :data:`FREIGHT_VOLUME` - residual turns negative
+#: air          0.026  36.9     :data:`FREIGHT_VOLUME` - residual turns negative
+#: pipeline     1.033  n/a      :data:`OUTPUT_RATIO` - no residual, and no PCE
+#: ============ ====== ======== ================================================
+MODE_CONTROL: dict[str, str] = {
+    '481000': FREIGHT_VOLUME,  # air
+    '482000': RESIDUAL,  # rail
+    '483000': FREIGHT_VOLUME,  # water
+    '484000': RESIDUAL,  # truck
+    '486000': OUTPUT_RATIO,  # pipeline
+}
 
 #: The FBS column the SCTG commodity-moved name survives in, and the crosswalk
 #: column holding its BEA 2017 detail code.
@@ -177,7 +246,7 @@ def sctg_to_commodity() -> pd.DataFrame:
         crosswalk['ActivitySourceName'] == _CROSSWALK_SOURCE,
         ['Activity', _CROSSWALK_BEA_COLUMN],
     ]
-    pairs.columns = ['sctg', COMMODITY_LEVEL]
+    pairs.columns = pd.Index(['sctg', COMMODITY_LEVEL])
     return pairs.drop_duplicates().reset_index(drop=True)
 
 
@@ -235,28 +304,211 @@ def _gross_output(years: tuple[int, ...]) -> pd.DataFrame:
     )
 
 
-def control_total_components(years: tuple[int, ...]) -> pd.DataFrame:
+@functools.cache
+def pce_final_use_index(years: tuple[int, ...]) -> pd.DataFrame:
+    """
+    Each mode's PCE relative to :data:`ANCHOR_YEAR`. Anchor column 1.
+
+    The annual final-use driver of the :data:`RESIDUAL` treatment, built from
+    two sources neither of which is annual on its own: NIPA table 2.4.5U, which
+    is annual but by PCE category, and the 2017 PCE bridge, which maps category
+    to commodity but exists for benchmark years only. Holding the bridge at 2017
+    and moving the categories is the intended use of it - the bridge supplies
+    structure, NIPA supplies the year.
+
+    The join is on the bridge's ``NIPA Line`` column, so no name matching is
+    involved. Thirteen bridge rows reach the five modes, and they reproduce the
+    2017 SUT exactly: air 129,784 million against 129,785 published, water
+    22,027, truck 11,700, rail 1,458, pipeline nil.
+
+    Where a NIPA line splits across commodities its 2017 split is held fixed,
+    the same assumption the bridge itself carries. Pipeline has no PCE at all,
+    so its index is 1 throughout and unused - :data:`MODE_CONTROL` gives it
+    :data:`OUTPUT_RATIO` for exactly that reason.
+    """
+    wanted = _as_years(years)
+    pce = pd.DataFrame({year: _pce_by_nipa_line(year) for year in wanted}).fillna(0.0)
+
+    bridge = load_2017_pce_bridge_detail_usa()
+    line = pd.to_numeric(bridge['NIPA Line'], errors='coerce')
+    bridge = bridge.assign(_line=line).dropna(subset=['_line'])
+    line_total = bridge.groupby('_line')["Purchasers' Value"].transform('sum')
+    bridge = bridge.assign(_share=bridge["Purchasers' Value"] / line_total)
+
+    modes = list(TRANSPORT_MODE_COMMODITIES)
+    rows = bridge[bridge[COMMODITY_LEVEL].isin(modes)].dropna(subset=['_share'])
+    missing = set(rows['_line']) - set(pce.index)
+    if missing:
+        raise ValueError(
+            f'the 2017 PCE bridge names NIPA lines that {FINAL_USE_TABLE} does '
+            f'not carry: {sorted(missing)}. The bridge and the NIPA table have '
+            f'come from different vintages.'
+        )
+    joined = rows.join(pce, on='_line')
+    by_mode = (
+        joined[list(wanted)]
+        .mul(joined['_share'], axis=0)
+        .groupby(joined[COMMODITY_LEVEL])
+        .sum()
+        .reindex(modes)
+        .fillna(0.0)
+    )
+    anchor = by_mode[ANCHOR_YEAR].replace(0.0, float('nan'))
+    return by_mode.div(anchor, axis=0).fillna(1.0)
+
+
+@functools.cache
+def _pce_by_nipa_line(year: int) -> pd.Series:
+    """Personal consumption expenditure per NIPA line of :data:`FINAL_USE_TABLE`."""
+    fba = getFlowByActivity(FINAL_USE_SOURCE, year, download_FBA_if_missing=False)
+    parsed = (
+        fba['Description']
+        .astype(str)
+        .str.extract(r'^(?P<table>[^:]+): \S+ - (?P<line>\d+)$')
+    )
+    parsed['FlowAmount'] = fba['FlowAmount'].to_numpy()
+    rows = parsed[parsed['table'] == FINAL_USE_TABLE].dropna()
+    return (
+        rows.assign(line=pd.to_numeric(rows['line']))
+        .groupby('line')['FlowAmount']
+        .sum()
+    )
+
+
+@functools.cache
+def mode_ton_miles(years: tuple[int, ...]) -> pd.DataFrame:
+    """
+    Freight ton-miles per mode and year, from the FBS's producing-sector column.
+
+    The counterpart of :func:`sctg_ton_miles`, summed the other way. Freight-only
+    by construction, which is the whole point for air and water: FAF knows
+    nothing about passengers, so this moves air freight without air fares.
+    """
+    frames = {}
+    for year in _as_years(years):
+        fbs = getFlowBySector(
+            FBS_METHOD.format(year=year),
+            download_FBAs_if_missing=False,
+            download_FBS_if_missing=False,
+        )
+        by_sector = fbs.groupby('SectorProducedBy')['FlowAmount'].sum()
+        by_sector.index = pd.Index(
+            [f'{sector}000' for sector in by_sector.index], name=COMMODITY_LEVEL
+        )
+        frames[year] = by_sector
+    return pd.DataFrame(frames).reindex(list(TRANSPORT_MODE_COMMODITIES))
+
+
+@functools.cache
+def mode_price_index(years: tuple[int, ...]) -> pd.DataFrame:
+    """
+    Chain-type price index per mode and year, rebased so the anchor year is 1.
+
+    ``UGO304-A``, the price companion of the ``UGO305-A`` gross output this
+    module's other level source reads. Whole-industry, so air's carries fares -
+    see the docstring warning.
+    """
+    detail = map_detail_table(load_pi_detail()).rename(
+        columns={'sector_code': COMMODITY_LEVEL}
+    )
+    indexed = detail.set_index(COMMODITY_LEVEL)
+    wanted = [str(year) for year in _as_years(years)]
+    frame = indexed.loc[list(TRANSPORT_MODE_COMMODITIES), wanted].astype(float)
+    frame.columns = pd.Index(_as_years(years))
+    return frame.div(frame[ANCHOR_YEAR], axis=0)
+
+
+def control_total_components(
+    years: tuple[int, ...], method: str = MIXED
+) -> pd.DataFrame:
     """
     The margin each transport mode gives up, per year. USD, index the five
     :data:`TRANSPORT_MODE_COMMODITIES`.
 
-    Each mode's gross output at its 2017 ratio of margin-given-up to output.
-    That ratio is what carries the nominal freight rate: truck output runs 1.57x
-    its 2017 level by 2022 against ton-miles that barely move, which is the
-    2021-22 rate surge and the reason the volume index alone will not do.
+    *method* selects the treatment: :data:`MIXED` dispatches per mode on
+    :data:`MODE_CONTROL` and is the default; the other three apply one treatment
+    to all five, which is what :func:`control_total_comparison` uses and what
+    #620 will judge against external sources.
+
+    One of three treatments per mode, dispatched on :data:`MODE_CONTROL` - see
+    the module docstring for why no single one serves all five:
+
+    ``residual``
+        ``output[t] - direct_uses[2017] x pce_index[t]``, where direct uses are
+        output less the margin given up in 2017. Truck and rail.
+    ``freight_volume``
+        ``given_up[2017] x ton_miles[t] x price_index[t]``, all three relative
+        to the anchor. Air and water.
+    ``output_ratio``
+        ``output[t] x (given_up / output)[2017]``. Pipeline.
+
+    Every treatment is an identity in the anchor year, so all five reproduce the
+    published 2017 give-up exactly and the choice affects only the movement.
 
     This is also the *negative* side of the ``TRANS`` column, commodity by
     commodity. Step 4a owns that side and derives it from commodity output; it
     is produced here so the two can be checked against each other, and because
     the positive side has to be controlled to something.
     """
+    by_method = _give_up_by_method(_as_years(years))
+    if method != MIXED:
+        if method not in by_method:
+            raise ValueError(
+                f'unknown control method {method!r}; expected one of '
+                f'{(MIXED, *by_method)}'
+            )
+        return by_method[method].rename_axis(COMMODITY_LEVEL)
+    return pd.concat(
+        [
+            by_method[MODE_CONTROL[mode]].loc[[mode]]
+            for mode in TRANSPORT_MODE_COMMODITIES
+        ]
+    ).rename_axis(COMMODITY_LEVEL)
+
+
+def _give_up_by_method(years: tuple[int, ...]) -> dict[str, pd.DataFrame]:
+    """Each single treatment applied to all five modes. USD."""
     modes = list(TRANSPORT_MODE_COMMODITIES)
     output = _gross_output(years).loc[modes]
     given_up = margins_by_commodity()['margin_given_up'].loc[modes]
-    return output.mul(given_up / output[ANCHOR_YEAR], axis=0)
+    ton_miles = mode_ton_miles(years)
+    return {
+        RESIDUAL: output.sub(
+            pce_final_use_index(years).mul(output[ANCHOR_YEAR] - given_up, axis=0)
+        ),
+        FREIGHT_VOLUME: ton_miles.div(ton_miles[ANCHOR_YEAR], axis=0)
+        .mul(mode_price_index(years))
+        .mul(given_up, axis=0),
+        OUTPUT_RATIO: output.mul(given_up / output[ANCHOR_YEAR], axis=0),
+    }
 
 
-def transport_margin_control_total(years: tuple[int, ...]) -> pd.Series:
+def control_total_comparison(years: tuple[int, ...]) -> pd.DataFrame:
+    """
+    Every control-total construction side by side, per year. USD, columns the
+    methods plus :data:`MIXED`.
+
+    The artifact for
+    `#620 <https://github.com/cornerstone-data/bedrock/issues/620>`_, which
+    settles the choice against BTS_TSA and Freight Facts & Figures rather than
+    against itself. All four are identities in the anchor year, so they differ
+    only in movement - and they differ by **12% at 2022**, from 575,587 million
+    on :data:`FREIGHT_VOLUME` to 643,443 million on :data:`MIXED`. That spread
+    is the single largest open uncertainty in the transport column, which is why
+    the method is selectable rather than settled here.
+
+    ⚠️ :data:`RESIDUAL` in this table is applied to *all five* modes, which is
+    diagnostic only - it goes negative for air from 2019 and water from 2023.
+    """
+    by_method = _give_up_by_method(_as_years(years))
+    columns = {name: frame.sum() for name, frame in by_method.items()}
+    columns[MIXED] = control_total_components(years, method=MIXED).sum()
+    return pd.DataFrame(columns).rename_axis('Year')
+
+
+def transport_margin_control_total(
+    years: tuple[int, ...], method: str = MIXED
+) -> pd.Series:
     """
     Total transport margin per year. USD, indexed by year.
 
@@ -266,7 +518,7 @@ def transport_margin_control_total(years: tuple[int, ...]) -> pd.Series:
     million received, the gap being the handful of negative ``F03000``
     inventory-timing rows on the receiving side.
     """
-    composite = control_total_components(years).sum()
+    composite = control_total_components(years, method=method).sum()
     anchor = _anchor_margins().sum()
     return composite * (anchor / composite[ANCHOR_YEAR])
 
@@ -278,7 +530,7 @@ def _anchor_margins() -> pd.Series:
     return transport[transport > 0]
 
 
-def transport_margins(years: tuple[int, ...]) -> pd.DataFrame:
+def transport_margins(years: tuple[int, ...], method: str = MIXED) -> pd.DataFrame:
     """
     Transport margin per commodity and year. USD, commodities x years.
 
@@ -303,7 +555,7 @@ def transport_margins(years: tuple[int, ...]) -> pd.DataFrame:
             f'has changed.'
         )
     shape = growth.mul(anchor, axis=0)
-    control = transport_margin_control_total(years)
+    control = transport_margin_control_total(years, method=method)
     scaled = shape.mul(control / shape.sum(), axis=1)
     return scaled.reindex(list(USA_2017_COMMODITY_CODES), fill_value=0.0).rename_axis(
         COMMODITY_LEVEL

--- a/bedrock/transform/iot/nowcast_transport_margins.py
+++ b/bedrock/transform/iot/nowcast_transport_margins.py
@@ -1,0 +1,336 @@
+"""Annual transport margin by commodity, from the 2017 anchor and FAF ton-miles.
+
+Step 4c of the nowcast build
+(``bedrock/analysis/nowcasting/margins_estimation_plan.md``), phase 2
+(`#611 <https://github.com/cornerstone-data/bedrock/issues/611>`_). Phase 1
+(:mod:`bedrock.transform.iot.nowcast_margins`) produced the 2017 structure; this
+module moves the transport column of it to an annual year. Transport is the one
+margin with an external source that reaches every commodity, so it is settled
+here rather than waiting for the trade levels in phase 3.
+
+**Shape from ton-miles, level from output.** The construction is two independent
+movements of the same 2017 column:
+
+.. code-block:: text
+
+    shape[c, t] = TRANS_2017[c] x ton-miles[group(c), t] / ton-miles[group(c), 2017]
+    TRANS[c, t] = shape[c, t] x control_total[t] / sum_c shape[c, t]
+
+Both factors are 1 in 2017, so the published 2017 column is reproduced exactly
+and BEA's own commodity allocation is inherited rather than approximated.
+
+**Why ton-miles move the allocation instead of generating it.** Allocating each
+mode's margin across commodities on its share of ton-miles - BEA's own
+construction - fits the published 2017 ``TRANS`` at a Pearson of only 0.370.
+Volume does not predict the margin: furniture costs roughly eight times more per
+ton-mile to deliver than coal, and a volume weighting discards exactly that. So
+the cost structure is taken from the 2017 table, which knows it, and ton-miles
+supply only the year-to-year movement. Ton-miles rather than tons all the same -
+tons fit at 0.099, and the manual's constant-revenue-per-ton assumption is a
+line-haul assumption where ``TRANS`` is the delivered margin.
+
+**Why a control total is needed at all.** Ton-miles are a *volume* index and
+``TRANS`` is nominal. Moving 2017 by ton-miles alone holds 2017 freight rates
+fixed, which misses the 2021-22 rate surge entirely: the volume index reaches
+1.04 by 2022 while the nominal control reaches 1.48. The level therefore comes
+from the transport industries' own gross output, held at each mode's 2017 ratio
+of margin given up to output - which is the same number the negative side of the
+``TRANS`` column carries, so the two sides stay consistent by construction.
+
+⚠️ **A better control total is designed and not yet built.** The give-up ratio
+here is frozen at 2017, which is the weak point the limitations below all come
+back to. The Supply table closes ``T016 = T013 + TRANS + TOP + SUB``, so the
+margin can instead be taken as a residual against direct uses moved by an annual
+final-use index - well conditioned for truck, rail and pipeline (leverage 0.19,
+0.14, 0.01; 96.2% of ``TRANS``) and hopeless for air and water (43.5 and 3.2),
+which would keep a freight-volume-times-price form. It is blocked on an annual
+final-use index: ``NIPA_FD`` works for 2017 only, since the later years carry
+2017 NIPA line numbers and drop most of their output. See
+``margins_estimation_plan.md`` §Agreed refinement, and #620 for the external
+validation of whichever driver wins.
+
+⚠️ **Three limitations of the construction as built.**
+
+*The 2017/2018 seam is partly methodological.* FAF's 2017 is anchored on the
+Commodity Flow Survey and 2018 onward are modelled. Aggregate ton-miles move
+only 1.9% across that seam, but the composition moves much more: 21% of 2017
+``TRANS`` sits in SCTG groups whose ton-miles jump by more than 25% in that one
+year, and the ``TRANS``-weighted mean step is 1.124 against the aggregate's
+1.019. The control total absorbs the level, so what survives is a shape shift.
+
+*Air and rail output are not freight-only.* :func:`control_total_components`
+scales each mode's whole gross output, and air's includes passengers - which is
+why air's 2017 give-up ratio is 0.026 where rail's is 0.862. Holding that ratio
+fixed makes air freight margin follow passenger air output. Air is 1.5% of
+``TRANS``, so the error is bounded; truck, at 68%, is the mode that matters and
+is close to freight-pure.
+
+*Pipeline gives up more margin than its gross output* - a 2017 ratio of 1.033.
+That is carried as an index rather than treated as an error, but it means
+pipeline margin tracks pipeline output including its crude-price component.
+
+**On BEA codes and the FBS.** :func:`sctg_ton_miles` aggregates the
+``Margins_Transport_<year>`` FBS back over its sector columns to the SCTG in
+``Flowable``, then :func:`sctg_to_commodity` joins to BEA detail through the
+crosswalk's ``Note`` column. That looks like undoing the FBS's work and is
+deliberate: the FBS resolves sectors to NAICS, so an SCTG mapped to a 3-digit
+NAICS group is spread across everything in it, while the ``Note`` column holds
+the SCTG-to-BEA-detail correspondence that was ported and corrected in #611 and
+covers all 258 ``TRANS``-receiving commodities at 100% of value. The mapping
+machinery cannot read that column until
+`#546 <https://github.com/cornerstone-data/bedrock/issues/546>`_ lands a BEA-code
+target schema; when it does, this join moves into the FBS and
+:func:`commodity_ton_miles` reads sectors instead of ``Flowable``.
+"""
+
+from __future__ import annotations
+
+import functools
+
+import pandas as pd
+
+from bedrock.extract.flowbyactivity import getFlowByActivity
+from bedrock.transform.flowbysector import getFlowBySector
+from bedrock.transform.iot.nowcast_margins import (
+    COMMODITY_LEVEL,
+    margins_by_commodity,
+)
+from bedrock.utils.config.settings import crosswalkpath
+from bedrock.utils.taxonomy.bea.v2017_commodity import USA_2017_COMMODITY_CODES
+
+#: The benchmark the whole construction is anchored on - the year of the
+#: published Margins table, and FAF 5.7.1's own base year.
+ANCHOR_YEAR = 2017
+
+#: The five BEA commodities that supply freight, and so give up the margin the
+#: goods receive. They are 100% of the ``TRANS`` suppliers; the other three FAF
+#: modes map to commodities with zero ``TRANS``.
+TRANSPORT_MODE_COMMODITIES: tuple[str, ...] = (
+    '481000',  # air
+    '482000',  # rail
+    '483000',  # water
+    '484000',  # truck
+    '486000',  # pipeline
+)
+
+#: FBS method carrying FAF ton-miles, one per year.
+FBS_METHOD = 'Margins_Transport_{year}'
+
+#: Annual nominal level source - gross output per BEA detail industry.
+GROSS_OUTPUT_SOURCE = 'BEA_Detail_GrossOutput_IO'
+
+#: The FBS column the SCTG commodity-moved name survives in, and the crosswalk
+#: column holding its BEA 2017 detail code.
+SCTG_COLUMN = 'Flowable'
+_CROSSWALK = 'NAICS_Crosswalk_FAF_Mode_and_SCTG.csv'
+_CROSSWALK_SOURCE = 'FAF_SCTG'
+_CROSSWALK_BEA_COLUMN = 'Note'
+
+#: Gross output is published in millions.
+_MILLIONS = 1e6
+
+
+def _as_years(years: tuple[int, ...] | list[int] | range) -> tuple[int, ...]:
+    """Normalise a year argument, with the anchor year always included."""
+    out = tuple(sorted({int(year) for year in years} | {ANCHOR_YEAR}))
+    return out
+
+
+@functools.cache
+def sctg_ton_miles(years: tuple[int, ...]) -> pd.DataFrame:
+    """
+    Ton-miles per SCTG commodity group and year. Index SCTG, columns years.
+
+    Aggregated over the FBS's mode and sector columns. Summing over modes is
+    also what makes the FBS's redistribution of the two non-primary modes a
+    no-op here - it moves ton-miles between modes of the same commodity, and
+    this total is taken across all of them. The mode dimension is kept in the
+    FBS for the mode-level refinement the plan records, not used here.
+    """
+    return pd.DataFrame(
+        {
+            year: getFlowBySector(
+                FBS_METHOD.format(year=year),
+                download_FBAs_if_missing=False,
+                download_FBS_if_missing=False,
+            )
+            .groupby(SCTG_COLUMN)['FlowAmount']
+            .sum()
+            for year in _as_years(years)
+        }
+    )
+
+
+@functools.cache
+def sctg_to_commodity() -> pd.DataFrame:
+    """
+    The ``(SCTG, BEA 2017 detail commodity)`` pairs, from the ported crosswalk.
+
+    Many-to-many, but barely: 254 of the 259 commodities sit in exactly one
+    SCTG. The five that do not are ``324110`` refineries (gasoline and fuel
+    oils), ``112300`` poultry (animal feed and meat/seafood), ``212310``
+    stone/sand/gravel, ``336414`` guided missiles, and ``S00402`` used and
+    secondhand goods, which spans eight. Together they are 13.5% of ``TRANS``.
+    """
+    crosswalk = pd.read_csv(crosswalkpath / _CROSSWALK, dtype=str).fillna('')
+    pairs = crosswalk.loc[
+        crosswalk['ActivitySourceName'] == _CROSSWALK_SOURCE,
+        ['Activity', _CROSSWALK_BEA_COLUMN],
+    ]
+    pairs.columns = ['sctg', COMMODITY_LEVEL]
+    return pairs.drop_duplicates().reset_index(drop=True)
+
+
+def commodity_ton_miles(years: tuple[int, ...]) -> pd.DataFrame:
+    """
+    Ton-miles per BEA commodity and year - the sum over the SCTGs it belongs to.
+
+    A commodity in more than one SCTG takes the total of them, which weights
+    each SCTG by its own ton-miles. Only the *ratio* of these figures is ever
+    used, so no share of an SCTG is allocated to a commodity and none of this
+    double-counts: two commodities in the same SCTG each carry the whole group's
+    ton-miles, and both are moved by the same growth.
+    """
+    ton_miles = sctg_ton_miles(_as_years(years))
+    missing = set(sctg_to_commodity()['sctg']) - set(ton_miles.index)
+    if missing:
+        raise ValueError(
+            f'{_CROSSWALK} names SCTGs the FBS does not carry: {sorted(missing)}. '
+            f'FAF has most likely renamed them; reconcile the crosswalk Activity '
+            f'column against the metadata workbook.'
+        )
+    return (
+        sctg_to_commodity()
+        .merge(ton_miles, left_on='sctg', right_index=True)
+        .groupby(COMMODITY_LEVEL)[list(ton_miles.columns)]
+        .sum()
+    )
+
+
+def ton_mile_growth(years: tuple[int, ...]) -> pd.DataFrame:
+    """
+    Each commodity's ton-miles relative to :data:`ANCHOR_YEAR`. Anchor column 1.
+
+    This is the whole cross-sectional content of the nowcast: how much more or
+    less freight each commodity's group moves than it did in 2017. Coal falls to
+    0.64 by 2024 and pharmaceuticals reach 1.74, which is the shape the 2017
+    table cannot know and the volume data can.
+    """
+    ton_miles = commodity_ton_miles(years)
+    return ton_miles.div(ton_miles[ANCHOR_YEAR], axis=0)
+
+
+@functools.cache
+def _gross_output(years: tuple[int, ...]) -> pd.DataFrame:
+    """Gross output per BEA detail industry and year, USD."""
+    return pd.DataFrame(
+        {
+            year: getFlowByActivity(
+                GROSS_OUTPUT_SOURCE, year, download_FBA_if_missing=False
+            )
+            .set_index('ActivityProducedBy')['FlowAmount']
+            .mul(_MILLIONS)
+            for year in _as_years(years)
+        }
+    )
+
+
+def control_total_components(years: tuple[int, ...]) -> pd.DataFrame:
+    """
+    The margin each transport mode gives up, per year. USD, index the five
+    :data:`TRANSPORT_MODE_COMMODITIES`.
+
+    Each mode's gross output at its 2017 ratio of margin-given-up to output.
+    That ratio is what carries the nominal freight rate: truck output runs 1.57x
+    its 2017 level by 2022 against ton-miles that barely move, which is the
+    2021-22 rate surge and the reason the volume index alone will not do.
+
+    This is also the *negative* side of the ``TRANS`` column, commodity by
+    commodity. Step 4a owns that side and derives it from commodity output; it
+    is produced here so the two can be checked against each other, and because
+    the positive side has to be controlled to something.
+    """
+    modes = list(TRANSPORT_MODE_COMMODITIES)
+    output = _gross_output(years).loc[modes]
+    given_up = margins_by_commodity()['margin_given_up'].loc[modes]
+    return output.mul(given_up / output[ANCHOR_YEAR], axis=0)
+
+
+def transport_margin_control_total(years: tuple[int, ...]) -> pd.Series:
+    """
+    Total transport margin per year. USD, indexed by year.
+
+    The mode composite of :func:`control_total_components`, rescaled so the
+    anchor year equals the published 2017 total exactly. The rescaling is
+    0.24%: the composite reaches 415,548 million against a published 414,559
+    million received, the gap being the handful of negative ``F03000``
+    inventory-timing rows on the receiving side.
+    """
+    composite = control_total_components(years).sum()
+    anchor = _anchor_margins().sum()
+    return composite * (anchor / composite[ANCHOR_YEAR])
+
+
+@functools.cache
+def _anchor_margins() -> pd.Series:
+    """Published 2017 transport margin per commodity, receiving side only."""
+    transport = margins_by_commodity()['transport_margins']
+    return transport[transport > 0]
+
+
+def transport_margins(years: tuple[int, ...]) -> pd.DataFrame:
+    """
+    Transport margin per commodity and year. USD, commodities x years.
+
+    The published 2017 column moved by each commodity's ton-mile growth and
+    scaled to :func:`transport_margin_control_total`. Reindexed to all 402
+    commodities, so one bearing no transport margin appears as zero rather than
+    dropping out, and the anchor-year column reproduces the published one
+    exactly.
+
+    The five transport commodities themselves stay at zero here - they *give up*
+    margin rather than receive it, and that side is
+    :func:`control_total_components`.
+    """
+    anchor = _anchor_margins()
+    growth = ton_mile_growth(years).reindex(anchor.index)
+    if growth.isna().to_numpy().any():
+        missing = sorted(growth.index[growth.isna().any(axis=1)])
+        raise ValueError(
+            f'{len(missing)} commodities receive 2017 transport margin but have '
+            f'no ton-miles to move by: {missing[:10]}. Every one of the 258 is '
+            f'covered by {_CROSSWALK}, so this means the anchor or the crosswalk '
+            f'has changed.'
+        )
+    shape = growth.mul(anchor, axis=0)
+    control = transport_margin_control_total(years)
+    scaled = shape.mul(control / shape.sum(), axis=1)
+    return scaled.reindex(list(USA_2017_COMMODITY_CODES), fill_value=0.0).rename_axis(
+        COMMODITY_LEVEL
+    )
+
+
+def movement_summary(years: tuple[int, ...]) -> pd.DataFrame:
+    """
+    The two movements side by side, per year, both indexed to the anchor at 1.
+
+    ``volume``
+        what ton-miles alone would do to the total.
+    ``level``
+        what the control total does.
+    ``repricing``
+        ``level / volume`` - the part of the change that is freight rates rather
+        than freight. It reaches 1.43 in 2022 and is the single largest thing
+        this module does; a build that dropped the control total would lose it.
+    """
+    anchor_total = _anchor_margins().sum()
+    shape = (
+        ton_mile_growth(years)
+        .reindex(_anchor_margins().index)
+        .mul(_anchor_margins(), axis=0)
+    )
+    volume = shape.sum() / anchor_total
+    level = transport_margin_control_total(years) / anchor_total
+    return pd.DataFrame(
+        {'volume': volume, 'level': level, 'repricing': level / volume}
+    ).rename_axis('Year')

--- a/bedrock/transform/margins/Margins_Transport_2017.yaml
+++ b/bedrock/transform/margins/Margins_Transport_2017.yaml
@@ -1,0 +1,14 @@
+# FAF ton-miles by mode and commodity moved, 2017. Nowcast Step 4c phase 2
+# (#611) - the weights that move each commodity's published 2017 transport
+# margin. See Margins_Transport_source.yaml for what the activity sets do and
+# why, and margins_estimation_plan.md section Transportation for the
+# construction.
+
+!include:BEA_detail_target.yaml
+year: &year 2017
+target_naics_year: 2017
+geoscale: national
+
+source_names:
+  BTS_FAF: !include:Margins_Transport_source.yaml:BTS_FAF
+    year: *year

--- a/bedrock/transform/margins/Margins_Transport_2018.yaml
+++ b/bedrock/transform/margins/Margins_Transport_2018.yaml
@@ -1,0 +1,14 @@
+# FAF ton-miles by mode and commodity moved, 2018. Nowcast Step 4c phase 2
+# (#611) - the weights that move each commodity's published 2017 transport
+# margin. See Margins_Transport_source.yaml for what the activity sets do and
+# why, and margins_estimation_plan.md section Transportation for the
+# construction.
+
+!include:BEA_detail_target.yaml
+year: &year 2018
+target_naics_year: 2017
+geoscale: national
+
+source_names:
+  BTS_FAF: !include:Margins_Transport_source.yaml:BTS_FAF
+    year: *year

--- a/bedrock/transform/margins/Margins_Transport_2019.yaml
+++ b/bedrock/transform/margins/Margins_Transport_2019.yaml
@@ -1,0 +1,14 @@
+# FAF ton-miles by mode and commodity moved, 2019. Nowcast Step 4c phase 2
+# (#611) - the weights that move each commodity's published 2017 transport
+# margin. See Margins_Transport_source.yaml for what the activity sets do and
+# why, and margins_estimation_plan.md section Transportation for the
+# construction.
+
+!include:BEA_detail_target.yaml
+year: &year 2019
+target_naics_year: 2017
+geoscale: national
+
+source_names:
+  BTS_FAF: !include:Margins_Transport_source.yaml:BTS_FAF
+    year: *year

--- a/bedrock/transform/margins/Margins_Transport_2020.yaml
+++ b/bedrock/transform/margins/Margins_Transport_2020.yaml
@@ -1,0 +1,14 @@
+# FAF ton-miles by mode and commodity moved, 2020. Nowcast Step 4c phase 2
+# (#611) - the weights that move each commodity's published 2017 transport
+# margin. See Margins_Transport_source.yaml for what the activity sets do and
+# why, and margins_estimation_plan.md section Transportation for the
+# construction.
+
+!include:BEA_detail_target.yaml
+year: &year 2020
+target_naics_year: 2017
+geoscale: national
+
+source_names:
+  BTS_FAF: !include:Margins_Transport_source.yaml:BTS_FAF
+    year: *year

--- a/bedrock/transform/margins/Margins_Transport_2021.yaml
+++ b/bedrock/transform/margins/Margins_Transport_2021.yaml
@@ -1,0 +1,14 @@
+# FAF ton-miles by mode and commodity moved, 2021. Nowcast Step 4c phase 2
+# (#611) - the weights that move each commodity's published 2017 transport
+# margin. See Margins_Transport_source.yaml for what the activity sets do and
+# why, and margins_estimation_plan.md section Transportation for the
+# construction.
+
+!include:BEA_detail_target.yaml
+year: &year 2021
+target_naics_year: 2017
+geoscale: national
+
+source_names:
+  BTS_FAF: !include:Margins_Transport_source.yaml:BTS_FAF
+    year: *year

--- a/bedrock/transform/margins/Margins_Transport_2022.yaml
+++ b/bedrock/transform/margins/Margins_Transport_2022.yaml
@@ -1,0 +1,14 @@
+# FAF ton-miles by mode and commodity moved, 2022. Nowcast Step 4c phase 2
+# (#611) - the weights that move each commodity's published 2017 transport
+# margin. See Margins_Transport_source.yaml for what the activity sets do and
+# why, and margins_estimation_plan.md section Transportation for the
+# construction.
+
+!include:BEA_detail_target.yaml
+year: &year 2022
+target_naics_year: 2017
+geoscale: national
+
+source_names:
+  BTS_FAF: !include:Margins_Transport_source.yaml:BTS_FAF
+    year: *year

--- a/bedrock/transform/margins/Margins_Transport_2023.yaml
+++ b/bedrock/transform/margins/Margins_Transport_2023.yaml
@@ -1,0 +1,14 @@
+# FAF ton-miles by mode and commodity moved, 2023. Nowcast Step 4c phase 2
+# (#611) - the weights that move each commodity's published 2017 transport
+# margin. See Margins_Transport_source.yaml for what the activity sets do and
+# why, and margins_estimation_plan.md section Transportation for the
+# construction.
+
+!include:BEA_detail_target.yaml
+year: &year 2023
+target_naics_year: 2017
+geoscale: national
+
+source_names:
+  BTS_FAF: !include:Margins_Transport_source.yaml:BTS_FAF
+    year: *year

--- a/bedrock/transform/margins/Margins_Transport_2024.yaml
+++ b/bedrock/transform/margins/Margins_Transport_2024.yaml
@@ -1,0 +1,14 @@
+# FAF ton-miles by mode and commodity moved, 2024. Nowcast Step 4c phase 2
+# (#611) - the weights that move each commodity's published 2017 transport
+# margin. See Margins_Transport_source.yaml for what the activity sets do and
+# why, and margins_estimation_plan.md section Transportation for the
+# construction.
+
+!include:BEA_detail_target.yaml
+year: &year 2024
+target_naics_year: 2017
+geoscale: national
+
+source_names:
+  BTS_FAF: !include:Margins_Transport_source.yaml:BTS_FAF
+    year: *year

--- a/bedrock/transform/margins/Margins_Transport_source.yaml
+++ b/bedrock/transform/margins/Margins_Transport_source.yaml
@@ -1,0 +1,75 @@
+# Shared source block for the Margins_Transport_<year> methods.
+#
+# Not a runnable method - the per-year files include this and set the year. Kept
+# in one place because the eight years differ only in that number, and the
+# activity sets carry enough reasoning that eight copies of it would drift.
+#
+# Step 4c phase 2 of the nowcast build (#611). FAF ton-miles by mode and
+# commodity moved: the transport mode produces the freight service and so lands
+# in SectorProducedBy, while the commodity moved rides in Flowable, which is what
+# carries ton-miles to the commodities that receive the margin.
+#
+# Ton-miles rather than tons: cost scales with distance, and against the
+# published 2017 TRANS column ton-miles fit at 0.370 where tons fit at 0.099.
+# See margins_estimation_plan.md §Transportation.
+#
+# Ported from flowsa's margins branch with three departures, all forced by the
+# data rather than chosen:
+#
+# - FAF's published mode names. The flowsa file spells three of the eight
+#   differently ("Air (includes truck-air)", "Multiple Modes and Mail", "Other
+#   and Unknown"), and a misspelled name selects nothing - the activity set
+#   would come back empty rather than raise.
+# - "No domestic mode" is in neither activity set. It maps to no sector by
+#   design: it is crude petroleum transferred ship-to-refinery at the port,
+#   which uses no domestic freight and so bears no transport margin.
+# - BEA_detail_target rather than a bare industry_spec override, so the ton-mile
+#   sectors line up one-to-one with BEA detail.
+
+BTS_FAF:
+  geoscale: national
+  # the commodity moved is published as a flow, not an activity; promote it to
+  # ActivityConsumedBy so the crosswalk can map it
+  clean_fba_before_activity_sets: !script_function:BTS_FAF move_flow_to_ACB
+  selection_fields:
+    Unit: ton-miles
+  activity_sets:
+
+    direct:
+      selection_fields:
+        ActivityProducedBy:
+          - Truck
+          - Rail
+          - Water
+          - Air (include truck-air)
+          - Pipeline
+      activity_to_sector_mapping: FAF_Mode_and_SCTG
+      attribution_method: equal
+
+    # These two modes have no single mode to book against, and both map to
+    # commodities with zero TRANS - postal and courier freight is bought as a
+    # direct service rather than embedded as margin. Split them across the
+    # primary modes carrying the same commodity. This is a no-op for the
+    # per-commodity total that the growth factors use, and matters only for the
+    # mode dimension, which the plan keeps for the mode-level refinement.
+    proportional:
+      selection_fields:
+        ActivityProducedBy:
+          - Multiple modes & mail
+          - Other and unknown
+      primary_action_type: Produced
+      activity_to_sector_mapping: FAF_Mode_and_SCTG
+      attribution_method: proportional
+      attribute_on: [Flowable, PrimarySector] # to align SCTG codes
+      attribution_source:
+        BTS_FAF:
+          selection_fields:
+            Unit: ton-miles
+            ActivityProducedBy:
+              - Truck
+              - Rail
+              - Water
+              - Air (include truck-air)
+              - Pipeline
+          geoscale: national
+          activity_to_sector_mapping: FAF_Mode_and_SCTG

--- a/bedrock/utils/config/source_catalog.yaml
+++ b/bedrock/utils/config/source_catalog.yaml
@@ -150,6 +150,12 @@ BLS_QCEW:
 BTS_Airlines:
   data_format: FBA
   activity_schema: None
+BTS_FAF:
+  data_format: FBA
+  class:
+    - Other
+  activity_schema: None
+  sector_hierarchy: "flat"
 BTS_TSA:
   data_format: FBA
   activity_schema: None

--- a/bedrock/utils/mapping/activitytosectormapping/NAICS_Crosswalk_FAF_Mode_and_SCTG.csv
+++ b/bedrock/utils/mapping/activitytosectormapping/NAICS_Crosswalk_FAF_Mode_and_SCTG.csv
@@ -2,325 +2,325 @@ ActivitySourceName,Activity,Activity_Description,SectorSourceName,Sector,SectorT
 FAF_Mode,Truck,Includes private and for-hire trucks. Does not include truck that is part of Multiple Modes and Mail or truck moves in conjunction with domestic air cargo.,NAICS_2017_Code,484,,
 FAF_Mode,Rail,Includes any common carrier or private railroad. Does not include rail that is part of Multiple Modes and Mail.,NAICS_2017_Code,482,,
 FAF_Mode,Water,"Includes shallow draft, deep draft, Great Lakes, and intra-port shipments. Does not include water that is part of Multiple Modes and Mail",NAICS_2017_Code,483,,
-FAF_Mode,Air (includes truck-air),"Includes shipments move by air or a combination of truck and air in commercial or private aircraft. Includes air freight and air express. In the case of imports and exports by air, domestic moves by ground to and from the port of entry or exit are categorized with Truck.",NAICS_2017_Code,481,,
-FAF_Mode,Multiple Modes and Mail,"Includes shipments by multiple modes and by parcel delivery services, U.S. Postal Service, or couriers (capped at 150 pounds). This category is not limited to containerized or trailer-on-flatcar shipments.",NAICS_2017_Code,481,,
-FAF_Mode,Multiple Modes and Mail,"Includes shipments by multiple modes and by parcel delivery services, U.S. Postal Service, or couriers (capped at 150 pounds). This category is not limited to containerized or trailer-on-flatcar shipments.",NAICS_2017_Code,482,,
-FAF_Mode,Multiple Modes and Mail,"Includes shipments by multiple modes and by parcel delivery services, U.S. Postal Service, or couriers (capped at 150 pounds). This category is not limited to containerized or trailer-on-flatcar shipments.",NAICS_2017_Code,483,,
-FAF_Mode,Multiple Modes and Mail,"Includes shipments by multiple modes and by parcel delivery services, U.S. Postal Service, or couriers (capped at 150 pounds). This category is not limited to containerized or trailer-on-flatcar shipments.",NAICS_2017_Code,484,,
+FAF_Mode,Air (include truck-air),"Includes shipments move by air or a combination of truck and air in commercial or private aircraft. Includes air freight and air express. In the case of imports and exports by air, domestic moves by ground to and from the port of entry or exit are categorized with Truck.",NAICS_2017_Code,481,,
+FAF_Mode,Multiple modes & mail,"Includes shipments by multiple modes and by parcel delivery services, U.S. Postal Service, or couriers (capped at 150 pounds). This category is not limited to containerized or trailer-on-flatcar shipments.",NAICS_2017_Code,481,,
+FAF_Mode,Multiple modes & mail,"Includes shipments by multiple modes and by parcel delivery services, U.S. Postal Service, or couriers (capped at 150 pounds). This category is not limited to containerized or trailer-on-flatcar shipments.",NAICS_2017_Code,482,,
+FAF_Mode,Multiple modes & mail,"Includes shipments by multiple modes and by parcel delivery services, U.S. Postal Service, or couriers (capped at 150 pounds). This category is not limited to containerized or trailer-on-flatcar shipments.",NAICS_2017_Code,483,,
+FAF_Mode,Multiple modes & mail,"Includes shipments by multiple modes and by parcel delivery services, U.S. Postal Service, or couriers (capped at 150 pounds). This category is not limited to containerized or trailer-on-flatcar shipments.",NAICS_2017_Code,484,,
 FAF_Mode,Pipeline,"Includes crude petroleum, natural gas, and product pipelines. Note: Does include flows from offshore wells to land, which are counted as Water moves by the U.S. Army Corps of Engineers. Does not include pipeline that is part of Multiple Modes and Mail",NAICS_2017_Code,486,,
-FAF_Mode,Other and Unknown,"Includes movements not elsewhere classified such as flyaway aircraft, and shipments for which the mode cannot be determined.",NAICS_2017_Code,481,,
-FAF_Mode,Other and Unknown,"Includes movements not elsewhere classified such as flyaway aircraft, and shipments for which the mode cannot be determined.",NAICS_2017_Code,482,,
-FAF_Mode,Other and Unknown,"Includes movements not elsewhere classified such as flyaway aircraft, and shipments for which the mode cannot be determined.",NAICS_2017_Code,483,,
-FAF_Mode,Other and Unknown,"Includes movements not elsewhere classified such as flyaway aircraft, and shipments for which the mode cannot be determined.",NAICS_2017_Code,484,,
-FAF_Mode,No Domestic Mode,"Includes shipments that have an international mode, but no domestic mode and is limited to import shipments of crude petroleum transferred directly from inbound ships to a U.S. refinery at the zone of entry. This classification enables a proper accounting of flows that do not utilize any domestic transportation network.",NAICS_2017_Code,,,
-FAF_SCTG,Animals and Fish (live),,NAICS_2017_Code,112,,1121A0
-FAF_SCTG,Animals and Fish (live),,NAICS_2017_Code,112,,112A00
-FAF_SCTG,Animals and Fish (live),,NAICS_2017_Code,114,,114000
-FAF_SCTG,Cereal Grains (includes seed),,NAICS_2017_Code,11113,,1111B0
-FAF_SCTG,Cereal Grains (includes seed),,NAICS_2017_Code,11114,,1111B0
-FAF_SCTG,Cereal Grains (includes seed),,NAICS_2017_Code,11115,,1111B0
-FAF_SCTG,Cereal Grains (includes seed),,NAICS_2017_Code,11116,,1111B0
-FAF_SCTG,Cereal Grains (includes seed),,NAICS_2017_Code,11119,,1111B0
-FAF_SCTG,"Agricultural Products (excludes Animal Feed, Cereal Grains, and Forage Products)",,NAICS_2017_Code,11111,,1111A0
-FAF_SCTG,"Agricultural Products (excludes Animal Feed, Cereal Grains, and Forage Products)",,NAICS_2017_Code,11112,,1111A0
-FAF_SCTG,"Agricultural Products (excludes Animal Feed, Cereal Grains, and Forage Products)",,NAICS_2017_Code,1112,,111200
-FAF_SCTG,"Agricultural Products (excludes Animal Feed, Cereal Grains, and Forage Products)",,NAICS_2017_Code,1113,,111300
-FAF_SCTG,"Agricultural Products (excludes Animal Feed, Cereal Grains, and Forage Products)",,NAICS_2017_Code,1114,,111400
-FAF_SCTG,"Agricultural Products (excludes Animal Feed, Cereal Grains, and Forage Products)",,NAICS_2017_Code,1119,,111900
-FAF_SCTG,"Animal Feed, Eggs, Honey, and Other Products of Animal Origin",,NAICS_2017_Code,1123,,112300
-FAF_SCTG,"Animal Feed, Eggs, Honey, and Other Products of Animal Origin",,NAICS_2017_Code,311111,,311111
-FAF_SCTG,"Animal Feed, Eggs, Honey, and Other Products of Animal Origin",,NAICS_2017_Code,311119,,311119
-FAF_SCTG,"Meat, Poultry, Fish, Seafood, and Their Preparations",,NAICS_2017_Code,1123,,112300
-FAF_SCTG,"Meat, Poultry, Fish, Seafood, and Their Preparations",,NAICS_2017_Code,311615,,311615
-FAF_SCTG,"Meat, Poultry, Fish, Seafood, and Their Preparations",,NAICS_2017_Code,311611,,31161A
-FAF_SCTG,"Meat, Poultry, Fish, Seafood, and Their Preparations",,NAICS_2017_Code,311612,,31161A
-FAF_SCTG,"Meat, Poultry, Fish, Seafood, and Their Preparations",,NAICS_2017_Code,311613,,31161A
-FAF_SCTG,"Meat, Poultry, Fish, Seafood, and Their Preparations",,NAICS_2017_Code,3117,,311700
-FAF_SCTG,"Milled Grain Products and Preparations, and Bakery Products",,NAICS_2017_Code,11212,,112120
-FAF_SCTG,"Milled Grain Products and Preparations, and Bakery Products",,NAICS_2017_Code,31121,,311210
-FAF_SCTG,"Milled Grain Products and Preparations, and Bakery Products",,NAICS_2017_Code,311221,,311221
-FAF_SCTG,"Milled Grain Products and Preparations, and Bakery Products",,NAICS_2017_Code,31123,,311230
-FAF_SCTG,"Milled Grain Products and Preparations, and Bakery Products",,NAICS_2017_Code,31181,,311810
-FAF_SCTG,"Milled Grain Products and Preparations, and Bakery Products",,NAICS_2017_Code,31182,,3118A0
-FAF_SCTG,"Milled Grain Products and Preparations, and Bakery Products",,NAICS_2017_Code,31183,,3118A0
-FAF_SCTG,"Other Prepared Foodstuffs, Fats and Oils",,NAICS_2017_Code,311224,,311224
-FAF_SCTG,"Other Prepared Foodstuffs, Fats and Oils",,NAICS_2017_Code,311225,,311225
-FAF_SCTG,"Other Prepared Foodstuffs, Fats and Oils",,NAICS_2017_Code,3113,,311300
-FAF_SCTG,"Other Prepared Foodstuffs, Fats and Oils",,NAICS_2017_Code,31141,,311410
-FAF_SCTG,"Other Prepared Foodstuffs, Fats and Oils",,NAICS_2017_Code,31142,,311420
-FAF_SCTG,"Other Prepared Foodstuffs, Fats and Oils",,NAICS_2017_Code,311513,,311513
-FAF_SCTG,"Other Prepared Foodstuffs, Fats and Oils",,NAICS_2017_Code,311514,,311514
-FAF_SCTG,"Other Prepared Foodstuffs, Fats and Oils",,NAICS_2017_Code,311511,,31151A
-FAF_SCTG,"Other Prepared Foodstuffs, Fats and Oils",,NAICS_2017_Code,311512,,31151A
-FAF_SCTG,"Other Prepared Foodstuffs, Fats and Oils",,NAICS_2017_Code,31152,,311520
-FAF_SCTG,"Other Prepared Foodstuffs, Fats and Oils",,NAICS_2017_Code,31191,,311910
-FAF_SCTG,"Other Prepared Foodstuffs, Fats and Oils",,NAICS_2017_Code,31192,,311920
-FAF_SCTG,"Other Prepared Foodstuffs, Fats and Oils",,NAICS_2017_Code,31193,,311930
-FAF_SCTG,"Other Prepared Foodstuffs, Fats and Oils",,NAICS_2017_Code,31194,,311940
-FAF_SCTG,"Other Prepared Foodstuffs, Fats and Oils",,NAICS_2017_Code,31199,,311990
-FAF_SCTG,"Other Prepared Foodstuffs, Fats and Oils",,NAICS_2017_Code,31211,,312110
-FAF_SCTG,Alcoholic Beverages and Denatured Alcohol,,NAICS_2017_Code,31212,,312120
-FAF_SCTG,Alcoholic Beverages and Denatured Alcohol,,NAICS_2017_Code,31213,,312130
-FAF_SCTG,Alcoholic Beverages and Denatured Alcohol,,NAICS_2017_Code,31214,,312140
-FAF_SCTG,Tobacco Products,,NAICS_2017_Code,3122,,312200
-FAF_SCTG,Monumental or Building Stone,,NAICS_2017_Code,21231,,212310
-FAF_SCTG,Natural Sands,,NAICS_2017_Code,21231,,212310
-FAF_SCTG,Gravel and Crushed Stone (excludes Dolomite and Slate),,NAICS_2017_Code,21231,,212310
-FAF_SCTG,Other Non-Metallic Minerals not elsewhere classified,,NAICS_2017_Code,21232,,2123A0
-FAF_SCTG,Other Non-Metallic Minerals not elsewhere classified,,NAICS_2017_Code,21239,,2123A0
-FAF_SCTG,Metallic Ores and Concentrates,,NAICS_2017_Code,21223,,212230
-FAF_SCTG,Metallic Ores and Concentrates,,NAICS_2017_Code,21222,,2122A0
-FAF_SCTG,Metallic Ores and Concentrates,,NAICS_2017_Code,21229,,2122A0
-FAF_SCTG,Coal,,NAICS_2017_Code,2121,,212100
-FAF_SCTG,Crude Petroleum,,NAICS_2017_Code,211,,211000
-FAF_SCTG,"Gasoline, Aviation Turbine Fuel, and Ethanol (includes Kerosene, and Fuel Alcohols)",,NAICS_2017_Code,32411,,324110
-FAF_SCTG,"Gasoline, Aviation Turbine Fuel, and Ethanol (includes Kerosene, and Fuel Alcohols)",,NAICS_2017_Code,324121,,324121
-FAF_SCTG,"Gasoline, Aviation Turbine Fuel, and Ethanol (includes Kerosene, and Fuel Alcohols)",,NAICS_2017_Code,324122,,324122
-FAF_SCTG,"Fuel Oils (includes Diesel, Bunker C, and Biodiesel)",,NAICS_2017_Code,32411,,324110
-FAF_SCTG,"Other Coal and Petroleum Products, not elsewhere classified",,NAICS_2017_Code,32419,,324190
-FAF_SCTG,Basic Chemicals,,NAICS_2017_Code,32511,,325110
-FAF_SCTG,Basic Chemicals,,NAICS_2017_Code,32512,,325120
-FAF_SCTG,Basic Chemicals,,NAICS_2017_Code,32513,,325130
-FAF_SCTG,Basic Chemicals,,NAICS_2017_Code,32518,,325180
-FAF_SCTG,Basic Chemicals,,NAICS_2017_Code,32519,,325190
-FAF_SCTG,Pharmaceutical Products,,NAICS_2017_Code,325411,,325411
-FAF_SCTG,Pharmaceutical Products,,NAICS_2017_Code,325412,,325412
-FAF_SCTG,Pharmaceutical Products,,NAICS_2017_Code,325413,,325413
-FAF_SCTG,Pharmaceutical Products,,NAICS_2017_Code,325414,,325414
-FAF_SCTG,Fertilizers,,NAICS_2017_Code,32531,,325310
-FAF_SCTG,Other Chemical Products and Preparations,,NAICS_2017_Code,32532,,325320
-FAF_SCTG,Other Chemical Products and Preparations,,NAICS_2017_Code,32551,,325510
-FAF_SCTG,Other Chemical Products and Preparations,,NAICS_2017_Code,32552,,325520
-FAF_SCTG,Other Chemical Products and Preparations,,NAICS_2017_Code,32561,,325610
-FAF_SCTG,Other Chemical Products and Preparations,,NAICS_2017_Code,32562,,325620
-FAF_SCTG,Other Chemical Products and Preparations,,NAICS_2017_Code,32591,,325910
-FAF_SCTG,Other Chemical Products and Preparations,,NAICS_2017_Code,32592,,3259A0
-FAF_SCTG,Other Chemical Products and Preparations,,NAICS_2017_Code,32599,,3259A0
-FAF_SCTG,Plastics and Rubber,,NAICS_2017_Code,325211,,325211
-FAF_SCTG,Plastics and Rubber,,NAICS_2017_Code,325212,,3252A0
-FAF_SCTG,Plastics and Rubber,,NAICS_2017_Code,32522,,3252A0
-FAF_SCTG,Plastics and Rubber,,NAICS_2017_Code,32611,,326110
-FAF_SCTG,Plastics and Rubber,,NAICS_2017_Code,32612,,326120
-FAF_SCTG,Plastics and Rubber,,NAICS_2017_Code,32613,,326130
-FAF_SCTG,Plastics and Rubber,,NAICS_2017_Code,32614,,326140
-FAF_SCTG,Plastics and Rubber,,NAICS_2017_Code,32615,,326150
-FAF_SCTG,Plastics and Rubber,,NAICS_2017_Code,32616,,326160
-FAF_SCTG,Plastics and Rubber,,NAICS_2017_Code,32619,,326190
-FAF_SCTG,Plastics and Rubber,,NAICS_2017_Code,32621,,326210
-FAF_SCTG,Plastics and Rubber,,NAICS_2017_Code,32622,,326220
-FAF_SCTG,Plastics and Rubber,,NAICS_2017_Code,32629,,326290
-FAF_SCTG,Logs and Other Wood in the Rough,,NAICS_2017_Code,113,,113000
-FAF_SCTG,Wood Products,,NAICS_2017_Code,3211,,321100
-FAF_SCTG,Wood Products,,NAICS_2017_Code,3212,,321200
-FAF_SCTG,Wood Products,,NAICS_2017_Code,32191,,321910
-FAF_SCTG,Wood Products,,NAICS_2017_Code,32192,,3219A0
-FAF_SCTG,Wood Products,,NAICS_2017_Code,32199,,3219A0
-FAF_SCTG,"Pulp, Newsprint, Paper, and Paperboard",,NAICS_2017_Code,32211,,322110
-FAF_SCTG,"Pulp, Newsprint, Paper, and Paperboard",,NAICS_2017_Code,32212,,322120
-FAF_SCTG,"Pulp, Newsprint, Paper, and Paperboard",,NAICS_2017_Code,32213,,322130
-FAF_SCTG,Paper or Paperboard Articles,,NAICS_2017_Code,32221,,322210
-FAF_SCTG,Paper or Paperboard Articles,,NAICS_2017_Code,32222,,322220
-FAF_SCTG,Paper or Paperboard Articles,,NAICS_2017_Code,32223,,322230
-FAF_SCTG,Paper or Paperboard Articles,,NAICS_2017_Code,322291,,322291
-FAF_SCTG,Paper or Paperboard Articles,,NAICS_2017_Code,322299,,322299
-FAF_SCTG,Printed Products,,NAICS_2017_Code,323111,,323110
-FAF_SCTG,Printed Products,,NAICS_2017_Code,323113,,323110
-FAF_SCTG,Printed Products,,NAICS_2017_Code,323117,,323110
-FAF_SCTG,Printed Products,,NAICS_2017_Code,323120,,323120
-FAF_SCTG,Printed Products,,NAICS_2017_Code,51111,,511110
-FAF_SCTG,Printed Products,,NAICS_2017_Code,51112,,511120
-FAF_SCTG,Printed Products,,NAICS_2017_Code,51113,,511130
-FAF_SCTG,Printed Products,,NAICS_2017_Code,51114,,5111A0
-FAF_SCTG,Printed Products,,NAICS_2017_Code,51119,,5111A0
-FAF_SCTG,Printed Products,,NAICS_2017_Code,S00402,,S00402
-FAF_SCTG,"Textiles, Leather, and Articles of Textiles or Leather",,NAICS_2017_Code,3131,,313100
-FAF_SCTG,"Textiles, Leather, and Articles of Textiles or Leather",,NAICS_2017_Code,3132,,313200
-FAF_SCTG,"Textiles, Leather, and Articles of Textiles or Leather",,NAICS_2017_Code,3133,,313300
-FAF_SCTG,"Textiles, Leather, and Articles of Textiles or Leather",,NAICS_2017_Code,31411,,314110
-FAF_SCTG,"Textiles, Leather, and Articles of Textiles or Leather",,NAICS_2017_Code,31412,,314120
-FAF_SCTG,"Textiles, Leather, and Articles of Textiles or Leather",,NAICS_2017_Code,3149,,314900
-FAF_SCTG,"Textiles, Leather, and Articles of Textiles or Leather",,NAICS_2017_Code,315,,315000
-FAF_SCTG,"Textiles, Leather, and Articles of Textiles or Leather",,NAICS_2017_Code,316,,316000
-FAF_SCTG,"Textiles, Leather, and Articles of Textiles or Leather",,NAICS_2017_Code,S00402,,S00402
-FAF_SCTG,Non-Metallic Mineral Products,,NAICS_2017_Code,3271,,327100
-FAF_SCTG,Non-Metallic Mineral Products,,NAICS_2017_Code,3272,,327200
-FAF_SCTG,Non-Metallic Mineral Products,,NAICS_2017_Code,32731,,327310
-FAF_SCTG,Non-Metallic Mineral Products,,NAICS_2017_Code,32732,,327320
-FAF_SCTG,Non-Metallic Mineral Products,,NAICS_2017_Code,32733,,327330
-FAF_SCTG,Non-Metallic Mineral Products,,NAICS_2017_Code,32739,,327390
-FAF_SCTG,Non-Metallic Mineral Products,,NAICS_2017_Code,3274,,327400
-FAF_SCTG,Non-Metallic Mineral Products,,NAICS_2017_Code,32791,,327910
-FAF_SCTG,Non-Metallic Mineral Products,,NAICS_2017_Code,327991,,327991
-FAF_SCTG,Non-Metallic Mineral Products,,NAICS_2017_Code,327992,,327992
-FAF_SCTG,Non-Metallic Mineral Products,,NAICS_2017_Code,327993,,327993
-FAF_SCTG,Non-Metallic Mineral Products,,NAICS_2017_Code,327999,,327999
-FAF_SCTG,Non-Metallic Mineral Products,,NAICS_2017_Code,332119,,332119
-FAF_SCTG,Base Metal in Primary or Semi-Finished Forms and in Finished Basic Shapes,,NAICS_2017_Code,33111,,331110
-FAF_SCTG,Base Metal in Primary or Semi-Finished Forms and in Finished Basic Shapes,,NAICS_2017_Code,3312,,331200
-FAF_SCTG,Base Metal in Primary or Semi-Finished Forms and in Finished Basic Shapes,,NAICS_2017_Code,331313,,331313
-FAF_SCTG,Base Metal in Primary or Semi-Finished Forms and in Finished Basic Shapes,,NAICS_2017_Code,331314,,33131B
-FAF_SCTG,Base Metal in Primary or Semi-Finished Forms and in Finished Basic Shapes,,NAICS_2017_Code,331315,,33131B
-FAF_SCTG,Base Metal in Primary or Semi-Finished Forms and in Finished Basic Shapes,,NAICS_2017_Code,331318,,33131B
-FAF_SCTG,Base Metal in Primary or Semi-Finished Forms and in Finished Basic Shapes,,NAICS_2017_Code,33141,,331410
-FAF_SCTG,Base Metal in Primary or Semi-Finished Forms and in Finished Basic Shapes,,NAICS_2017_Code,33142,,331420
-FAF_SCTG,Base Metal in Primary or Semi-Finished Forms and in Finished Basic Shapes,,NAICS_2017_Code,33149,,331490
-FAF_SCTG,Base Metal in Primary or Semi-Finished Forms and in Finished Basic Shapes,,NAICS_2017_Code,33151,,331510
-FAF_SCTG,Base Metal in Primary or Semi-Finished Forms and in Finished Basic Shapes,,NAICS_2017_Code,33152,,331520
-FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,332114,,332114
-FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,332111,,33211A
-FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,332112,,33211A
-FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,332117,,33211A
-FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,3322,,332200
-FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,33231,,332310
-FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,33232,,332320
-FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,33241,,332410
-FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,33242,,332420
-FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,33243,,332430
-FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,3325,,332500
-FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,3326,,332600
-FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,33271,,332710
-FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,33272,,332720
-FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,3328,,332800
-FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,332913,,332913
-FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,332911,,33291A
-FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,332912,,33291A
-FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,332919,,33291A
-FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,332991,,332991
-FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,332996,,332996
-FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,332992,,33299A
-FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,332993,,33299A
-FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,332994,,33299A
-FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,332999,,332999
-FAF_SCTG,Machinery,,NAICS_2017_Code,333111,,333111
-FAF_SCTG,Machinery,,NAICS_2017_Code,333112,,333112
-FAF_SCTG,Machinery,,NAICS_2017_Code,333120,,333120
-FAF_SCTG,Machinery,,NAICS_2017_Code,33313,,333130
-FAF_SCTG,Machinery,,NAICS_2017_Code,333242,,333242
-FAF_SCTG,Machinery,,NAICS_2017_Code,333241,,33329A
-FAF_SCTG,Machinery,,NAICS_2017_Code,333243,,33329A
-FAF_SCTG,Machinery,,NAICS_2017_Code,333244,,33329A
-FAF_SCTG,Machinery,,NAICS_2017_Code,333249,,33329A
-FAF_SCTG,Machinery,,NAICS_2017_Code,333314,,333314
-FAF_SCTG,Machinery,,NAICS_2017_Code,333316,,333316
-FAF_SCTG,Machinery,,NAICS_2017_Code,333318,,333318
-FAF_SCTG,Machinery,,NAICS_2017_Code,333413,,333413
-FAF_SCTG,Machinery,,NAICS_2017_Code,333414,,333414
-FAF_SCTG,Machinery,,NAICS_2017_Code,333415,,333415
-FAF_SCTG,Machinery,,NAICS_2017_Code,333511,,333511
-FAF_SCTG,Machinery,,NAICS_2017_Code,333514,,333514
-FAF_SCTG,Machinery,,NAICS_2017_Code,333517,,333517
-FAF_SCTG,Machinery,,NAICS_2017_Code,333515,,33351B
-FAF_SCTG,Machinery,,NAICS_2017_Code,333519,,33351B
-FAF_SCTG,Machinery,,NAICS_2017_Code,333611,,333611
-FAF_SCTG,Machinery,,NAICS_2017_Code,333612,,333612
-FAF_SCTG,Machinery,,NAICS_2017_Code,333613,,333613
-FAF_SCTG,Machinery,,NAICS_2017_Code,333618,,333618
-FAF_SCTG,Machinery,,NAICS_2017_Code,333912,,333912
-FAF_SCTG,Machinery,,NAICS_2017_Code,333914,,333914
-FAF_SCTG,Machinery,,NAICS_2017_Code,33392,,333920
-FAF_SCTG,Machinery,,NAICS_2017_Code,333991,,333991
-FAF_SCTG,Machinery,,NAICS_2017_Code,333993,,333993
-FAF_SCTG,Machinery,,NAICS_2017_Code,333994,,333994
-FAF_SCTG,Machinery,,NAICS_2017_Code,333992,,33399A
-FAF_SCTG,Machinery,,NAICS_2017_Code,333997,,33399A
-FAF_SCTG,Machinery,,NAICS_2017_Code,333999,,33399A
-FAF_SCTG,Machinery,,NAICS_2017_Code,333995,,33399B
-FAF_SCTG,Machinery,,NAICS_2017_Code,333996,,33399B
-FAF_SCTG,Machinery,,NAICS_2017_Code,33631,,336310
-FAF_SCTG,Machinery,,NAICS_2017_Code,33635,,336350
-FAF_SCTG,Machinery,,NAICS_2017_Code,336412,,336412
-FAF_SCTG,Machinery,,NAICS_2017_Code,S00402,,S00402
-FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,334111,,334111
-FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,334112,,334112
-FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,334118,,334118
-FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,33421,,334210
-FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,33422,,334220
-FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,33429,,334290
-FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,3343,,334300
-FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,334413,,334413
-FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,334418,,334418
-FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,334412,,33441A
-FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,334416,,33441A
-FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,334417,,33441A
-FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,334419,,33441A
-FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,33521,,335210
-FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,33522,,335220
-FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,335311,,335311
-FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,335312,,335312
-FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,335313,,335313
-FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,335911,,335911
-FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,335912,,335912
-FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,33592,,335920
-FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,33593,,335930
-FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,335991,,335991
-FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,335999,,335999
-FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,33632,,336320
-FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,51121,,511200
-FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,5121,,512100
-FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,5122,,512200
-FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,S00402,,S00402
-FAF_SCTG,Motorized and Other Vehicles (includes parts),,NAICS_2017_Code,336111,,336111
-FAF_SCTG,Motorized and Other Vehicles (includes parts),,NAICS_2017_Code,336112,,336112
-FAF_SCTG,Motorized and Other Vehicles (includes parts),,NAICS_2017_Code,33612,,336120
-FAF_SCTG,Motorized and Other Vehicles (includes parts),,NAICS_2017_Code,336211,,336211
-FAF_SCTG,Motorized and Other Vehicles (includes parts),,NAICS_2017_Code,336212,,336212
-FAF_SCTG,Motorized and Other Vehicles (includes parts),,NAICS_2017_Code,336213,,336213
-FAF_SCTG,Motorized and Other Vehicles (includes parts),,NAICS_2017_Code,336214,,336214
-FAF_SCTG,Motorized and Other Vehicles (includes parts),,NAICS_2017_Code,33636,,336360
-FAF_SCTG,Motorized and Other Vehicles (includes parts),,NAICS_2017_Code,33637,,336370
-FAF_SCTG,Motorized and Other Vehicles (includes parts),,NAICS_2017_Code,33639,,336390
-FAF_SCTG,Motorized and Other Vehicles (includes parts),,NAICS_2017_Code,33633,,3363A0
-FAF_SCTG,Motorized and Other Vehicles (includes parts),,NAICS_2017_Code,33634,,3363A0
-FAF_SCTG,Motorized and Other Vehicles (includes parts),,NAICS_2017_Code,336991,,336991
-FAF_SCTG,Motorized and Other Vehicles (includes parts),,NAICS_2017_Code,336992,,336992
-FAF_SCTG,Motorized and Other Vehicles (includes parts),,NAICS_2017_Code,S00402,,S00402
-FAF_SCTG,"Transportation Equipment, not elsewhere classified",,NAICS_2017_Code,336411,,336411
-FAF_SCTG,"Transportation Equipment, not elsewhere classified",,NAICS_2017_Code,336413,,336413
-FAF_SCTG,"Transportation Equipment, not elsewhere classified",,NAICS_2017_Code,336414,,336414
-FAF_SCTG,"Transportation Equipment, not elsewhere classified",,NAICS_2017_Code,336415,,33641A
-FAF_SCTG,"Transportation Equipment, not elsewhere classified",,NAICS_2017_Code,336419,,33641A
-FAF_SCTG,"Transportation Equipment, not elsewhere classified",,NAICS_2017_Code,3365,,336500
-FAF_SCTG,"Transportation Equipment, not elsewhere classified",,NAICS_2017_Code,336611,,336611
-FAF_SCTG,"Transportation Equipment, not elsewhere classified",,NAICS_2017_Code,336612,,336612
-FAF_SCTG,"Transportation Equipment, not elsewhere classified",,NAICS_2017_Code,336999,,336999
-FAF_SCTG,"Transportation Equipment, not elsewhere classified",,NAICS_2017_Code,S00402,,S00402
-FAF_SCTG,Precision Instruments and Apparatus,,NAICS_2017_Code,33451,,334510
-FAF_SCTG,Precision Instruments and Apparatus,,NAICS_2017_Code,334511,,334511
-FAF_SCTG,Precision Instruments and Apparatus,,NAICS_2017_Code,334512,,334512
-FAF_SCTG,Precision Instruments and Apparatus,,NAICS_2017_Code,334513,,334513
-FAF_SCTG,Precision Instruments and Apparatus,,NAICS_2017_Code,334514,,334514
-FAF_SCTG,Precision Instruments and Apparatus,,NAICS_2017_Code,334515,,334515
-FAF_SCTG,Precision Instruments and Apparatus,,NAICS_2017_Code,334516,,334516
-FAF_SCTG,Precision Instruments and Apparatus,,NAICS_2017_Code,334517,,334517
-FAF_SCTG,Precision Instruments and Apparatus,,NAICS_2017_Code,334519,,33451A
-FAF_SCTG,Precision Instruments and Apparatus,,NAICS_2017_Code,33461,,334610
-FAF_SCTG,Precision Instruments and Apparatus,,NAICS_2017_Code,335314,,335314
-FAF_SCTG,Precision Instruments and Apparatus,,NAICS_2017_Code,339112,,339112
-FAF_SCTG,Precision Instruments and Apparatus,,NAICS_2017_Code,339113,,339113
-FAF_SCTG,Precision Instruments and Apparatus,,NAICS_2017_Code,339114,,339114
-FAF_SCTG,Precision Instruments and Apparatus,,NAICS_2017_Code,339115,,339115
-FAF_SCTG,Precision Instruments and Apparatus,,NAICS_2017_Code,339116,,339116
-FAF_SCTG,Precision Instruments and Apparatus,,NAICS_2017_Code,S00402,,S00402
-FAF_SCTG,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",,NAICS_2017_Code,33511,,335110
-FAF_SCTG,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",,NAICS_2017_Code,33512,,335120
-FAF_SCTG,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",,NAICS_2017_Code,33711,,337110
-FAF_SCTG,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",,NAICS_2017_Code,337121,,337121
-FAF_SCTG,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",,NAICS_2017_Code,337122,,337122
-FAF_SCTG,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",,NAICS_2017_Code,337127,,337127
-FAF_SCTG,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",,NAICS_2017_Code,337124,,33712N
-FAF_SCTG,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",,NAICS_2017_Code,337125,,33712N
-FAF_SCTG,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",,NAICS_2017_Code,337215,,337215
-FAF_SCTG,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",,NAICS_2017_Code,337211,,33721A
-FAF_SCTG,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",,NAICS_2017_Code,337212,,33721A
-FAF_SCTG,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",,NAICS_2017_Code,337214,,33721A
-FAF_SCTG,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",,NAICS_2017_Code,3379,,337900
-FAF_SCTG,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",,NAICS_2017_Code,33995,,339950
-FAF_SCTG,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",,NAICS_2017_Code,S00402,,S00402
-FAF_SCTG,Miscellaneous Manufactured Products,,NAICS_2017_Code,336414,,336414
-FAF_SCTG,Miscellaneous Manufactured Products,,NAICS_2017_Code,33991,,339910
-FAF_SCTG,Miscellaneous Manufactured Products,,NAICS_2017_Code,33992,,339920
-FAF_SCTG,Miscellaneous Manufactured Products,,NAICS_2017_Code,33993,,339930
-FAF_SCTG,Miscellaneous Manufactured Products,,NAICS_2017_Code,33999,,339990
-FAF_SCTG,Waste and Scrap (excludes of agriculture or food),,NAICS_2017_Code,562,,562000
-FAF_SCTG,Waste and Scrap (excludes of agriculture or food),,NAICS_2017_Code,S00401,,S00401
-FAF_SCTG,Mixed Freight,,NAICS_2017_Code,33994,,339940
+FAF_Mode,Other and unknown,"Includes movements not elsewhere classified such as flyaway aircraft, and shipments for which the mode cannot be determined.",NAICS_2017_Code,481,,
+FAF_Mode,Other and unknown,"Includes movements not elsewhere classified such as flyaway aircraft, and shipments for which the mode cannot be determined.",NAICS_2017_Code,482,,
+FAF_Mode,Other and unknown,"Includes movements not elsewhere classified such as flyaway aircraft, and shipments for which the mode cannot be determined.",NAICS_2017_Code,483,,
+FAF_Mode,Other and unknown,"Includes movements not elsewhere classified such as flyaway aircraft, and shipments for which the mode cannot be determined.",NAICS_2017_Code,484,,
+FAF_Mode,No domestic mode,"Includes shipments that have an international mode, but no domestic mode and is limited to import shipments of crude petroleum transferred directly from inbound ships to a U.S. refinery at the zone of entry. This classification enables a proper accounting of flows that do not utilize any domestic transportation network.",NAICS_2017_Code,,,
+FAF_SCTG,Live animals/fish,Animals and Fish (live),NAICS_2017_Code,112,,1121A0
+FAF_SCTG,Live animals/fish,Animals and Fish (live),NAICS_2017_Code,112,,112A00
+FAF_SCTG,Live animals/fish,Animals and Fish (live),NAICS_2017_Code,114,,114000
+FAF_SCTG,Cereal grains,Cereal Grains (includes seed),NAICS_2017_Code,11113,,1111B0
+FAF_SCTG,Cereal grains,Cereal Grains (includes seed),NAICS_2017_Code,11114,,1111B0
+FAF_SCTG,Cereal grains,Cereal Grains (includes seed),NAICS_2017_Code,11115,,1111B0
+FAF_SCTG,Cereal grains,Cereal Grains (includes seed),NAICS_2017_Code,11116,,1111B0
+FAF_SCTG,Cereal grains,Cereal Grains (includes seed),NAICS_2017_Code,11119,,1111B0
+FAF_SCTG,Other ag prods.,"Agricultural Products (excludes Animal Feed, Cereal Grains, and Forage Products)",NAICS_2017_Code,11111,,1111A0
+FAF_SCTG,Other ag prods.,"Agricultural Products (excludes Animal Feed, Cereal Grains, and Forage Products)",NAICS_2017_Code,11112,,1111A0
+FAF_SCTG,Other ag prods.,"Agricultural Products (excludes Animal Feed, Cereal Grains, and Forage Products)",NAICS_2017_Code,1112,,111200
+FAF_SCTG,Other ag prods.,"Agricultural Products (excludes Animal Feed, Cereal Grains, and Forage Products)",NAICS_2017_Code,1113,,111300
+FAF_SCTG,Other ag prods.,"Agricultural Products (excludes Animal Feed, Cereal Grains, and Forage Products)",NAICS_2017_Code,1114,,111400
+FAF_SCTG,Other ag prods.,"Agricultural Products (excludes Animal Feed, Cereal Grains, and Forage Products)",NAICS_2017_Code,1119,,111900
+FAF_SCTG,Animal feed,"Animal Feed, Eggs, Honey, and Other Products of Animal Origin",NAICS_2017_Code,1123,,112300
+FAF_SCTG,Animal feed,"Animal Feed, Eggs, Honey, and Other Products of Animal Origin",NAICS_2017_Code,311111,,311111
+FAF_SCTG,Animal feed,"Animal Feed, Eggs, Honey, and Other Products of Animal Origin",NAICS_2017_Code,311119,,311119
+FAF_SCTG,Meat/seafood,"Meat, Poultry, Fish, Seafood, and Their Preparations",NAICS_2017_Code,1123,,112300
+FAF_SCTG,Meat/seafood,"Meat, Poultry, Fish, Seafood, and Their Preparations",NAICS_2017_Code,311615,,311615
+FAF_SCTG,Meat/seafood,"Meat, Poultry, Fish, Seafood, and Their Preparations",NAICS_2017_Code,311611,,31161A
+FAF_SCTG,Meat/seafood,"Meat, Poultry, Fish, Seafood, and Their Preparations",NAICS_2017_Code,311612,,31161A
+FAF_SCTG,Meat/seafood,"Meat, Poultry, Fish, Seafood, and Their Preparations",NAICS_2017_Code,311613,,31161A
+FAF_SCTG,Meat/seafood,"Meat, Poultry, Fish, Seafood, and Their Preparations",NAICS_2017_Code,3117,,311700
+FAF_SCTG,Milled grain prods.,"Milled Grain Products and Preparations, and Bakery Products",NAICS_2017_Code,11212,,112120
+FAF_SCTG,Milled grain prods.,"Milled Grain Products and Preparations, and Bakery Products",NAICS_2017_Code,31121,,311210
+FAF_SCTG,Milled grain prods.,"Milled Grain Products and Preparations, and Bakery Products",NAICS_2017_Code,311221,,311221
+FAF_SCTG,Milled grain prods.,"Milled Grain Products and Preparations, and Bakery Products",NAICS_2017_Code,31123,,311230
+FAF_SCTG,Milled grain prods.,"Milled Grain Products and Preparations, and Bakery Products",NAICS_2017_Code,31181,,311810
+FAF_SCTG,Milled grain prods.,"Milled Grain Products and Preparations, and Bakery Products",NAICS_2017_Code,31182,,3118A0
+FAF_SCTG,Milled grain prods.,"Milled Grain Products and Preparations, and Bakery Products",NAICS_2017_Code,31183,,3118A0
+FAF_SCTG,Other foodstuffs,"Other Prepared Foodstuffs, Fats and Oils",NAICS_2017_Code,311224,,311224
+FAF_SCTG,Other foodstuffs,"Other Prepared Foodstuffs, Fats and Oils",NAICS_2017_Code,311225,,311225
+FAF_SCTG,Other foodstuffs,"Other Prepared Foodstuffs, Fats and Oils",NAICS_2017_Code,3113,,311300
+FAF_SCTG,Other foodstuffs,"Other Prepared Foodstuffs, Fats and Oils",NAICS_2017_Code,31141,,311410
+FAF_SCTG,Other foodstuffs,"Other Prepared Foodstuffs, Fats and Oils",NAICS_2017_Code,31142,,311420
+FAF_SCTG,Other foodstuffs,"Other Prepared Foodstuffs, Fats and Oils",NAICS_2017_Code,311513,,311513
+FAF_SCTG,Other foodstuffs,"Other Prepared Foodstuffs, Fats and Oils",NAICS_2017_Code,311514,,311514
+FAF_SCTG,Other foodstuffs,"Other Prepared Foodstuffs, Fats and Oils",NAICS_2017_Code,311511,,31151A
+FAF_SCTG,Other foodstuffs,"Other Prepared Foodstuffs, Fats and Oils",NAICS_2017_Code,311512,,31151A
+FAF_SCTG,Other foodstuffs,"Other Prepared Foodstuffs, Fats and Oils",NAICS_2017_Code,31152,,311520
+FAF_SCTG,Other foodstuffs,"Other Prepared Foodstuffs, Fats and Oils",NAICS_2017_Code,31191,,311910
+FAF_SCTG,Other foodstuffs,"Other Prepared Foodstuffs, Fats and Oils",NAICS_2017_Code,31192,,311920
+FAF_SCTG,Other foodstuffs,"Other Prepared Foodstuffs, Fats and Oils",NAICS_2017_Code,31193,,311930
+FAF_SCTG,Other foodstuffs,"Other Prepared Foodstuffs, Fats and Oils",NAICS_2017_Code,31194,,311940
+FAF_SCTG,Other foodstuffs,"Other Prepared Foodstuffs, Fats and Oils",NAICS_2017_Code,31199,,311990
+FAF_SCTG,Other foodstuffs,"Other Prepared Foodstuffs, Fats and Oils",NAICS_2017_Code,31211,,312110
+FAF_SCTG,Alcoholic beverages,Alcoholic Beverages and Denatured Alcohol,NAICS_2017_Code,31212,,312120
+FAF_SCTG,Alcoholic beverages,Alcoholic Beverages and Denatured Alcohol,NAICS_2017_Code,31213,,312130
+FAF_SCTG,Alcoholic beverages,Alcoholic Beverages and Denatured Alcohol,NAICS_2017_Code,31214,,312140
+FAF_SCTG,Tobacco prods.,Tobacco Products,NAICS_2017_Code,3122,,312200
+FAF_SCTG,Building stone,Monumental or Building Stone,NAICS_2017_Code,21231,,212310
+FAF_SCTG,Natural sands,Natural Sands,NAICS_2017_Code,21231,,212310
+FAF_SCTG,Gravel,Gravel and Crushed Stone (excludes Dolomite and Slate),NAICS_2017_Code,21231,,212310
+FAF_SCTG,Nonmetallic minerals,Other Non-Metallic Minerals not elsewhere classified,NAICS_2017_Code,21232,,2123A0
+FAF_SCTG,Nonmetallic minerals,Other Non-Metallic Minerals not elsewhere classified,NAICS_2017_Code,21239,,2123A0
+FAF_SCTG,Metallic ores,Metallic Ores and Concentrates,NAICS_2017_Code,21223,,212230
+FAF_SCTG,Metallic ores,Metallic Ores and Concentrates,NAICS_2017_Code,21222,,2122A0
+FAF_SCTG,Metallic ores,Metallic Ores and Concentrates,NAICS_2017_Code,21229,,2122A0
+FAF_SCTG,Coal,Coal,NAICS_2017_Code,2121,,212100
+FAF_SCTG,Crude petroleum,Crude Petroleum,NAICS_2017_Code,211,,211000
+FAF_SCTG,Gasoline,"Gasoline, Aviation Turbine Fuel, and Ethanol (includes Kerosene, and Fuel Alcohols)",NAICS_2017_Code,32411,,324110
+FAF_SCTG,Gasoline,"Gasoline, Aviation Turbine Fuel, and Ethanol (includes Kerosene, and Fuel Alcohols)",NAICS_2017_Code,324121,,324121
+FAF_SCTG,Gasoline,"Gasoline, Aviation Turbine Fuel, and Ethanol (includes Kerosene, and Fuel Alcohols)",NAICS_2017_Code,324122,,324122
+FAF_SCTG,Fuel oils,"Fuel Oils (includes Diesel, Bunker C, and Biodiesel)",NAICS_2017_Code,32411,,324110
+FAF_SCTG,Natural gas and other fossil products,"Other Coal and Petroleum Products, not elsewhere classified",NAICS_2017_Code,32419,,324190
+FAF_SCTG,Basic chemicals,Basic Chemicals,NAICS_2017_Code,32511,,325110
+FAF_SCTG,Basic chemicals,Basic Chemicals,NAICS_2017_Code,32512,,325120
+FAF_SCTG,Basic chemicals,Basic Chemicals,NAICS_2017_Code,32513,,325130
+FAF_SCTG,Basic chemicals,Basic Chemicals,NAICS_2017_Code,32518,,325180
+FAF_SCTG,Basic chemicals,Basic Chemicals,NAICS_2017_Code,32519,,325190
+FAF_SCTG,Pharmaceuticals,Pharmaceutical Products,NAICS_2017_Code,325411,,325411
+FAF_SCTG,Pharmaceuticals,Pharmaceutical Products,NAICS_2017_Code,325412,,325412
+FAF_SCTG,Pharmaceuticals,Pharmaceutical Products,NAICS_2017_Code,325413,,325413
+FAF_SCTG,Pharmaceuticals,Pharmaceutical Products,NAICS_2017_Code,325414,,325414
+FAF_SCTG,Fertilizers,Fertilizers,NAICS_2017_Code,32531,,325310
+FAF_SCTG,Chemical prods.,Other Chemical Products and Preparations,NAICS_2017_Code,32532,,325320
+FAF_SCTG,Chemical prods.,Other Chemical Products and Preparations,NAICS_2017_Code,32551,,325510
+FAF_SCTG,Chemical prods.,Other Chemical Products and Preparations,NAICS_2017_Code,32552,,325520
+FAF_SCTG,Chemical prods.,Other Chemical Products and Preparations,NAICS_2017_Code,32561,,325610
+FAF_SCTG,Chemical prods.,Other Chemical Products and Preparations,NAICS_2017_Code,32562,,325620
+FAF_SCTG,Chemical prods.,Other Chemical Products and Preparations,NAICS_2017_Code,32591,,325910
+FAF_SCTG,Chemical prods.,Other Chemical Products and Preparations,NAICS_2017_Code,32592,,3259A0
+FAF_SCTG,Chemical prods.,Other Chemical Products and Preparations,NAICS_2017_Code,32599,,3259A0
+FAF_SCTG,Plastics/rubber,Plastics and Rubber,NAICS_2017_Code,325211,,325211
+FAF_SCTG,Plastics/rubber,Plastics and Rubber,NAICS_2017_Code,325212,,3252A0
+FAF_SCTG,Plastics/rubber,Plastics and Rubber,NAICS_2017_Code,32522,,3252A0
+FAF_SCTG,Plastics/rubber,Plastics and Rubber,NAICS_2017_Code,32611,,326110
+FAF_SCTG,Plastics/rubber,Plastics and Rubber,NAICS_2017_Code,32612,,326120
+FAF_SCTG,Plastics/rubber,Plastics and Rubber,NAICS_2017_Code,32613,,326130
+FAF_SCTG,Plastics/rubber,Plastics and Rubber,NAICS_2017_Code,32614,,326140
+FAF_SCTG,Plastics/rubber,Plastics and Rubber,NAICS_2017_Code,32615,,326150
+FAF_SCTG,Plastics/rubber,Plastics and Rubber,NAICS_2017_Code,32616,,326160
+FAF_SCTG,Plastics/rubber,Plastics and Rubber,NAICS_2017_Code,32619,,326190
+FAF_SCTG,Plastics/rubber,Plastics and Rubber,NAICS_2017_Code,32621,,326210
+FAF_SCTG,Plastics/rubber,Plastics and Rubber,NAICS_2017_Code,32622,,326220
+FAF_SCTG,Plastics/rubber,Plastics and Rubber,NAICS_2017_Code,32629,,326290
+FAF_SCTG,Logs,Logs and Other Wood in the Rough,NAICS_2017_Code,113,,113000
+FAF_SCTG,Wood prods.,Wood Products,NAICS_2017_Code,3211,,321100
+FAF_SCTG,Wood prods.,Wood Products,NAICS_2017_Code,3212,,321200
+FAF_SCTG,Wood prods.,Wood Products,NAICS_2017_Code,32191,,321910
+FAF_SCTG,Wood prods.,Wood Products,NAICS_2017_Code,32192,,3219A0
+FAF_SCTG,Wood prods.,Wood Products,NAICS_2017_Code,32199,,3219A0
+FAF_SCTG,Newsprint/paper,"Pulp, Newsprint, Paper, and Paperboard",NAICS_2017_Code,32211,,322110
+FAF_SCTG,Newsprint/paper,"Pulp, Newsprint, Paper, and Paperboard",NAICS_2017_Code,32212,,322120
+FAF_SCTG,Newsprint/paper,"Pulp, Newsprint, Paper, and Paperboard",NAICS_2017_Code,32213,,322130
+FAF_SCTG,Paper articles,Paper or Paperboard Articles,NAICS_2017_Code,32221,,322210
+FAF_SCTG,Paper articles,Paper or Paperboard Articles,NAICS_2017_Code,32222,,322220
+FAF_SCTG,Paper articles,Paper or Paperboard Articles,NAICS_2017_Code,32223,,322230
+FAF_SCTG,Paper articles,Paper or Paperboard Articles,NAICS_2017_Code,322291,,322291
+FAF_SCTG,Paper articles,Paper or Paperboard Articles,NAICS_2017_Code,322299,,322299
+FAF_SCTG,Printed prods.,Printed Products,NAICS_2017_Code,323111,,323110
+FAF_SCTG,Printed prods.,Printed Products,NAICS_2017_Code,323113,,323110
+FAF_SCTG,Printed prods.,Printed Products,NAICS_2017_Code,323117,,323110
+FAF_SCTG,Printed prods.,Printed Products,NAICS_2017_Code,323120,,323120
+FAF_SCTG,Printed prods.,Printed Products,NAICS_2017_Code,51111,,511110
+FAF_SCTG,Printed prods.,Printed Products,NAICS_2017_Code,51112,,511120
+FAF_SCTG,Printed prods.,Printed Products,NAICS_2017_Code,51113,,511130
+FAF_SCTG,Printed prods.,Printed Products,NAICS_2017_Code,51114,,5111A0
+FAF_SCTG,Printed prods.,Printed Products,NAICS_2017_Code,51119,,5111A0
+FAF_SCTG,Printed prods.,Printed Products,NAICS_2017_Code,S00402,,S00402
+FAF_SCTG,Textiles/leather,"Textiles, Leather, and Articles of Textiles or Leather",NAICS_2017_Code,3131,,313100
+FAF_SCTG,Textiles/leather,"Textiles, Leather, and Articles of Textiles or Leather",NAICS_2017_Code,3132,,313200
+FAF_SCTG,Textiles/leather,"Textiles, Leather, and Articles of Textiles or Leather",NAICS_2017_Code,3133,,313300
+FAF_SCTG,Textiles/leather,"Textiles, Leather, and Articles of Textiles or Leather",NAICS_2017_Code,31411,,314110
+FAF_SCTG,Textiles/leather,"Textiles, Leather, and Articles of Textiles or Leather",NAICS_2017_Code,31412,,314120
+FAF_SCTG,Textiles/leather,"Textiles, Leather, and Articles of Textiles or Leather",NAICS_2017_Code,3149,,314900
+FAF_SCTG,Textiles/leather,"Textiles, Leather, and Articles of Textiles or Leather",NAICS_2017_Code,315,,315000
+FAF_SCTG,Textiles/leather,"Textiles, Leather, and Articles of Textiles or Leather",NAICS_2017_Code,316,,316000
+FAF_SCTG,Textiles/leather,"Textiles, Leather, and Articles of Textiles or Leather",NAICS_2017_Code,S00402,,S00402
+FAF_SCTG,Nonmetal min. prods.,Non-Metallic Mineral Products,NAICS_2017_Code,3271,,327100
+FAF_SCTG,Nonmetal min. prods.,Non-Metallic Mineral Products,NAICS_2017_Code,3272,,327200
+FAF_SCTG,Nonmetal min. prods.,Non-Metallic Mineral Products,NAICS_2017_Code,32731,,327310
+FAF_SCTG,Nonmetal min. prods.,Non-Metallic Mineral Products,NAICS_2017_Code,32732,,327320
+FAF_SCTG,Nonmetal min. prods.,Non-Metallic Mineral Products,NAICS_2017_Code,32733,,327330
+FAF_SCTG,Nonmetal min. prods.,Non-Metallic Mineral Products,NAICS_2017_Code,32739,,327390
+FAF_SCTG,Nonmetal min. prods.,Non-Metallic Mineral Products,NAICS_2017_Code,3274,,327400
+FAF_SCTG,Nonmetal min. prods.,Non-Metallic Mineral Products,NAICS_2017_Code,32791,,327910
+FAF_SCTG,Nonmetal min. prods.,Non-Metallic Mineral Products,NAICS_2017_Code,327991,,327991
+FAF_SCTG,Nonmetal min. prods.,Non-Metallic Mineral Products,NAICS_2017_Code,327992,,327992
+FAF_SCTG,Nonmetal min. prods.,Non-Metallic Mineral Products,NAICS_2017_Code,327993,,327993
+FAF_SCTG,Nonmetal min. prods.,Non-Metallic Mineral Products,NAICS_2017_Code,327999,,327999
+FAF_SCTG,Nonmetal min. prods.,Non-Metallic Mineral Products,NAICS_2017_Code,332119,,332119
+FAF_SCTG,Base metals,Base Metal in Primary or Semi-Finished Forms and in Finished Basic Shapes,NAICS_2017_Code,33111,,331110
+FAF_SCTG,Base metals,Base Metal in Primary or Semi-Finished Forms and in Finished Basic Shapes,NAICS_2017_Code,3312,,331200
+FAF_SCTG,Base metals,Base Metal in Primary or Semi-Finished Forms and in Finished Basic Shapes,NAICS_2017_Code,331313,,331313
+FAF_SCTG,Base metals,Base Metal in Primary or Semi-Finished Forms and in Finished Basic Shapes,NAICS_2017_Code,331314,,33131B
+FAF_SCTG,Base metals,Base Metal in Primary or Semi-Finished Forms and in Finished Basic Shapes,NAICS_2017_Code,331315,,33131B
+FAF_SCTG,Base metals,Base Metal in Primary or Semi-Finished Forms and in Finished Basic Shapes,NAICS_2017_Code,331318,,33131B
+FAF_SCTG,Base metals,Base Metal in Primary or Semi-Finished Forms and in Finished Basic Shapes,NAICS_2017_Code,33141,,331410
+FAF_SCTG,Base metals,Base Metal in Primary or Semi-Finished Forms and in Finished Basic Shapes,NAICS_2017_Code,33142,,331420
+FAF_SCTG,Base metals,Base Metal in Primary or Semi-Finished Forms and in Finished Basic Shapes,NAICS_2017_Code,33149,,331490
+FAF_SCTG,Base metals,Base Metal in Primary or Semi-Finished Forms and in Finished Basic Shapes,NAICS_2017_Code,33151,,331510
+FAF_SCTG,Base metals,Base Metal in Primary or Semi-Finished Forms and in Finished Basic Shapes,NAICS_2017_Code,33152,,331520
+FAF_SCTG,Articles-base metal,Articles of Base Metal,NAICS_2017_Code,332114,,332114
+FAF_SCTG,Articles-base metal,Articles of Base Metal,NAICS_2017_Code,332111,,33211A
+FAF_SCTG,Articles-base metal,Articles of Base Metal,NAICS_2017_Code,332112,,33211A
+FAF_SCTG,Articles-base metal,Articles of Base Metal,NAICS_2017_Code,332117,,33211A
+FAF_SCTG,Articles-base metal,Articles of Base Metal,NAICS_2017_Code,3322,,332200
+FAF_SCTG,Articles-base metal,Articles of Base Metal,NAICS_2017_Code,33231,,332310
+FAF_SCTG,Articles-base metal,Articles of Base Metal,NAICS_2017_Code,33232,,332320
+FAF_SCTG,Articles-base metal,Articles of Base Metal,NAICS_2017_Code,33241,,332410
+FAF_SCTG,Articles-base metal,Articles of Base Metal,NAICS_2017_Code,33242,,332420
+FAF_SCTG,Articles-base metal,Articles of Base Metal,NAICS_2017_Code,33243,,332430
+FAF_SCTG,Articles-base metal,Articles of Base Metal,NAICS_2017_Code,3325,,332500
+FAF_SCTG,Articles-base metal,Articles of Base Metal,NAICS_2017_Code,3326,,332600
+FAF_SCTG,Articles-base metal,Articles of Base Metal,NAICS_2017_Code,33271,,332710
+FAF_SCTG,Articles-base metal,Articles of Base Metal,NAICS_2017_Code,33272,,332720
+FAF_SCTG,Articles-base metal,Articles of Base Metal,NAICS_2017_Code,3328,,332800
+FAF_SCTG,Articles-base metal,Articles of Base Metal,NAICS_2017_Code,332913,,332913
+FAF_SCTG,Articles-base metal,Articles of Base Metal,NAICS_2017_Code,332911,,33291A
+FAF_SCTG,Articles-base metal,Articles of Base Metal,NAICS_2017_Code,332912,,33291A
+FAF_SCTG,Articles-base metal,Articles of Base Metal,NAICS_2017_Code,332919,,33291A
+FAF_SCTG,Articles-base metal,Articles of Base Metal,NAICS_2017_Code,332991,,332991
+FAF_SCTG,Articles-base metal,Articles of Base Metal,NAICS_2017_Code,332996,,332996
+FAF_SCTG,Articles-base metal,Articles of Base Metal,NAICS_2017_Code,332992,,33299A
+FAF_SCTG,Articles-base metal,Articles of Base Metal,NAICS_2017_Code,332993,,33299A
+FAF_SCTG,Articles-base metal,Articles of Base Metal,NAICS_2017_Code,332994,,33299A
+FAF_SCTG,Articles-base metal,Articles of Base Metal,NAICS_2017_Code,332999,,332999
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,333111,,333111
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,333112,,333112
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,333120,,333120
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,33313,,333130
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,333242,,333242
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,333241,,33329A
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,333243,,33329A
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,333244,,33329A
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,333249,,33329A
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,333314,,333314
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,333316,,333316
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,333318,,333318
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,333413,,333413
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,333414,,333414
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,333415,,333415
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,333511,,333511
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,333514,,333514
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,333517,,333517
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,333515,,33351B
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,333519,,33351B
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,333611,,333611
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,333612,,333612
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,333613,,333613
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,333618,,333618
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,333912,,333912
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,333914,,333914
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,33392,,333920
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,333991,,333991
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,333993,,333993
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,333994,,333994
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,333992,,33399A
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,333997,,33399A
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,333999,,33399A
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,333995,,33399B
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,333996,,33399B
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,33631,,336310
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,33635,,336350
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,336412,,336412
+FAF_SCTG,Machinery,Machinery,NAICS_2017_Code,S00402,,S00402
+FAF_SCTG,Electronics,"Electronic and Other Electrical Equipment and Components, and Office Equipment",NAICS_2017_Code,334111,,334111
+FAF_SCTG,Electronics,"Electronic and Other Electrical Equipment and Components, and Office Equipment",NAICS_2017_Code,334112,,334112
+FAF_SCTG,Electronics,"Electronic and Other Electrical Equipment and Components, and Office Equipment",NAICS_2017_Code,334118,,334118
+FAF_SCTG,Electronics,"Electronic and Other Electrical Equipment and Components, and Office Equipment",NAICS_2017_Code,33421,,334210
+FAF_SCTG,Electronics,"Electronic and Other Electrical Equipment and Components, and Office Equipment",NAICS_2017_Code,33422,,334220
+FAF_SCTG,Electronics,"Electronic and Other Electrical Equipment and Components, and Office Equipment",NAICS_2017_Code,33429,,334290
+FAF_SCTG,Electronics,"Electronic and Other Electrical Equipment and Components, and Office Equipment",NAICS_2017_Code,3343,,334300
+FAF_SCTG,Electronics,"Electronic and Other Electrical Equipment and Components, and Office Equipment",NAICS_2017_Code,334413,,334413
+FAF_SCTG,Electronics,"Electronic and Other Electrical Equipment and Components, and Office Equipment",NAICS_2017_Code,334418,,334418
+FAF_SCTG,Electronics,"Electronic and Other Electrical Equipment and Components, and Office Equipment",NAICS_2017_Code,334412,,33441A
+FAF_SCTG,Electronics,"Electronic and Other Electrical Equipment and Components, and Office Equipment",NAICS_2017_Code,334416,,33441A
+FAF_SCTG,Electronics,"Electronic and Other Electrical Equipment and Components, and Office Equipment",NAICS_2017_Code,334417,,33441A
+FAF_SCTG,Electronics,"Electronic and Other Electrical Equipment and Components, and Office Equipment",NAICS_2017_Code,334419,,33441A
+FAF_SCTG,Electronics,"Electronic and Other Electrical Equipment and Components, and Office Equipment",NAICS_2017_Code,33521,,335210
+FAF_SCTG,Electronics,"Electronic and Other Electrical Equipment and Components, and Office Equipment",NAICS_2017_Code,33522,,335220
+FAF_SCTG,Electronics,"Electronic and Other Electrical Equipment and Components, and Office Equipment",NAICS_2017_Code,335311,,335311
+FAF_SCTG,Electronics,"Electronic and Other Electrical Equipment and Components, and Office Equipment",NAICS_2017_Code,335312,,335312
+FAF_SCTG,Electronics,"Electronic and Other Electrical Equipment and Components, and Office Equipment",NAICS_2017_Code,335313,,335313
+FAF_SCTG,Electronics,"Electronic and Other Electrical Equipment and Components, and Office Equipment",NAICS_2017_Code,335911,,335911
+FAF_SCTG,Electronics,"Electronic and Other Electrical Equipment and Components, and Office Equipment",NAICS_2017_Code,335912,,335912
+FAF_SCTG,Electronics,"Electronic and Other Electrical Equipment and Components, and Office Equipment",NAICS_2017_Code,33592,,335920
+FAF_SCTG,Electronics,"Electronic and Other Electrical Equipment and Components, and Office Equipment",NAICS_2017_Code,33593,,335930
+FAF_SCTG,Electronics,"Electronic and Other Electrical Equipment and Components, and Office Equipment",NAICS_2017_Code,335991,,335991
+FAF_SCTG,Electronics,"Electronic and Other Electrical Equipment and Components, and Office Equipment",NAICS_2017_Code,335999,,335999
+FAF_SCTG,Electronics,"Electronic and Other Electrical Equipment and Components, and Office Equipment",NAICS_2017_Code,33632,,336320
+FAF_SCTG,Electronics,"Electronic and Other Electrical Equipment and Components, and Office Equipment",NAICS_2017_Code,51121,,511200
+FAF_SCTG,Electronics,"Electronic and Other Electrical Equipment and Components, and Office Equipment",NAICS_2017_Code,5121,,512100
+FAF_SCTG,Electronics,"Electronic and Other Electrical Equipment and Components, and Office Equipment",NAICS_2017_Code,5122,,512200
+FAF_SCTG,Electronics,"Electronic and Other Electrical Equipment and Components, and Office Equipment",NAICS_2017_Code,S00402,,S00402
+FAF_SCTG,Motorized vehicles,Motorized and Other Vehicles (includes parts),NAICS_2017_Code,336111,,336111
+FAF_SCTG,Motorized vehicles,Motorized and Other Vehicles (includes parts),NAICS_2017_Code,336112,,336112
+FAF_SCTG,Motorized vehicles,Motorized and Other Vehicles (includes parts),NAICS_2017_Code,33612,,336120
+FAF_SCTG,Motorized vehicles,Motorized and Other Vehicles (includes parts),NAICS_2017_Code,336211,,336211
+FAF_SCTG,Motorized vehicles,Motorized and Other Vehicles (includes parts),NAICS_2017_Code,336212,,336212
+FAF_SCTG,Motorized vehicles,Motorized and Other Vehicles (includes parts),NAICS_2017_Code,336213,,336213
+FAF_SCTG,Motorized vehicles,Motorized and Other Vehicles (includes parts),NAICS_2017_Code,336214,,336214
+FAF_SCTG,Motorized vehicles,Motorized and Other Vehicles (includes parts),NAICS_2017_Code,33636,,336360
+FAF_SCTG,Motorized vehicles,Motorized and Other Vehicles (includes parts),NAICS_2017_Code,33637,,336370
+FAF_SCTG,Motorized vehicles,Motorized and Other Vehicles (includes parts),NAICS_2017_Code,33639,,336390
+FAF_SCTG,Motorized vehicles,Motorized and Other Vehicles (includes parts),NAICS_2017_Code,33633,,3363A0
+FAF_SCTG,Motorized vehicles,Motorized and Other Vehicles (includes parts),NAICS_2017_Code,33634,,3363A0
+FAF_SCTG,Motorized vehicles,Motorized and Other Vehicles (includes parts),NAICS_2017_Code,336991,,336991
+FAF_SCTG,Motorized vehicles,Motorized and Other Vehicles (includes parts),NAICS_2017_Code,336992,,336992
+FAF_SCTG,Motorized vehicles,Motorized and Other Vehicles (includes parts),NAICS_2017_Code,S00402,,S00402
+FAF_SCTG,Transport equip.,"Transportation Equipment, not elsewhere classified",NAICS_2017_Code,336411,,336411
+FAF_SCTG,Transport equip.,"Transportation Equipment, not elsewhere classified",NAICS_2017_Code,336413,,336413
+FAF_SCTG,Transport equip.,"Transportation Equipment, not elsewhere classified",NAICS_2017_Code,336414,,336414
+FAF_SCTG,Transport equip.,"Transportation Equipment, not elsewhere classified",NAICS_2017_Code,336415,,33641A
+FAF_SCTG,Transport equip.,"Transportation Equipment, not elsewhere classified",NAICS_2017_Code,336419,,33641A
+FAF_SCTG,Transport equip.,"Transportation Equipment, not elsewhere classified",NAICS_2017_Code,3365,,336500
+FAF_SCTG,Transport equip.,"Transportation Equipment, not elsewhere classified",NAICS_2017_Code,336611,,336611
+FAF_SCTG,Transport equip.,"Transportation Equipment, not elsewhere classified",NAICS_2017_Code,336612,,336612
+FAF_SCTG,Transport equip.,"Transportation Equipment, not elsewhere classified",NAICS_2017_Code,336999,,336999
+FAF_SCTG,Transport equip.,"Transportation Equipment, not elsewhere classified",NAICS_2017_Code,S00402,,S00402
+FAF_SCTG,Precision instruments,Precision Instruments and Apparatus,NAICS_2017_Code,33451,,334510
+FAF_SCTG,Precision instruments,Precision Instruments and Apparatus,NAICS_2017_Code,334511,,334511
+FAF_SCTG,Precision instruments,Precision Instruments and Apparatus,NAICS_2017_Code,334512,,334512
+FAF_SCTG,Precision instruments,Precision Instruments and Apparatus,NAICS_2017_Code,334513,,334513
+FAF_SCTG,Precision instruments,Precision Instruments and Apparatus,NAICS_2017_Code,334514,,334514
+FAF_SCTG,Precision instruments,Precision Instruments and Apparatus,NAICS_2017_Code,334515,,334515
+FAF_SCTG,Precision instruments,Precision Instruments and Apparatus,NAICS_2017_Code,334516,,334516
+FAF_SCTG,Precision instruments,Precision Instruments and Apparatus,NAICS_2017_Code,334517,,334517
+FAF_SCTG,Precision instruments,Precision Instruments and Apparatus,NAICS_2017_Code,334519,,33451A
+FAF_SCTG,Precision instruments,Precision Instruments and Apparatus,NAICS_2017_Code,33461,,334610
+FAF_SCTG,Precision instruments,Precision Instruments and Apparatus,NAICS_2017_Code,335314,,335314
+FAF_SCTG,Precision instruments,Precision Instruments and Apparatus,NAICS_2017_Code,339112,,339112
+FAF_SCTG,Precision instruments,Precision Instruments and Apparatus,NAICS_2017_Code,339113,,339113
+FAF_SCTG,Precision instruments,Precision Instruments and Apparatus,NAICS_2017_Code,339114,,339114
+FAF_SCTG,Precision instruments,Precision Instruments and Apparatus,NAICS_2017_Code,339115,,339115
+FAF_SCTG,Precision instruments,Precision Instruments and Apparatus,NAICS_2017_Code,339116,,339116
+FAF_SCTG,Precision instruments,Precision Instruments and Apparatus,NAICS_2017_Code,S00402,,S00402
+FAF_SCTG,Furniture,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",NAICS_2017_Code,33511,,335110
+FAF_SCTG,Furniture,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",NAICS_2017_Code,33512,,335120
+FAF_SCTG,Furniture,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",NAICS_2017_Code,33711,,337110
+FAF_SCTG,Furniture,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",NAICS_2017_Code,337121,,337121
+FAF_SCTG,Furniture,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",NAICS_2017_Code,337122,,337122
+FAF_SCTG,Furniture,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",NAICS_2017_Code,337127,,337127
+FAF_SCTG,Furniture,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",NAICS_2017_Code,337124,,33712N
+FAF_SCTG,Furniture,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",NAICS_2017_Code,337125,,33712N
+FAF_SCTG,Furniture,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",NAICS_2017_Code,337215,,337215
+FAF_SCTG,Furniture,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",NAICS_2017_Code,337211,,33721A
+FAF_SCTG,Furniture,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",NAICS_2017_Code,337212,,33721A
+FAF_SCTG,Furniture,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",NAICS_2017_Code,337214,,33721A
+FAF_SCTG,Furniture,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",NAICS_2017_Code,3379,,337900
+FAF_SCTG,Furniture,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",NAICS_2017_Code,33995,,339950
+FAF_SCTG,Furniture,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",NAICS_2017_Code,S00402,,S00402
+FAF_SCTG,Misc. mfg. prods.,Miscellaneous Manufactured Products,NAICS_2017_Code,336414,,336414
+FAF_SCTG,Misc. mfg. prods.,Miscellaneous Manufactured Products,NAICS_2017_Code,33991,,339910
+FAF_SCTG,Misc. mfg. prods.,Miscellaneous Manufactured Products,NAICS_2017_Code,33992,,339920
+FAF_SCTG,Misc. mfg. prods.,Miscellaneous Manufactured Products,NAICS_2017_Code,33993,,339930
+FAF_SCTG,Misc. mfg. prods.,Miscellaneous Manufactured Products,NAICS_2017_Code,33999,,339990
+FAF_SCTG,Waste/scrap,Waste and Scrap (excludes of agriculture or food),NAICS_2017_Code,562,,562000
+FAF_SCTG,Waste/scrap,Waste and Scrap (excludes of agriculture or food),NAICS_2017_Code,S00401,,S00401
+FAF_SCTG,Mixed freight,Mixed Freight,NAICS_2017_Code,33994,,339940

--- a/bedrock/utils/mapping/activitytosectormapping/NAICS_Crosswalk_FAF_Mode_and_SCTG.csv
+++ b/bedrock/utils/mapping/activitytosectormapping/NAICS_Crosswalk_FAF_Mode_and_SCTG.csv
@@ -1,0 +1,326 @@
+ActivitySourceName,Activity,Activity_Description,SectorSourceName,Sector,SectorType,Note
+FAF_Mode,Truck,Includes private and for-hire trucks. Does not include truck that is part of Multiple Modes and Mail or truck moves in conjunction with domestic air cargo.,NAICS_2017_Code,484,,
+FAF_Mode,Rail,Includes any common carrier or private railroad. Does not include rail that is part of Multiple Modes and Mail.,NAICS_2017_Code,482,,
+FAF_Mode,Water,"Includes shallow draft, deep draft, Great Lakes, and intra-port shipments. Does not include water that is part of Multiple Modes and Mail",NAICS_2017_Code,483,,
+FAF_Mode,Air (includes truck-air),"Includes shipments move by air or a combination of truck and air in commercial or private aircraft. Includes air freight and air express. In the case of imports and exports by air, domestic moves by ground to and from the port of entry or exit are categorized with Truck.",NAICS_2017_Code,481,,
+FAF_Mode,Multiple Modes and Mail,"Includes shipments by multiple modes and by parcel delivery services, U.S. Postal Service, or couriers (capped at 150 pounds). This category is not limited to containerized or trailer-on-flatcar shipments.",NAICS_2017_Code,481,,
+FAF_Mode,Multiple Modes and Mail,"Includes shipments by multiple modes and by parcel delivery services, U.S. Postal Service, or couriers (capped at 150 pounds). This category is not limited to containerized or trailer-on-flatcar shipments.",NAICS_2017_Code,482,,
+FAF_Mode,Multiple Modes and Mail,"Includes shipments by multiple modes and by parcel delivery services, U.S. Postal Service, or couriers (capped at 150 pounds). This category is not limited to containerized or trailer-on-flatcar shipments.",NAICS_2017_Code,483,,
+FAF_Mode,Multiple Modes and Mail,"Includes shipments by multiple modes and by parcel delivery services, U.S. Postal Service, or couriers (capped at 150 pounds). This category is not limited to containerized or trailer-on-flatcar shipments.",NAICS_2017_Code,484,,
+FAF_Mode,Pipeline,"Includes crude petroleum, natural gas, and product pipelines. Note: Does include flows from offshore wells to land, which are counted as Water moves by the U.S. Army Corps of Engineers. Does not include pipeline that is part of Multiple Modes and Mail",NAICS_2017_Code,486,,
+FAF_Mode,Other and Unknown,"Includes movements not elsewhere classified such as flyaway aircraft, and shipments for which the mode cannot be determined.",NAICS_2017_Code,481,,
+FAF_Mode,Other and Unknown,"Includes movements not elsewhere classified such as flyaway aircraft, and shipments for which the mode cannot be determined.",NAICS_2017_Code,482,,
+FAF_Mode,Other and Unknown,"Includes movements not elsewhere classified such as flyaway aircraft, and shipments for which the mode cannot be determined.",NAICS_2017_Code,483,,
+FAF_Mode,Other and Unknown,"Includes movements not elsewhere classified such as flyaway aircraft, and shipments for which the mode cannot be determined.",NAICS_2017_Code,484,,
+FAF_Mode,No Domestic Mode,"Includes shipments that have an international mode, but no domestic mode and is limited to import shipments of crude petroleum transferred directly from inbound ships to a U.S. refinery at the zone of entry. This classification enables a proper accounting of flows that do not utilize any domestic transportation network.",NAICS_2017_Code,,,
+FAF_SCTG,Animals and Fish (live),,NAICS_2017_Code,112,,1121A0
+FAF_SCTG,Animals and Fish (live),,NAICS_2017_Code,112,,112A00
+FAF_SCTG,Animals and Fish (live),,NAICS_2017_Code,114,,114000
+FAF_SCTG,Cereal Grains (includes seed),,NAICS_2017_Code,11113,,1111B0
+FAF_SCTG,Cereal Grains (includes seed),,NAICS_2017_Code,11114,,1111B0
+FAF_SCTG,Cereal Grains (includes seed),,NAICS_2017_Code,11115,,1111B0
+FAF_SCTG,Cereal Grains (includes seed),,NAICS_2017_Code,11116,,1111B0
+FAF_SCTG,Cereal Grains (includes seed),,NAICS_2017_Code,11119,,1111B0
+FAF_SCTG,"Agricultural Products (excludes Animal Feed, Cereal Grains, and Forage Products)",,NAICS_2017_Code,11111,,1111A0
+FAF_SCTG,"Agricultural Products (excludes Animal Feed, Cereal Grains, and Forage Products)",,NAICS_2017_Code,11112,,1111A0
+FAF_SCTG,"Agricultural Products (excludes Animal Feed, Cereal Grains, and Forage Products)",,NAICS_2017_Code,1112,,111200
+FAF_SCTG,"Agricultural Products (excludes Animal Feed, Cereal Grains, and Forage Products)",,NAICS_2017_Code,1113,,111300
+FAF_SCTG,"Agricultural Products (excludes Animal Feed, Cereal Grains, and Forage Products)",,NAICS_2017_Code,1114,,111400
+FAF_SCTG,"Agricultural Products (excludes Animal Feed, Cereal Grains, and Forage Products)",,NAICS_2017_Code,1119,,111900
+FAF_SCTG,"Animal Feed, Eggs, Honey, and Other Products of Animal Origin",,NAICS_2017_Code,1123,,112300
+FAF_SCTG,"Animal Feed, Eggs, Honey, and Other Products of Animal Origin",,NAICS_2017_Code,311111,,311111
+FAF_SCTG,"Animal Feed, Eggs, Honey, and Other Products of Animal Origin",,NAICS_2017_Code,311119,,311119
+FAF_SCTG,"Meat, Poultry, Fish, Seafood, and Their Preparations",,NAICS_2017_Code,1123,,112300
+FAF_SCTG,"Meat, Poultry, Fish, Seafood, and Their Preparations",,NAICS_2017_Code,311615,,311615
+FAF_SCTG,"Meat, Poultry, Fish, Seafood, and Their Preparations",,NAICS_2017_Code,311611,,31161A
+FAF_SCTG,"Meat, Poultry, Fish, Seafood, and Their Preparations",,NAICS_2017_Code,311612,,31161A
+FAF_SCTG,"Meat, Poultry, Fish, Seafood, and Their Preparations",,NAICS_2017_Code,311613,,31161A
+FAF_SCTG,"Meat, Poultry, Fish, Seafood, and Their Preparations",,NAICS_2017_Code,3117,,311700
+FAF_SCTG,"Milled Grain Products and Preparations, and Bakery Products",,NAICS_2017_Code,11212,,112120
+FAF_SCTG,"Milled Grain Products and Preparations, and Bakery Products",,NAICS_2017_Code,31121,,311210
+FAF_SCTG,"Milled Grain Products and Preparations, and Bakery Products",,NAICS_2017_Code,311221,,311221
+FAF_SCTG,"Milled Grain Products and Preparations, and Bakery Products",,NAICS_2017_Code,31123,,311230
+FAF_SCTG,"Milled Grain Products and Preparations, and Bakery Products",,NAICS_2017_Code,31181,,311810
+FAF_SCTG,"Milled Grain Products and Preparations, and Bakery Products",,NAICS_2017_Code,31182,,3118A0
+FAF_SCTG,"Milled Grain Products and Preparations, and Bakery Products",,NAICS_2017_Code,31183,,3118A0
+FAF_SCTG,"Other Prepared Foodstuffs, Fats and Oils",,NAICS_2017_Code,311224,,311224
+FAF_SCTG,"Other Prepared Foodstuffs, Fats and Oils",,NAICS_2017_Code,311225,,311225
+FAF_SCTG,"Other Prepared Foodstuffs, Fats and Oils",,NAICS_2017_Code,3113,,311300
+FAF_SCTG,"Other Prepared Foodstuffs, Fats and Oils",,NAICS_2017_Code,31141,,311410
+FAF_SCTG,"Other Prepared Foodstuffs, Fats and Oils",,NAICS_2017_Code,31142,,311420
+FAF_SCTG,"Other Prepared Foodstuffs, Fats and Oils",,NAICS_2017_Code,311513,,311513
+FAF_SCTG,"Other Prepared Foodstuffs, Fats and Oils",,NAICS_2017_Code,311514,,311514
+FAF_SCTG,"Other Prepared Foodstuffs, Fats and Oils",,NAICS_2017_Code,311511,,31151A
+FAF_SCTG,"Other Prepared Foodstuffs, Fats and Oils",,NAICS_2017_Code,311512,,31151A
+FAF_SCTG,"Other Prepared Foodstuffs, Fats and Oils",,NAICS_2017_Code,31152,,311520
+FAF_SCTG,"Other Prepared Foodstuffs, Fats and Oils",,NAICS_2017_Code,31191,,311910
+FAF_SCTG,"Other Prepared Foodstuffs, Fats and Oils",,NAICS_2017_Code,31192,,311920
+FAF_SCTG,"Other Prepared Foodstuffs, Fats and Oils",,NAICS_2017_Code,31193,,311930
+FAF_SCTG,"Other Prepared Foodstuffs, Fats and Oils",,NAICS_2017_Code,31194,,311940
+FAF_SCTG,"Other Prepared Foodstuffs, Fats and Oils",,NAICS_2017_Code,31199,,311990
+FAF_SCTG,"Other Prepared Foodstuffs, Fats and Oils",,NAICS_2017_Code,31211,,312110
+FAF_SCTG,Alcoholic Beverages and Denatured Alcohol,,NAICS_2017_Code,31212,,312120
+FAF_SCTG,Alcoholic Beverages and Denatured Alcohol,,NAICS_2017_Code,31213,,312130
+FAF_SCTG,Alcoholic Beverages and Denatured Alcohol,,NAICS_2017_Code,31214,,312140
+FAF_SCTG,Tobacco Products,,NAICS_2017_Code,3122,,312200
+FAF_SCTG,Monumental or Building Stone,,NAICS_2017_Code,21231,,212310
+FAF_SCTG,Natural Sands,,NAICS_2017_Code,21231,,212310
+FAF_SCTG,Gravel and Crushed Stone (excludes Dolomite and Slate),,NAICS_2017_Code,21231,,212310
+FAF_SCTG,Other Non-Metallic Minerals not elsewhere classified,,NAICS_2017_Code,21232,,2123A0
+FAF_SCTG,Other Non-Metallic Minerals not elsewhere classified,,NAICS_2017_Code,21239,,2123A0
+FAF_SCTG,Metallic Ores and Concentrates,,NAICS_2017_Code,21223,,212230
+FAF_SCTG,Metallic Ores and Concentrates,,NAICS_2017_Code,21222,,2122A0
+FAF_SCTG,Metallic Ores and Concentrates,,NAICS_2017_Code,21229,,2122A0
+FAF_SCTG,Coal,,NAICS_2017_Code,2121,,212100
+FAF_SCTG,Crude Petroleum,,NAICS_2017_Code,211,,211000
+FAF_SCTG,"Gasoline, Aviation Turbine Fuel, and Ethanol (includes Kerosene, and Fuel Alcohols)",,NAICS_2017_Code,32411,,324110
+FAF_SCTG,"Gasoline, Aviation Turbine Fuel, and Ethanol (includes Kerosene, and Fuel Alcohols)",,NAICS_2017_Code,324121,,324121
+FAF_SCTG,"Gasoline, Aviation Turbine Fuel, and Ethanol (includes Kerosene, and Fuel Alcohols)",,NAICS_2017_Code,324122,,324122
+FAF_SCTG,"Fuel Oils (includes Diesel, Bunker C, and Biodiesel)",,NAICS_2017_Code,32411,,324110
+FAF_SCTG,"Other Coal and Petroleum Products, not elsewhere classified",,NAICS_2017_Code,32419,,324190
+FAF_SCTG,Basic Chemicals,,NAICS_2017_Code,32511,,325110
+FAF_SCTG,Basic Chemicals,,NAICS_2017_Code,32512,,325120
+FAF_SCTG,Basic Chemicals,,NAICS_2017_Code,32513,,325130
+FAF_SCTG,Basic Chemicals,,NAICS_2017_Code,32518,,325180
+FAF_SCTG,Basic Chemicals,,NAICS_2017_Code,32519,,325190
+FAF_SCTG,Pharmaceutical Products,,NAICS_2017_Code,325411,,325411
+FAF_SCTG,Pharmaceutical Products,,NAICS_2017_Code,325412,,325412
+FAF_SCTG,Pharmaceutical Products,,NAICS_2017_Code,325413,,325413
+FAF_SCTG,Pharmaceutical Products,,NAICS_2017_Code,325414,,325414
+FAF_SCTG,Fertilizers,,NAICS_2017_Code,32531,,325310
+FAF_SCTG,Other Chemical Products and Preparations,,NAICS_2017_Code,32532,,325320
+FAF_SCTG,Other Chemical Products and Preparations,,NAICS_2017_Code,32551,,325510
+FAF_SCTG,Other Chemical Products and Preparations,,NAICS_2017_Code,32552,,325520
+FAF_SCTG,Other Chemical Products and Preparations,,NAICS_2017_Code,32561,,325610
+FAF_SCTG,Other Chemical Products and Preparations,,NAICS_2017_Code,32562,,325620
+FAF_SCTG,Other Chemical Products and Preparations,,NAICS_2017_Code,32591,,325910
+FAF_SCTG,Other Chemical Products and Preparations,,NAICS_2017_Code,32592,,3259A0
+FAF_SCTG,Other Chemical Products and Preparations,,NAICS_2017_Code,32599,,3259A0
+FAF_SCTG,Plastics and Rubber,,NAICS_2017_Code,325211,,325211
+FAF_SCTG,Plastics and Rubber,,NAICS_2017_Code,325212,,3252A0
+FAF_SCTG,Plastics and Rubber,,NAICS_2017_Code,32522,,3252A0
+FAF_SCTG,Plastics and Rubber,,NAICS_2017_Code,32611,,326110
+FAF_SCTG,Plastics and Rubber,,NAICS_2017_Code,32612,,326120
+FAF_SCTG,Plastics and Rubber,,NAICS_2017_Code,32613,,326130
+FAF_SCTG,Plastics and Rubber,,NAICS_2017_Code,32614,,326140
+FAF_SCTG,Plastics and Rubber,,NAICS_2017_Code,32615,,326150
+FAF_SCTG,Plastics and Rubber,,NAICS_2017_Code,32616,,326160
+FAF_SCTG,Plastics and Rubber,,NAICS_2017_Code,32619,,326190
+FAF_SCTG,Plastics and Rubber,,NAICS_2017_Code,32621,,326210
+FAF_SCTG,Plastics and Rubber,,NAICS_2017_Code,32622,,326220
+FAF_SCTG,Plastics and Rubber,,NAICS_2017_Code,32629,,326290
+FAF_SCTG,Logs and Other Wood in the Rough,,NAICS_2017_Code,113,,113000
+FAF_SCTG,Wood Products,,NAICS_2017_Code,3211,,321100
+FAF_SCTG,Wood Products,,NAICS_2017_Code,3212,,321200
+FAF_SCTG,Wood Products,,NAICS_2017_Code,32191,,321910
+FAF_SCTG,Wood Products,,NAICS_2017_Code,32192,,3219A0
+FAF_SCTG,Wood Products,,NAICS_2017_Code,32199,,3219A0
+FAF_SCTG,"Pulp, Newsprint, Paper, and Paperboard",,NAICS_2017_Code,32211,,322110
+FAF_SCTG,"Pulp, Newsprint, Paper, and Paperboard",,NAICS_2017_Code,32212,,322120
+FAF_SCTG,"Pulp, Newsprint, Paper, and Paperboard",,NAICS_2017_Code,32213,,322130
+FAF_SCTG,Paper or Paperboard Articles,,NAICS_2017_Code,32221,,322210
+FAF_SCTG,Paper or Paperboard Articles,,NAICS_2017_Code,32222,,322220
+FAF_SCTG,Paper or Paperboard Articles,,NAICS_2017_Code,32223,,322230
+FAF_SCTG,Paper or Paperboard Articles,,NAICS_2017_Code,322291,,322291
+FAF_SCTG,Paper or Paperboard Articles,,NAICS_2017_Code,322299,,322299
+FAF_SCTG,Printed Products,,NAICS_2017_Code,323111,,323110
+FAF_SCTG,Printed Products,,NAICS_2017_Code,323113,,323110
+FAF_SCTG,Printed Products,,NAICS_2017_Code,323117,,323110
+FAF_SCTG,Printed Products,,NAICS_2017_Code,323120,,323120
+FAF_SCTG,Printed Products,,NAICS_2017_Code,51111,,511110
+FAF_SCTG,Printed Products,,NAICS_2017_Code,51112,,511120
+FAF_SCTG,Printed Products,,NAICS_2017_Code,51113,,511130
+FAF_SCTG,Printed Products,,NAICS_2017_Code,51114,,5111A0
+FAF_SCTG,Printed Products,,NAICS_2017_Code,51119,,5111A0
+FAF_SCTG,Printed Products,,NAICS_2017_Code,S00402,,S00402
+FAF_SCTG,"Textiles, Leather, and Articles of Textiles or Leather",,NAICS_2017_Code,3131,,313100
+FAF_SCTG,"Textiles, Leather, and Articles of Textiles or Leather",,NAICS_2017_Code,3132,,313200
+FAF_SCTG,"Textiles, Leather, and Articles of Textiles or Leather",,NAICS_2017_Code,3133,,313300
+FAF_SCTG,"Textiles, Leather, and Articles of Textiles or Leather",,NAICS_2017_Code,31411,,314110
+FAF_SCTG,"Textiles, Leather, and Articles of Textiles or Leather",,NAICS_2017_Code,31412,,314120
+FAF_SCTG,"Textiles, Leather, and Articles of Textiles or Leather",,NAICS_2017_Code,3149,,314900
+FAF_SCTG,"Textiles, Leather, and Articles of Textiles or Leather",,NAICS_2017_Code,315,,315000
+FAF_SCTG,"Textiles, Leather, and Articles of Textiles or Leather",,NAICS_2017_Code,316,,316000
+FAF_SCTG,"Textiles, Leather, and Articles of Textiles or Leather",,NAICS_2017_Code,S00402,,S00402
+FAF_SCTG,Non-Metallic Mineral Products,,NAICS_2017_Code,3271,,327100
+FAF_SCTG,Non-Metallic Mineral Products,,NAICS_2017_Code,3272,,327200
+FAF_SCTG,Non-Metallic Mineral Products,,NAICS_2017_Code,32731,,327310
+FAF_SCTG,Non-Metallic Mineral Products,,NAICS_2017_Code,32732,,327320
+FAF_SCTG,Non-Metallic Mineral Products,,NAICS_2017_Code,32733,,327330
+FAF_SCTG,Non-Metallic Mineral Products,,NAICS_2017_Code,32739,,327390
+FAF_SCTG,Non-Metallic Mineral Products,,NAICS_2017_Code,3274,,327400
+FAF_SCTG,Non-Metallic Mineral Products,,NAICS_2017_Code,32791,,327910
+FAF_SCTG,Non-Metallic Mineral Products,,NAICS_2017_Code,327991,,327991
+FAF_SCTG,Non-Metallic Mineral Products,,NAICS_2017_Code,327992,,327992
+FAF_SCTG,Non-Metallic Mineral Products,,NAICS_2017_Code,327993,,327993
+FAF_SCTG,Non-Metallic Mineral Products,,NAICS_2017_Code,327999,,327999
+FAF_SCTG,Non-Metallic Mineral Products,,NAICS_2017_Code,332119,,332119
+FAF_SCTG,Base Metal in Primary or Semi-Finished Forms and in Finished Basic Shapes,,NAICS_2017_Code,33111,,331110
+FAF_SCTG,Base Metal in Primary or Semi-Finished Forms and in Finished Basic Shapes,,NAICS_2017_Code,3312,,331200
+FAF_SCTG,Base Metal in Primary or Semi-Finished Forms and in Finished Basic Shapes,,NAICS_2017_Code,331313,,331313
+FAF_SCTG,Base Metal in Primary or Semi-Finished Forms and in Finished Basic Shapes,,NAICS_2017_Code,331314,,33131B
+FAF_SCTG,Base Metal in Primary or Semi-Finished Forms and in Finished Basic Shapes,,NAICS_2017_Code,331315,,33131B
+FAF_SCTG,Base Metal in Primary or Semi-Finished Forms and in Finished Basic Shapes,,NAICS_2017_Code,331318,,33131B
+FAF_SCTG,Base Metal in Primary or Semi-Finished Forms and in Finished Basic Shapes,,NAICS_2017_Code,33141,,331410
+FAF_SCTG,Base Metal in Primary or Semi-Finished Forms and in Finished Basic Shapes,,NAICS_2017_Code,33142,,331420
+FAF_SCTG,Base Metal in Primary or Semi-Finished Forms and in Finished Basic Shapes,,NAICS_2017_Code,33149,,331490
+FAF_SCTG,Base Metal in Primary or Semi-Finished Forms and in Finished Basic Shapes,,NAICS_2017_Code,33151,,331510
+FAF_SCTG,Base Metal in Primary or Semi-Finished Forms and in Finished Basic Shapes,,NAICS_2017_Code,33152,,331520
+FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,332114,,332114
+FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,332111,,33211A
+FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,332112,,33211A
+FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,332117,,33211A
+FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,3322,,332200
+FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,33231,,332310
+FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,33232,,332320
+FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,33241,,332410
+FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,33242,,332420
+FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,33243,,332430
+FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,3325,,332500
+FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,3326,,332600
+FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,33271,,332710
+FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,33272,,332720
+FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,3328,,332800
+FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,332913,,332913
+FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,332911,,33291A
+FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,332912,,33291A
+FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,332919,,33291A
+FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,332991,,332991
+FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,332996,,332996
+FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,332992,,33299A
+FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,332993,,33299A
+FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,332994,,33299A
+FAF_SCTG,Articles of Base Metal,,NAICS_2017_Code,332999,,332999
+FAF_SCTG,Machinery,,NAICS_2017_Code,333111,,333111
+FAF_SCTG,Machinery,,NAICS_2017_Code,333112,,333112
+FAF_SCTG,Machinery,,NAICS_2017_Code,333120,,333120
+FAF_SCTG,Machinery,,NAICS_2017_Code,33313,,333130
+FAF_SCTG,Machinery,,NAICS_2017_Code,333242,,333242
+FAF_SCTG,Machinery,,NAICS_2017_Code,333241,,33329A
+FAF_SCTG,Machinery,,NAICS_2017_Code,333243,,33329A
+FAF_SCTG,Machinery,,NAICS_2017_Code,333244,,33329A
+FAF_SCTG,Machinery,,NAICS_2017_Code,333249,,33329A
+FAF_SCTG,Machinery,,NAICS_2017_Code,333314,,333314
+FAF_SCTG,Machinery,,NAICS_2017_Code,333316,,333316
+FAF_SCTG,Machinery,,NAICS_2017_Code,333318,,333318
+FAF_SCTG,Machinery,,NAICS_2017_Code,333413,,333413
+FAF_SCTG,Machinery,,NAICS_2017_Code,333414,,333414
+FAF_SCTG,Machinery,,NAICS_2017_Code,333415,,333415
+FAF_SCTG,Machinery,,NAICS_2017_Code,333511,,333511
+FAF_SCTG,Machinery,,NAICS_2017_Code,333514,,333514
+FAF_SCTG,Machinery,,NAICS_2017_Code,333517,,333517
+FAF_SCTG,Machinery,,NAICS_2017_Code,333515,,33351B
+FAF_SCTG,Machinery,,NAICS_2017_Code,333519,,33351B
+FAF_SCTG,Machinery,,NAICS_2017_Code,333611,,333611
+FAF_SCTG,Machinery,,NAICS_2017_Code,333612,,333612
+FAF_SCTG,Machinery,,NAICS_2017_Code,333613,,333613
+FAF_SCTG,Machinery,,NAICS_2017_Code,333618,,333618
+FAF_SCTG,Machinery,,NAICS_2017_Code,333912,,333912
+FAF_SCTG,Machinery,,NAICS_2017_Code,333914,,333914
+FAF_SCTG,Machinery,,NAICS_2017_Code,33392,,333920
+FAF_SCTG,Machinery,,NAICS_2017_Code,333991,,333991
+FAF_SCTG,Machinery,,NAICS_2017_Code,333993,,333993
+FAF_SCTG,Machinery,,NAICS_2017_Code,333994,,333994
+FAF_SCTG,Machinery,,NAICS_2017_Code,333992,,33399A
+FAF_SCTG,Machinery,,NAICS_2017_Code,333997,,33399A
+FAF_SCTG,Machinery,,NAICS_2017_Code,333999,,33399A
+FAF_SCTG,Machinery,,NAICS_2017_Code,333995,,33399B
+FAF_SCTG,Machinery,,NAICS_2017_Code,333996,,33399B
+FAF_SCTG,Machinery,,NAICS_2017_Code,33631,,336310
+FAF_SCTG,Machinery,,NAICS_2017_Code,33635,,336350
+FAF_SCTG,Machinery,,NAICS_2017_Code,336412,,336412
+FAF_SCTG,Machinery,,NAICS_2017_Code,S00402,,S00402
+FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,334111,,334111
+FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,334112,,334112
+FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,334118,,334118
+FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,33421,,334210
+FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,33422,,334220
+FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,33429,,334290
+FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,3343,,334300
+FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,334413,,334413
+FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,334418,,334418
+FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,334412,,33441A
+FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,334416,,33441A
+FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,334417,,33441A
+FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,334419,,33441A
+FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,33521,,335210
+FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,33522,,335220
+FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,335311,,335311
+FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,335312,,335312
+FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,335313,,335313
+FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,335911,,335911
+FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,335912,,335912
+FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,33592,,335920
+FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,33593,,335930
+FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,335991,,335991
+FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,335999,,335999
+FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,33632,,336320
+FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,51121,,511200
+FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,5121,,512100
+FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,5122,,512200
+FAF_SCTG,"Electronic and Other Electrical Equipment and Components, and Office Equipment",,NAICS_2017_Code,S00402,,S00402
+FAF_SCTG,Motorized and Other Vehicles (includes parts),,NAICS_2017_Code,336111,,336111
+FAF_SCTG,Motorized and Other Vehicles (includes parts),,NAICS_2017_Code,336112,,336112
+FAF_SCTG,Motorized and Other Vehicles (includes parts),,NAICS_2017_Code,33612,,336120
+FAF_SCTG,Motorized and Other Vehicles (includes parts),,NAICS_2017_Code,336211,,336211
+FAF_SCTG,Motorized and Other Vehicles (includes parts),,NAICS_2017_Code,336212,,336212
+FAF_SCTG,Motorized and Other Vehicles (includes parts),,NAICS_2017_Code,336213,,336213
+FAF_SCTG,Motorized and Other Vehicles (includes parts),,NAICS_2017_Code,336214,,336214
+FAF_SCTG,Motorized and Other Vehicles (includes parts),,NAICS_2017_Code,33636,,336360
+FAF_SCTG,Motorized and Other Vehicles (includes parts),,NAICS_2017_Code,33637,,336370
+FAF_SCTG,Motorized and Other Vehicles (includes parts),,NAICS_2017_Code,33639,,336390
+FAF_SCTG,Motorized and Other Vehicles (includes parts),,NAICS_2017_Code,33633,,3363A0
+FAF_SCTG,Motorized and Other Vehicles (includes parts),,NAICS_2017_Code,33634,,3363A0
+FAF_SCTG,Motorized and Other Vehicles (includes parts),,NAICS_2017_Code,336991,,336991
+FAF_SCTG,Motorized and Other Vehicles (includes parts),,NAICS_2017_Code,336992,,336992
+FAF_SCTG,Motorized and Other Vehicles (includes parts),,NAICS_2017_Code,S00402,,S00402
+FAF_SCTG,"Transportation Equipment, not elsewhere classified",,NAICS_2017_Code,336411,,336411
+FAF_SCTG,"Transportation Equipment, not elsewhere classified",,NAICS_2017_Code,336413,,336413
+FAF_SCTG,"Transportation Equipment, not elsewhere classified",,NAICS_2017_Code,336414,,336414
+FAF_SCTG,"Transportation Equipment, not elsewhere classified",,NAICS_2017_Code,336415,,33641A
+FAF_SCTG,"Transportation Equipment, not elsewhere classified",,NAICS_2017_Code,336419,,33641A
+FAF_SCTG,"Transportation Equipment, not elsewhere classified",,NAICS_2017_Code,3365,,336500
+FAF_SCTG,"Transportation Equipment, not elsewhere classified",,NAICS_2017_Code,336611,,336611
+FAF_SCTG,"Transportation Equipment, not elsewhere classified",,NAICS_2017_Code,336612,,336612
+FAF_SCTG,"Transportation Equipment, not elsewhere classified",,NAICS_2017_Code,336999,,336999
+FAF_SCTG,"Transportation Equipment, not elsewhere classified",,NAICS_2017_Code,S00402,,S00402
+FAF_SCTG,Precision Instruments and Apparatus,,NAICS_2017_Code,33451,,334510
+FAF_SCTG,Precision Instruments and Apparatus,,NAICS_2017_Code,334511,,334511
+FAF_SCTG,Precision Instruments and Apparatus,,NAICS_2017_Code,334512,,334512
+FAF_SCTG,Precision Instruments and Apparatus,,NAICS_2017_Code,334513,,334513
+FAF_SCTG,Precision Instruments and Apparatus,,NAICS_2017_Code,334514,,334514
+FAF_SCTG,Precision Instruments and Apparatus,,NAICS_2017_Code,334515,,334515
+FAF_SCTG,Precision Instruments and Apparatus,,NAICS_2017_Code,334516,,334516
+FAF_SCTG,Precision Instruments and Apparatus,,NAICS_2017_Code,334517,,334517
+FAF_SCTG,Precision Instruments and Apparatus,,NAICS_2017_Code,334519,,33451A
+FAF_SCTG,Precision Instruments and Apparatus,,NAICS_2017_Code,33461,,334610
+FAF_SCTG,Precision Instruments and Apparatus,,NAICS_2017_Code,335314,,335314
+FAF_SCTG,Precision Instruments and Apparatus,,NAICS_2017_Code,339112,,339112
+FAF_SCTG,Precision Instruments and Apparatus,,NAICS_2017_Code,339113,,339113
+FAF_SCTG,Precision Instruments and Apparatus,,NAICS_2017_Code,339114,,339114
+FAF_SCTG,Precision Instruments and Apparatus,,NAICS_2017_Code,339115,,339115
+FAF_SCTG,Precision Instruments and Apparatus,,NAICS_2017_Code,339116,,339116
+FAF_SCTG,Precision Instruments and Apparatus,,NAICS_2017_Code,S00402,,S00402
+FAF_SCTG,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",,NAICS_2017_Code,33511,,335110
+FAF_SCTG,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",,NAICS_2017_Code,33512,,335120
+FAF_SCTG,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",,NAICS_2017_Code,33711,,337110
+FAF_SCTG,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",,NAICS_2017_Code,337121,,337121
+FAF_SCTG,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",,NAICS_2017_Code,337122,,337122
+FAF_SCTG,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",,NAICS_2017_Code,337127,,337127
+FAF_SCTG,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",,NAICS_2017_Code,337124,,33712N
+FAF_SCTG,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",,NAICS_2017_Code,337125,,33712N
+FAF_SCTG,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",,NAICS_2017_Code,337215,,337215
+FAF_SCTG,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",,NAICS_2017_Code,337211,,33721A
+FAF_SCTG,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",,NAICS_2017_Code,337212,,33721A
+FAF_SCTG,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",,NAICS_2017_Code,337214,,33721A
+FAF_SCTG,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",,NAICS_2017_Code,3379,,337900
+FAF_SCTG,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",,NAICS_2017_Code,33995,,339950
+FAF_SCTG,"Furniture, Mattresses and Mattress Supports, Lamps, Lighting Fittings, and Illuminated Signs",,NAICS_2017_Code,S00402,,S00402
+FAF_SCTG,Miscellaneous Manufactured Products,,NAICS_2017_Code,336414,,336414
+FAF_SCTG,Miscellaneous Manufactured Products,,NAICS_2017_Code,33991,,339910
+FAF_SCTG,Miscellaneous Manufactured Products,,NAICS_2017_Code,33992,,339920
+FAF_SCTG,Miscellaneous Manufactured Products,,NAICS_2017_Code,33993,,339930
+FAF_SCTG,Miscellaneous Manufactured Products,,NAICS_2017_Code,33999,,339990
+FAF_SCTG,Waste and Scrap (excludes of agriculture or food),,NAICS_2017_Code,562,,562000
+FAF_SCTG,Waste and Scrap (excludes of agriculture or food),,NAICS_2017_Code,S00401,,S00401
+FAF_SCTG,Mixed Freight,,NAICS_2017_Code,33994,,339940


### PR DESCRIPTION
cc:
Related: #571, #611

**Stack 2 of 3** for Step 4c margins. Base #610 (`margins_2017_anchor`) — review that first.
→ #612 trade levels.

## What changed? Why?

Phase 2: the annual transportation margin column, 2017–2024. `nowcast_transport_margins.py` reproduces the published 2017 `TRANS` **to the dollar** and moves it forward on FAF ton-miles.

**Ported:** `BTS_FAF` extractor (FAF5.7.1), the mode/SCTG crosswalk, and `Margins_Transport_<year>` FBS methods for 2017–2024 sharing one `Margins_Transport_source.yaml`, so a year is eight lines.

Two departures from the flowsa original, both forced by the data:
- **No `tabula`/PDF scrape** — the SCTG and mode code tables ship inside the archive as `FAF5_metadata.xlsx`.
- **All trade types kept.** FAF's `dms_*` fields already describe only the domestic leg, so the `trade_type == 1` filter was discarding 20% of ton-miles, concentrated in imports, rather than avoiding a double count.

Two fixes the issue did not scope: `faf_parse` filtered on a year that `call_all_years: True` never passes it, so **no FBA could be generated at all**; and `BTS_FAF` was missing from `source_catalog.yaml`, without which any FBS reading it fails on `data_format`.

## The construction: ton-miles *move* the 2017 allocation, they do not generate it

Measured on 2017, allocating each mode's margin on its share of the measure — BEA's own construction — and scoring against published `TRANS` at SCTG level:

| source | measure | pearson | total abs share error |
|---|---|---:|---:|
| **FAF** | **ton-miles** | **0.370** | **68.2pp** |
| FAF | tons | 0.099 | 92.9pp |
| CFS PUF | ton-miles | 0.099 | 79.9pp |

**Ton-miles beat tons decisively**, so the manual's constant-revenue-per-ton assumption is the weaker one — weight-based allocation over-pays bulk (coal 35,609 predicted against 13,432 published) and starves light high-value goods (furniture 2,502 against 21,035).

**The CFS public use file is disqualified on scope**: it carries 2,979 of FAF's 5,436 billion ton-miles, and **crude petroleum, the largest `TRANS` commodity at 47,613, has zero CFS coverage.**

But neither measure *predicts* the margin, so the weak cross-sectional fit is made irrelevant rather than blocking — each commodity's published 2017 `TRANS` is moved by its SCTG group's ton-mile growth, controlled to the annual total. Exact in 2017 by construction, so BEA's own commodity allocation is inherited rather than approximated.

## The control total is most of the movement, and it is three treatments

⚠️ Ton-miles are a **volume** index and `TRANS` is **nominal**. The volume index reaches only 1.036 by 2022 while the level reaches 1.548 — nearly all movement is repricing, which the volume index cannot see. Truck is 68% of `TRANS` and its output runs 1.572× its 2017 level in 2022.

A single treatment cannot serve all five modes, because they differ in how much of their output is margin at all — 0.026 for air against 0.862 for rail:

| mode | share of `TRANS` | margin ÷ output | leverage | treatment |
|---|---:|---:|---:|---|
| truck | 67.8% | 0.767 | 0.30 | `residual` |
| rail | 16.5% | 0.862 | 0.16 | `residual` |
| pipeline | 11.9% | 1.033 | — | `output_ratio` |
| water | 2.3% | 0.173 | 4.8 | `freight_volume` |
| air | 1.5% | 0.026 | 36.9 | `freight_volume` |

A residual for air **goes negative** from 2019 (−121,719 million by 2024), and a frozen ratio would make air *freight* margin follow air *passenger* output, cutting it 46% in 2020 when air freight ton-miles were 1.010.

⚠️ **This choice is the largest open uncertainty in the column** — all four constructions are identities in 2017 and spread **11.8% by 2022** (`mixed` 643,443 against `freight_volume` 575,587). So the method is a **parameter**, not baked in: `control_total_components(years, method=…)` and `control_total_comparison(years)`. #620 settles it against external sources.

## Limitations recorded rather than corrected

- **The 2017/2018 seam is partly methodological** — FAF's 2017 is CFS-anchored, 2018 onward modelled. The `TRANS`-weighted mean step is 1.124 against the aggregate's 1.019, so a shape shift survives the control total.
- **The residual freezes the intermediate:final split at 2017.** Taking it from a nowcast Use matrix would be circular — Step 6b needs these margins to build it.
- ⚠️ **`BEA_Detail_GrossOutput_IO` is *industry* output; the margin given up is a *commodity* quantity.** For truck they differ by a third (367,154 against 333,879). The conclusion is unaffected, but the build should move to `T013` once 4a lands so the residual is one framework throughout.
- **The industry price index needs no commodity conversion — measured.** The transport block of the Make table is near-diagonal, so re-weighting moves the indices by at most 0.696% anywhere and changes the built control total by **0.000% and 0.084%**. This would not generalise to the trade commodities.

## Known limitation: the FBS cannot express BEA codes

⚠️ `SectorConsumedBy` resolves to NAICS, which is the #546 limitation — an SCTG mapped to a 3-digit NAICS group would be spread across everything in it. The module therefore aggregates the FBS back over its sector columns to the SCTG surviving in `Flowable` and joins to BEA detail on the crosswalk's `Note` column in Python. When #546 lands a BEA-code target the join moves into the FBS. For the same reason flowsa's `move_SCB_to_flow` is deliberately **not** ported: it overwrites `Flowable` with the NAICS sector and would silently coarsen every growth factor.

## Testing

`bedrock/transform/iot/__tests__/test_nowcast_transport_margins.py` (301 lines). The 2017 reproduction is exact.

Depends on `retain_activity_columns` from #601, confirmed present on `nowcast`.
