### PR TITLE
Read API keys from the project .env as well as API_Keys.env (#624)

### DIFF
--- a/bedrock/utils/config/common.py
+++ b/bedrock/utils/config/common.py
@@ -72,6 +72,12 @@ def load_env_file_key(env_file: str, key: str) -> str:
     See README for how to generate an API key:
     https://github.com/cornerstone-data/bedrock/blob/main/bedrock/extract/README.md
 
+    Two layouts are accepted, in this order: ``extract/API_Keys.env`` naming the
+    key by ``api_name`` (``Census=...``), and the project-root ``.env`` naming it
+    by the conventional ``<API_NAME>_API_KEY`` (``CENSUS_API_KEY=...``). The
+    second is where this project's keys actually live, and it saves keeping the
+    same secret in two files.
+
     :param env_file: str, name of env to load, either 'API_Key'
     or 'external_path'
     :param key: str, name of source/key defined in env file, like 'BEA' or
@@ -80,7 +86,8 @@ def load_env_file_key(env_file: str, key: str) -> str:
     """
     if env_file == 'API_Key':
         load_dotenv(f'{extractpath}/API_Keys.env', verbose=True)
-        value = os.getenv(key)
+        load_dotenv(MODULEPATH.parent / '.env', verbose=True)
+        value = os.getenv(key) or os.getenv(f'{key.upper()}_API_KEY')
         if value is None:
             raise APIError(api_source=key)
     else:


### PR DESCRIPTION
cc: @bl-young 
Related: #624

Standalone fix, base `nowcast`. **No git dependency on the Step 4c margins stack (#626 → #627 → #628), but #628's `Census_AIES` needs it** to reach `CENSUS_API_KEY`.

## What changed? Why?

`load_env_file_key` read API keys only from `bedrock/extract/API_Keys.env`, keyed by the bare `api_name` (`Census=...`). This project's keys actually live in the project-root `.env` under the conventional `<API_NAME>_API_KEY` form (`CENSUS_API_KEY=...`), so any extractor needing a key failed unless the same secret was copied into a second file.

Both layouts are now accepted, in order:

1. `extract/API_Keys.env`, keyed by `api_name` — the existing behaviour, unchanged and still first
2. project-root `.env`, keyed by `<API_NAME>_API_KEY`

`os.getenv(key) or os.getenv(f'{key.upper()}_API_KEY')` keeps the original lookup winning where it is populated, so nothing that works today changes behaviour. `APIError` still raises when neither is present.

## Scope

Eight lines in `bedrock/utils/config/common.py` plus docstring. No new dependency — `load_dotenv` is already imported and already called for the first file.
